### PR TITLE
fix(brevo_webhooks): update failed status with delivered events only

### DIFF
--- a/app/models/concerns/deliverable.rb
+++ b/app/models/concerns/deliverable.rb
@@ -1,8 +1,8 @@
 module Deliverable
   extend ActiveSupport::Concern
 
-  FINAL_DELIVERY_STATUS = %w[delivered hard_bounce blocked invalid_email error].freeze
   FAILED_DELIVERY_STATUS = %w[soft_bounce hard_bounce blocked invalid_email error].freeze
+  DELIVERED_STATUS = %w[delivered].freeze
 
   included do
     # https://developers.brevo.com/docs/transactional-webhooks
@@ -16,7 +16,7 @@ module Deliverable
   end
 
   def human_delivery_status_and_date
-    if delivery_status == "delivered"
+    if delivery_status.in?(DELIVERED_STATUS)
       if delivery_date == creation_date
         "Délivrée à #{delivery_hour}"
       else

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -7,8 +7,9 @@ module InboundWebhooks
       end
 
       def call
-        set_last_brevo_webhook_received_at
         return if @record.delivered?
+
+        set_last_brevo_webhook_received_at
         return unless delivery_status.in?(record_class.delivery_statuses.keys)
         return if webhook_mismatch?
 

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -7,6 +7,7 @@ module InboundWebhooks
       end
 
       def call
+        return if old_update?
         return if @record.delivered?
 
         set_last_brevo_webhook_received_at
@@ -36,8 +37,13 @@ module InboundWebhooks
         raise NoMethodError
       end
 
-      def delivered?
-        delivery_status.in?(record_class::DELIVERED_STATUS)
+      def old_update?
+        return false if @record.last_brevo_webhook_received_at.blank?
+
+        record_datetime = Time.zone.parse(@record.last_brevo_webhook_received_at.to_s)
+        webhook_datetime = Time.zone.parse(@webhook_params[:date].to_s)
+
+        record_datetime > webhook_datetime
       end
     end
   end

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -7,7 +7,7 @@ module InboundWebhooks
       end
 
       def call
-        return if @record.delivery_status.in?(record_class::FINAL_DELIVERY_STATUS)
+        return if record_has_a_failed_delivery_status? && !delivered?
         return if old_update?
         return if webhook_mismatch?
 
@@ -17,6 +17,10 @@ module InboundWebhooks
       end
 
       private
+
+      def record_has_a_failed_delivery_status?
+        @record.delivery_status.in?(record_class::FAILED_DELIVERY_STATUS)
+      end
 
       def old_update?
         return false if @record.delivered_at.blank?
@@ -34,6 +38,10 @@ module InboundWebhooks
 
       def delivery_status
         raise NoMethodError
+      end
+
+      def delivered?
+        delivery_status.in?(record_class::DELIVERED_STATUS)
       end
     end
   end

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -8,6 +8,7 @@ module InboundWebhooks
 
       def call
         set_last_brevo_webhook_received_at
+        return if @record.delivered?
         return unless delivery_status.in?(record_class.delivery_statuses.keys)
         return if webhook_mismatch?
 

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -7,25 +7,19 @@ module InboundWebhooks
       end
 
       def call
-        return if record_has_a_failed_delivery_status? && !delivered?
-        return if old_update?
+        set_last_brevo_webhook_received_at
+        return unless delivery_status.in?(record_class.delivery_statuses.keys)
         return if webhook_mismatch?
 
         @record.delivery_status = delivery_status
-        @record.delivered_at = @webhook_params[:date]
         save_record!(@record)
       end
 
       private
 
-      def record_has_a_failed_delivery_status?
-        @record.delivery_status.in?(record_class::FAILED_DELIVERY_STATUS)
-      end
-
-      def old_update?
-        return false if @record.delivered_at.blank?
-
-        @record.delivered_at.to_datetime > @webhook_params[:date].to_datetime
+      def set_last_brevo_webhook_received_at
+        @record.last_brevo_webhook_received_at = @webhook_params[:date]
+        save_record!(@record)
       end
 
       def record_class

--- a/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
+++ b/app/services/inbound_webhooks/brevo/assign_delivery_status_and_date_base.rb
@@ -10,9 +10,9 @@ module InboundWebhooks
         return if old_update?
         return if @record.delivered?
 
