### PR TITLE
fix(brevo): compare email without case when sending warning to sentry

### DIFF
--- a/app/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date.rb
+++ b/app/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date.rb
@@ -8,7 +8,7 @@ module InboundWebhooks
       end
 
       def alert_sentry_if_webhook_mismatch
-        return if @record.email == @webhook_params[:email]
+        return if @record.email.casecmp?(@webhook_params[:email])
 
         Sentry.capture_message("#{record_class} email and webhook email does not match",
                                extra: { record: @record, webhook: @webhook_params })

--- a/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
+++ b/spec/services/inbound_webhooks/brevo/assign_mail_delivery_status_and_date_spec.rb
@@ -1,7 +1,7 @@
 describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
   subject { described_class.call(webhook_params: webhook_params, record: record) }
 
-  let(:webhook_params) { { email: "test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
+  let(:webhook_params) { { email: "Test@example.com", event: "delivered", date: "2023-06-07T12:34:56Z" } }
   let!(:user) { create(:user, email: "test@example.com", invitations: []) }
   let!(:participation) { create(:participation, user: user) }
   let(:notification) { create(:notification, participation: participation) }
@@ -40,6 +40,7 @@ describe InboundWebhooks::Brevo::AssignMailDeliveryStatusAndDate do
 
       it "updates the #{record_type} with the correct delivery status and date" do
         subject
+        expect(Sentry).not_to receive(:capture_message).with(any_args)
         record.reload
         expect(record.delivery_status).to eq("delivered")
         expect(record.last_brevo_webhook_received_at).to eq(Time.zone.parse("2023-06-07T12:34:56Z"))


### PR DESCRIPTION
Pour éviter d'avoir des faux positif : https://sentry.incubateur.net/organizations/betagouv/issues/110095/?environment=staging&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=1
