### PR TITLE
fix(agent_roles): Unauthorize export when access level changes

### DIFF
--- a/app/controllers/concerns/agent_roles/csv_export_authorizations_controller.rb
+++ b/app/controllers/concerns/agent_roles/csv_export_authorizations_controller.rb
@@ -6,6 +6,7 @@ module AgentRoles
 
     def batch_update
       if manage_export_authorizations_for_an_organisation.success?
+        flash[:success] = "Les autorisations ont bien été mises à jour"
         redirect_to(organisation_category_configurations_path(current_organisation))
       else
         turbo_stream_display_error_modal(manage_export_authorizations_for_an_organisation.errors)

--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -12,5 +12,5 @@ class AgentRole < ApplicationRecord
   scope :authorized_to_export_csv, -> { where(authorized_to_export_csv: true) }
   scope :with_last_name, -> { joins(:agent).where.not(agents: { last_name: nil }) }
 
-  before_save -> { self.authorized_to_export_csv = true }, if: -> { admin? && !authorized_to_export_csv? }
+  before_save -> { self.authorized_to_export_csv = admin? }, if: :access_level_changed?
 end

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -62,4 +62,43 @@ describe AgentRole do
       end
     end
   end
+
+  describe "authorized to export csv when admin" do
+    context "on record creation" do
+      let!(:agent_role) { build(:agent_role, access_level: "admin", authorized_to_export_csv: false) }
+
+      it "marks as authorized to export csv when admin" do
+        agent_role.save!
+        expect(agent_role.reload.authorized_to_export_csv).to eq(true)
+      end
+
+      it "does not mark as authorized when not admin" do
+        agent_role.access_level = "basic"
+        agent_role.save!
+        expect(agent_role.reload.authorized_to_export_csv).to eq(false)
+      end
+    end
+
+    context "on record update" do
+      context "from basic to admin" do
+        let!(:agent_role) { create(:agent_role, access_level: "basic", authorized_to_export_csv: false) }
+
+        it "marks as authorized to export csv when admin" do
+          agent_role.access_level = "admin"
+          agent_role.save!
+          expect(agent_role.reload.authorized_to_export_csv).to eq(true)
+        end
+      end
+
+      context "from admin to basic" do
+        let!(:agent_role) { create(:agent_role, access_level: "admin", authorized_to_export_csv: true) }
+
+        it "does not mark as authorized when not admin" do
+          agent_role.access_level = "basic"
+          agent_role.save!
+          expect(agent_role.reload.authorized_to_export_csv).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Lorsqu'un agent n'est passe du niveau admin à un niveau basique, il était toujours autorisé à exporter les csv.
Je change ce comportement pour qu'il ne soit plus autorisé à exporter les csv s'il redevient un agent basique au sein de l'organisation.

J'en profite pour ajouter un flash message au moment de l'update des autorisations (ça ne coûte rien et c'est perturbant je trouve de ne rien voir).