+        alert_sentry_if_webhook_mismatch
         set_last_brevo_webhook_received_at
         return unless delivery_status.in?(record_class.delivery_statuses.keys)
-        return if webhook_mismatch?
 
         @record.delivery_status = delivery_status
         save_record!(@record)
@@ -29,7 +29,7 @@ module InboundWebhooks
         @record_class ||= @record.class
       end
 
-      def webhook_mismatch?
+      def alert_sentry_if_webhook_mismatch
         raise NoMethodError
       end
 
@@ -40,7 +40,7 @@ module InboundWebhooks
       def old_update?
         return false if @record.last_brevo_webhook_received_at.blank?
 
-        record_datetime = Time.zone.parse(@record.last_brevo_webhook_received_at.to_s)
+        record_datetime = @record.last_brevo_webhook_received_at
         webhook_datetime = Time.zone.parse(@webhook_params[:date].to_s)
 
         record_datetime > webhook_datetime

--- a/app/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date.rb
+++ b/app/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date.rb
@@ -7,12 +7,11 @@ module InboundWebhooks
         @delivery_status ||= @webhook_params[:event]
       end
 
-      def webhook_mismatch?
-        return false if @record.email == @webhook_params[:email]
+      def alert_sentry_if_webhook_mismatch
+        return if @record.email == @webhook_params[:email]
 
         Sentry.capture_message("#{record_class} email and webhook email does not match",
                                extra: { record: @record, webhook: @webhook_params })
-        true
       end
     end
   end

--- a/app/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date.rb
+++ b/app/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date.rb
@@ -7,12 +7,11 @@ module InboundWebhooks
         @delivery_status ||= @webhook_params[:msg_status]
       end
 
-      def webhook_mismatch?
-        return false if @record.user.phone_number == PhoneNumberHelper.format_phone_number(@webhook_params[:to])
+      def alert_sentry_if_webhook_mismatch
+        return if @record.user.phone_number == PhoneNumberHelper.format_phone_number(@webhook_params[:to])
 
         Sentry.capture_message("#{record_class} mobile phone and webhook mobile phone does not match",
                                extra: { record: @record, webhook: @webhook_params })
-        true
       end
     end
   end

--- a/db/migrate/20240705140428_rename_delivered_at_to_last_brevo_webhook_received_at.rb
+++ b/db/migrate/20240705140428_rename_delivered_at_to_last_brevo_webhook_received_at.rb
@@ -1,0 +1,6 @@
+class RenameDeliveredAtToLastBrevoWebhookReceivedAt < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :notifications, :delivered_at, :last_brevo_webhook_received_at
+    rename_column :invitations, :delivered_at, :last_brevo_webhook_received_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_27_145505) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_140428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -200,7 +200,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_145505) do
     t.boolean "rdv_with_referents", default: false
     t.string "trigger", default: "manual", null: false
     t.string "delivery_status"
-    t.datetime "delivered_at"
+    t.datetime "last_brevo_webhook_received_at"
     t.index ["department_id"], name: "index_invitations_on_department_id"
     t.index ["follow_up_id"], name: "index_invitations_on_follow_up_id"
     t.index ["trigger"], name: "index_invitations_on_trigger"
@@ -284,7 +284,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_145505) do
     t.string "format"
     t.bigint "participation_id"
     t.string "delivery_status"
-    t.datetime "delivered_at"
+    t.datetime "last_brevo_webhook_received_at"
     t.index ["participation_id"], name: "index_notifications_on_participation_id"
   end
 

--- a/spec/requests/brevo_mail_webhooks_spec.rb
+++ b/spec/requests/brevo_mail_webhooks_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "BrevoMailWebhooks" do
     end
 
     context "with an event not in enum" do
