### PR TITLE
chore(deps): Update stringio

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,7 +481,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.1.0)
+    stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
     tilt (2.3.0)


### PR DESCRIPTION
Depuis le passage à ruby 3.3.3 j'ai des problèmes en local à cause de la version de `stringio` dans le `Gemfile.lock`. Je me permets donc de la mettre cette gem à jour avec la dernière version.