-      let(:invalid_webhook_params) do
+      let(:unprocessed_event_webhook_params) do
         {
           email: "test@example.com",
           event: "request",
@@ -62,7 +62,7 @@ RSpec.describe "BrevoMailWebhooks" do
       end
 
       it "does not update the invitation but save last_brevo_webhook_received_at date" do
-        post "/brevo/mail_webhooks", params: invalid_webhook_params, as: :json
+        post "/brevo/mail_webhooks", params: unprocessed_event_webhook_params, as: :json
         expect(response).to be_successful
 
         invitation.reload

--- a/spec/requests/brevo_mail_webhooks_spec.rb
+++ b/spec/requests/brevo_mail_webhooks_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "BrevoMailWebhooks" do
   let(:webhook_params) do
     {
       email: "test@example.com",
-      event: "opened",
+      event: "delivered",
       date: "2023-06-07T12:34:56Z",
       :"X-Mailin-custom" => "{\"record_identifier\": \"#{record_identifier}\"}"
     }
@@ -25,15 +25,15 @@ RSpec.describe "BrevoMailWebhooks" do
       expect(response).to be_successful
 
       invitation.reload
-      expect(invitation.delivery_status).to eq("opened")
-      expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      expect(invitation.delivery_status).to eq("delivered")
+      expect(invitation.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
     end
 
     context "with invalid data" do
       let(:invalid_webhook_params) do
         {
           email: "mismatch@example.com",
-          event: "opened",
+          event: "delivered",
           date: "2023-06-07T12:34:56Z",
           :"X-Mailin-custom" => "{\"record_identifier\": \"#{invitation.record_identifier}\"}"
         }
@@ -45,9 +45,29 @@ RSpec.describe "BrevoMailWebhooks" do
 
         invitation.reload
         expect(invitation.delivery_status).to be_nil
-        expect(invitation.delivered_at).to be_nil
+        expect(invitation.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         expect(Sentry).to have_received(:capture_message).with("Invitation email and webhook email does not match",
                                                                any_args)
+      end
+    end
+
+    context "with an event not in enum" do
+      let(:invalid_webhook_params) do
+        {
+          email: "test@example.com",
+          event: "request",
+          date: "2023-06-07T12:34:56Z",
+          :"X-Mailin-custom" => "{\"record_identifier\": \"#{invitation.record_identifier}\"}"
+        }
+      end
+
+      it "does not update the invitation but save last_brevo_webhook_received_at date" do
+        post "/brevo/mail_webhooks", params: invalid_webhook_params, as: :json
+        expect(response).to be_successful
+
+        invitation.reload
+        expect(invitation.delivery_status).to be_nil
+        expect(invitation.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
       end
     end
 
@@ -55,7 +75,7 @@ RSpec.describe "BrevoMailWebhooks" do
       let(:invalid_webhook_params) do
         {
           email: "test@example.com",
-          event: "opened",
+          event: "delivered",
           date: "2023-06-07T12:34:56Z",
           :"X-Mailin-custom" => '{"record_identifier": "invitation_9999"}'
         }
@@ -80,15 +100,15 @@ RSpec.describe "BrevoMailWebhooks" do
       expect(response).to be_successful
 
       notification.reload
-      expect(notification.delivery_status).to eq("opened")
-      expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      expect(notification.delivery_status).to eq("delivered")
+      expect(notification.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
     end
 
     context "when notification is not found" do
       let(:invalid_webhook_params) do
         {
           email: "test@example.com",
-          event: "opened",
+          event: "delivered",
           date: "2023-06-07T12:34:56Z",
           :"X-Mailin-custom" => '{"record_identifier": "notification_9999"}'
         }

--- a/spec/requests/brevo_sms_webhooks_spec.rb
+++ b/spec/requests/brevo_sms_webhooks_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "BrevoSmsWebhooks" do
     end
 
     context "when event is not in enum" do
-      let(:invalid_webhook_params) do
+      let(:unprocessed_event_webhook_params) do
         {
           to: "0601010101",
           msg_status: "sent",
@@ -59,7 +59,7 @@ RSpec.describe "BrevoSmsWebhooks" do
       end
 
       it "does not update the invitation but save last_brevo_webhook_received_at date" do
-        post "/brevo/sms_webhooks/#{invitation.record_identifier}", params: invalid_webhook_params, as: :json
+        post "/brevo/sms_webhooks/#{invitation.record_identifier}", params: unprocessed_event_webhook_params, as: :json
         expect(response).to be_successful
 
         invitation.reload

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -22,16 +22,18 @@ describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
         end
       end
 
-      context "when the email does not match" do
-        let(:webhook_params) { { email: "mismatch@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
+      context "when emails does not match" do
+        let(:webhook_params) do
+          { email: "email_changed@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" }
+        end
 
-        it "does not update the #{record_type}" do
+        it "update the #{record_type} but capture an error" do
           expect(Sentry).to receive(:capture_message).with(
             "#{record_type.capitalize} email and webhook email does not match",
             any_args
           )
           subject
-          expect(record.delivery_status).to be_nil
+          expect(record.delivery_status).to eq("delivered")
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -53,6 +53,19 @@ describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
+
+      context "when the record is already delivered" do
+        let(:webhook_params) { { email: "test@example.com", event: "error", date: "2023-06-07T12:34:56Z" } }
+
+        it "does not update the #{record_type} but save last_brevo_webhook_received_at date" do
+          record.update(delivery_status: "delivered",
+                        last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+          subject
+          record.reload
+          expect(record.delivery_status).to eq("delivered")
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+        end
+      end
     end
   end
 end

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -57,13 +57,13 @@ describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
       context "when the record is already delivered" do
         let(:webhook_params) { { email: "test@example.com", event: "error", date: "2023-06-07T12:34:56Z" } }
 
-        it "does not update the #{record_type} but save last_brevo_webhook_received_at date" do
+        it "does not update the #{record_type}" do
           record.update(delivery_status: "delivered",
                         last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
           record.reload
           expect(record.delivery_status).to eq("delivered")
-          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
         end
       end
     end

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -66,6 +66,20 @@ describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
         end
       end
+
+      context "when the update is old" do
+        let!(:old_date) { "2022-06-07T12:34:56Z" }
+        let!(:webhook_params) { { email: "test@example.com", event: "error", date: old_date } }
+
+        it "does not update the #{record_type}" do
+          record.update(last_brevo_webhook_received_at: Time.zone.parse("2023-06-08T12:34:56Z"),
+                        delivery_status: "blocked")
+          subject
+          record.reload
+          expect(record.delivery_status).to eq("blocked")
+          expect(record.delivered_at).not_to eq(old_date)
+        end
+      end
     end
   end
 end

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -1,155 +1,57 @@
 describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
   subject { described_class.call(webhook_params: webhook_params, record: record) }
 
-  let(:webhook_params) { { email: "test@example.com", event: "opened", date: "2023-06-07T12:34:56Z" } }
+  let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
   let!(:user) { create(:user, email: "test@example.com", invitations: []) }
+  let!(:participation) { create(:participation, user: user) }
+  let(:notification) { create(:notification, participation: participation) }
+  let!(:invitation) { build(:invitation, user: user) }
 
-  context "for an invitation" do
-    let!(:invitation) { build(:invitation, user: user) }
-    let(:record) { invitation }
+  %w[invitation notification].each do |record_type|
+    context "for an #{record_type}" do
+      let(:record) { send(record_type) }
 
-    context "when the invitation had a failed delivery status and the delivery status is now opened" do
-      Invitation::FAILED_DELIVERY_STATUS.each do |status|
-        it "does not update the failed invitation (#{status})" do
-          invitation.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+      context "when the #{record_type} had a failed delivery status and the delivery status is now delivered" do
+        it "update the #{record_type} with delivered status" do
+          record.update(delivery_status: "soft_bounce",
+                        last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
-          invitation.reload
-          expect(invitation.delivery_status).to eq(status)
-          expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+          record.reload
+          expect(record.delivery_status).to eq("delivered")
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
 
-      context "when the invitation had a failed delivery status and the delivery status is now delivered" do
-        let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
+      context "when the email does not match" do
+        let(:webhook_params) { { email: "mismatch@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
 
-        it "update the invitation with delivered status" do
-          invitation.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+        it "does not update the #{record_type}" do
+          expect(Sentry).to receive(:capture_message).with(
+            "#{record_type.capitalize} email and webhook email does not match",
+            any_args
+          )
           subject
-          invitation.reload
-          expect(invitation.delivery_status).to eq("delivered")
-          expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-        end
-      end
-    end
-
-    context "when the update is old" do
-      let(:old_date) { "2022-06-07T12:34:56Z" }
-
-      before do
-        invitation.update(delivered_at: Time.zone.parse("2023-06-08T12:34:56Z"))
-      end
-
-      it "does not update the invitation" do
-        subject
-        invitation.reload
-        expect(invitation.delivery_status).to be_nil
-        expect(invitation.delivered_at).not_to eq(old_date)
-      end
-    end
-
-    context "when the email does not match" do
-      let(:webhook_params) { { email: "mismatch@example.com", event: "opened", date: "2023-06-07T12:34:56Z" } }
-
-      it "does not update the invitation" do
-        expect(Sentry).to receive(:capture_message).with("Invitation email and webhook email does not match",
-                                                         any_args)
-        subject
-        expect(invitation.delivery_status).to be_nil
-        expect(invitation.delivered_at).to be_nil
-      end
-    end
-
-    it "updates the invitation with the correct delivery status and date" do
-      subject
-      invitation.reload
-      expect(invitation.delivery_status).to eq("opened")
-      expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-    end
-
-    context "when the delivery status is delivered" do
-      let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "update the invitation with delivered status" do
-        subject
-        invitation.reload
-        expect(invitation.delivery_status).to eq("delivered")
-        expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-      end
-    end
-  end
-
-  context "for a notification" do
-    let!(:participation) { create(:participation, user: user) }
-    let(:notification) { create(:notification, participation: participation) }
-    let(:record) { notification }
-
-    context "when the notification had a failed delivery status and the delivery status is now opened" do
-      Notification::FAILED_DELIVERY_STATUS.each do |status|
-        it "does not update the failed notification (#{status})" do
-          notification.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
-          subject
-          notification.reload
-          expect(notification.delivery_status).to eq(status)
-          expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+          expect(record.delivery_status).to be_nil
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
 
-      context "when the notification had a failed delivery status and the delivery status is now delivered" do
-        let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
+      it "updates the #{record_type} with the correct delivery status and date" do
+        subject
+        record.reload
+        expect(record.delivery_status).to eq("delivered")
+        expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      end
 
-        it "update the notification with delivered status" do
-          notification.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+      context "when the delivery status is not in enum" do
+        let(:webhook_params) { { email: "test@example.com", event: "opened", date: "2023-06-07T12:34:56Z" } }
+
+        it "doesnt update the #{record_type} delivery_status but update last_brevo_webhook_received_at" do
           subject
-          notification.reload
-          expect(notification.delivery_status).to eq("delivered")
-          expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+          record.reload
+          expect(record.delivery_status).to eq(nil)
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
-      end
-    end
-
-    context "when the update is old" do
-      let(:old_date) { "2022-06-07T12:34:56Z" }
-
-      before do
-        notification.update(delivered_at: Time.zone.parse("2023-06-08T12:34:56Z"))
-      end
-
-      it "does not update the notification" do
-        subject
-        notification.reload
-        expect(notification.delivery_status).to be_nil
-        expect(notification.delivered_at).not_to eq(old_date)
-      end
-    end
-
-    context "when the email does not match" do
-      let(:webhook_params) { { email: "mismatch@example.com", event: "opened", date: "2023-06-07T12:34:56Z" } }
-
-      it "does not update the notification" do
-        expect(Sentry).to receive(:capture_message).with("Notification email and webhook email does not match",
-                                                         any_args)
-        subject
-        expect(notification.delivery_status).to be_nil
-        expect(notification.delivered_at).to be_nil
-      end
-    end
-
-    it "updates the notification with the correct delivery status and date" do
-      subject
-      notification.reload
-      expect(notification.delivery_status).to eq("opened")
-      expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-    end
-
-    context "when the notification had a failed delivery status and the delivery status is now delivered" do
-      let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "update the notification with delivered status" do
-        notification.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
-        subject
-        notification.reload
-        expect(notification.delivery_status).to eq("delivered")
-        expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
       end
     end
   end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -65,6 +65,20 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
         end
       end
+
+      context "when the update is old" do
+        let!(:old_date) { "2022-06-07T12:34:56Z" }
+        let!(:webhook_params) { { email: "test@example.com", event: "error", date: old_date } }
+
+        it "does not update the #{record_type}" do
+          record.update(last_brevo_webhook_received_at: Time.zone.parse("2023-06-08T12:34:56Z"),
+                        delivery_status: "blocked")
+          subject
+          record.reload
+          expect(record.delivery_status).to eq("blocked")
+          expect(record.delivered_at).not_to eq(old_date)
+        end
+      end
     end
   end
 end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -52,6 +52,19 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
+
+      context "when the record is already delivered" do
+        let(:webhook_params) { { to: "0601010101", msg_status: "error", date: "2023-06-07T12:34:56Z" } }
+
+        it "does not update the #{record_type} but save last_brevo_webhook_received_at date" do
+          record.update(delivery_status: "delivered",
+                        last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+          subject
+          record.reload
+          expect(record.delivery_status).to eq("delivered")
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+        end
+      end
     end
   end
 end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -1,21 +1,33 @@
 describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
   subject { described_class.call(webhook_params: webhook_params, record: record) }
 
-  let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+  let(:webhook_params) { { to: "0601010101", msg_status: "sent", date: "2023-06-07T12:34:56Z" } }
   let(:user) { create(:user, phone_number: "0601010101") }
 
   context "for an invitation" do
     let(:invitation) { create(:invitation, user: user) }
     let(:record) { invitation }
 
-    context "when the invitation has a final delivery status" do
-      Invitation::FINAL_DELIVERY_STATUS.each do |status|
-        it "does not update the invitation if delivery status is #{status}" do
+    context "when the invitation had a failed delivery status and the delivery status is now opened" do
+      Invitation::FAILED_DELIVERY_STATUS.each do |status|
+        it "does not update the failed invitation (#{status})" do
           invitation.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
           invitation.reload
           expect(invitation.delivery_status).to eq(status)
           expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+        end
+      end
+
+      context "when the invitation had a failed delivery status and the delivery status is now delivered" do
+        let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+
+        it "update the invitation with delivered status" do
+          invitation.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+          subject
+          invitation.reload
+          expect(invitation.delivery_status).to eq("delivered")
+          expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
     end
@@ -51,8 +63,19 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
     it "updates the invitation with the correct delivery status and date" do
       subject
       invitation.reload
-      expect(invitation.delivery_status).to eq("delivered")
+      expect(invitation.delivery_status).to eq("sent")
       expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+    end
+
+    context "when the delivery status is delivered" do
+      let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+
+      it "update the invitation with delivered status" do
+        subject
+        invitation.reload
+        expect(invitation.delivery_status).to eq("delivered")
+        expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      end
     end
   end
 
@@ -61,14 +84,26 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
     let(:notification) { create(:notification, participation: participation) }
     let(:record) { notification }
 
-    context "when the notification has a final delivery status" do
-      Notification::FINAL_DELIVERY_STATUS.each do |status|
-        it "does not update the notification if delivery status is #{status}" do
+    context "when the notification had a failed delivery status and the delivery status is now opened" do
+      Notification::FAILED_DELIVERY_STATUS.each do |status|
+        it "does not update the failed notification (#{status})" do
           notification.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
           notification.reload
           expect(notification.delivery_status).to eq(status)
           expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+        end
+      end
+
+      context "when the notification had a failed delivery status and the delivery status is now delivered" do
+        let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+
+        it "update the notification with delivered status" do
+          notification.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+          subject
+          notification.reload
+          expect(notification.delivery_status).to eq("delivered")
+          expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
     end
@@ -104,8 +139,19 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
     it "updates the notification with the correct delivery status and date" do
       subject
       notification.reload
-      expect(notification.delivery_status).to eq("delivered")
+      expect(notification.delivery_status).to eq("sent")
       expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+    end
+
+    context "when the delivery status is delivered" do
+      let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+
+      it "update the notification with delivered status" do
+        subject
+        notification.reload
+        expect(notification.delivery_status).to eq("delivered")
+        expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      end
     end
   end
 end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -1,156 +1,56 @@
 describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
   subject { described_class.call(webhook_params: webhook_params, record: record) }
 
-  let(:webhook_params) { { to: "0601010101", msg_status: "sent", date: "2023-06-07T12:34:56Z" } }
+  let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
   let(:user) { create(:user, phone_number: "0601010101") }
+  let(:invitation) { create(:invitation, user: user) }
+  let!(:participation) { create(:participation, user: user) }
+  let(:notification) { create(:notification, participation: participation) }
 
-  context "for an invitation" do
-    let(:invitation) { create(:invitation, user: user) }
-    let(:record) { invitation }
+  %w[invitation notification].each do |record_type|
+    context "for an #{record_type}" do
+      let(:record) { send(record_type) }
 
-    context "when the invitation had a failed delivery status and the delivery status is now sent" do
-      Invitation::FAILED_DELIVERY_STATUS.each do |status|
-        it "does not update the failed invitation (#{status})" do
-          invitation.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+      context "when the #{record_type} had a failed delivery status and the delivery status is now delivered" do
+        it "update the #{record_type} with delivered status" do
+          record.update(delivery_status: "soft_bounce",
+                        last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
-          invitation.reload
-          expect(invitation.delivery_status).to eq(status)
-          expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+          record.reload
+          expect(record.delivery_status).to eq("delivered")
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
 
-      context "when the invitation had a failed delivery status and the delivery status is now delivered" do
-        let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+      context "when the phone number does not match" do
+        let(:webhook_params) { { to: "0987654321", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
 
-        it "update the invitation with delivered status" do
-          invitation.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+        it "does not update the #{record_type}" do
+          expect(Sentry).to receive(:capture_message).with(
+            "#{record_type.capitalize} mobile phone and webhook mobile phone does not match", any_args
+          )
           subject
-          invitation.reload
-          expect(invitation.delivery_status).to eq("delivered")
-          expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-        end
-      end
-    end
-
-    context "when the update is old" do
-      let(:old_date) { "2022-06-07T12:34:56Z" }
-
-      before do
-        invitation.update(delivered_at: Time.zone.parse("2023-06-08T12:34:56Z"))
-      end
-
-      it "does not update the invitation" do
-        subject
-        invitation.reload
-        expect(invitation.delivery_status).to be_nil
-        expect(invitation.delivered_at).not_to eq(old_date)
-      end
-    end
-
-    context "when the phone number does not match" do
-      let(:webhook_params) { { to: "0987654321", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "does not update the invitation" do
-        expect(Sentry).to receive(:capture_message).with(
-          "Invitation mobile phone and webhook mobile phone does not match", any_args
-        )
-        subject
-        expect(invitation.delivery_status).to be_nil
-        expect(invitation.delivered_at).to be_nil
-      end
-    end
-
-    it "updates the invitation with the correct delivery status and date" do
-      subject
-      invitation.reload
-      expect(invitation.delivery_status).to eq("sent")
-      expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-    end
-
-    context "when the delivery status is delivered" do
-      let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "update the invitation with delivered status" do
-        subject
-        invitation.reload
-        expect(invitation.delivery_status).to eq("delivered")
-        expect(invitation.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-      end
-    end
-  end
-
-  context "for a notification" do
-    let!(:participation) { create(:participation, user: user) }
-    let(:notification) { create(:notification, participation: participation) }
-    let(:record) { notification }
-
-    context "when the notification had a failed delivery status and the delivery status is now sent" do
-      Notification::FAILED_DELIVERY_STATUS.each do |status|
-        it "does not update the failed notification (#{status})" do
-          notification.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
-          subject
-          notification.reload
-          expect(notification.delivery_status).to eq(status)
-          expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
+          expect(record.delivery_status).to be_nil
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end
 
-      context "when the notification had a failed delivery status and the delivery status is now delivered" do
-        let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
+      it "updates the #{record_type} with the correct delivery status and date" do
+        subject
+        record.reload
+        expect(record.delivery_status).to eq("delivered")
+        expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+      end
 
-        it "update the notification with delivered status" do
-          notification.update(delivery_status: "soft_bounce", delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
+      context "when the delivery status is not in enum" do
+        let(:webhook_params) { { to: "0601010101", msg_status: "opened", date: "2023-06-07T12:34:56Z" } }
+
+        it "doesnt update the #{record_type} delivery_status but update last_brevo_webhook_received_at" do
           subject
-          notification.reload
-          expect(notification.delivery_status).to eq("delivered")
-          expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+          record.reload
+          expect(record.delivery_status).to eq(nil)
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
-      end
-    end
-
-    context "when the update is old" do
-      let(:old_date) { "2022-06-07T12:34:56Z" }
-
-      before do
-        notification.update(delivered_at: Time.zone.parse("2023-06-08T12:34:56Z"))
-      end
-
-      it "does not update the notification" do
-        subject
-        notification.reload
-        expect(notification.delivery_status).to be_nil
-        expect(notification.delivered_at).not_to eq(old_date)
-      end
-    end
-
-    context "when the phone number does not match" do
-      let(:webhook_params) { { to: "0987654321", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "does not update the notification" do
-        expect(Sentry).to receive(:capture_message).with(
-          "Notification mobile phone and webhook mobile phone does not match", any_args
-        )
-        subject
-        expect(notification.delivery_status).to be_nil
-        expect(notification.delivered_at).to be_nil
-      end
-    end
-
-    it "updates the notification with the correct delivery status and date" do
-      subject
-      notification.reload
-      expect(notification.delivery_status).to eq("sent")
-      expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
-    end
-
-    context "when the delivery status is delivered" do
-      let(:webhook_params) { { to: "0601010101", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
-
-      it "update the notification with delivered status" do
-        subject
-        notification.reload
-        expect(notification.delivery_status).to eq("delivered")
-        expect(notification.delivered_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
       end
     end
   end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -56,13 +56,13 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
       context "when the record is already delivered" do
         let(:webhook_params) { { to: "0601010101", msg_status: "error", date: "2023-06-07T12:34:56Z" } }
 
-        it "does not update the #{record_type} but save last_brevo_webhook_received_at date" do
+        it "does not update the #{record_type}" do
           record.update(delivery_status: "delivered",
                         last_brevo_webhook_received_at: Time.zone.parse("2023-06-07T12:00:00Z"))
           subject
           record.reload
           expect(record.delivery_status).to eq("delivered")
-          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
+          expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:00:00Z"))
         end
       end
     end

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -8,7 +8,7 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
     let(:invitation) { create(:invitation, user: user) }
     let(:record) { invitation }
 
-    context "when the invitation had a failed delivery status and the delivery status is now opened" do
+    context "when the invitation had a failed delivery status and the delivery status is now sent" do
       Invitation::FAILED_DELIVERY_STATUS.each do |status|
         it "does not update the failed invitation (#{status})" do
           invitation.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))
@@ -84,7 +84,7 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
     let(:notification) { create(:notification, participation: participation) }
     let(:record) { notification }
 
-    context "when the notification had a failed delivery status and the delivery status is now opened" do
+    context "when the notification had a failed delivery status and the delivery status is now sent" do
       Notification::FAILED_DELIVERY_STATUS.each do |status|
         it "does not update the failed notification (#{status})" do
           notification.update(delivery_status: status, delivered_at: Time.zone.parse("2023-06-07T12:00:00Z"))

--- a/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_sms_delivery_status_and_date_spec.rb
@@ -22,15 +22,15 @@ describe InboundWebhooks::Brevo::AssignSmsDeliveryStatusAndDate do
         end
       end
 
-      context "when the phone number does not match" do
+      context "when phone numbers does not match" do
         let(:webhook_params) { { to: "0987654321", msg_status: "delivered", date: "2023-06-07T12:34:56Z" } }
 
-        it "does not update the #{record_type}" do
+        it "update the #{record_type} but capture an error" do
           expect(Sentry).to receive(:capture_message).with(
             "#{record_type.capitalize} mobile phone and webhook mobile phone does not match", any_args
           )
           subject
-          expect(record.delivery_status).to be_nil
+          expect(record.delivery_status).to eq("delivered")
           expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))
         end
       end


### PR DESCRIPTION
Le bug est le suivant :
En enlevant `soft_bounce` des status d'erreur finaux hier (pour lui permettre de passer en `delivered` en cas de retry positif) je me suis retrouvé avec le problème d'ordre des webhook de Brevo (l'invitation passe en `soft_bounce` puis en `sent` parcequ'on reçoit les webhook dans le désordre).
J'ai un peu revu et amélioré le code en plus de fix le problème.
Désormais toutes les invitations avec un status en erreur peuvent changer de status passer en `delivered` (uniquement) si on reçoit un webhook dans ce sens (à priori ça n'arrivera jamais pour les `hard_bounce` mais c'est géré)
La constante `FINAL_DELIVERY_STATUS` rendait les choses un peu trop floues, je l'ai enlevé.