### PR TITLE
feat(api): add participations to webhook payload

### DIFF
--- a/app/blueprints/agent_blueprint.rb
+++ b/app/blueprints/agent_blueprint.rb
@@ -1,4 +1,4 @@
-class AgentBlueprint < Blueprinter::Base
+class AgentBlueprint < ApplicationBlueprint
   identifier :id
   fields :email, :first_name, :last_name, :rdv_solidarites_agent_id
 end

--- a/app/blueprints/application_blueprint.rb
+++ b/app/blueprints/application_blueprint.rb
@@ -1,0 +1,9 @@
+class ApplicationBlueprint < Blueprinter::Base
+  def self.policy_scoped_association(resources_name, blueprint:)
+    association(resources_name, blueprint:) do |record, _options|
+      record.send(resources_name).select do |resource|
+        Pundit.policy!(Current.agent, resource).show?
+      end
+    end
+  end
+end

--- a/app/blueprints/archive_blueprint.rb
+++ b/app/blueprints/archive_blueprint.rb
@@ -1,4 +1,4 @@
-class ArchiveBlueprint < Blueprinter::Base
+class ArchiveBlueprint < ApplicationBlueprint
   identifier :id
   fields :archiving_reason, :department_id, :user_id
 end

--- a/app/blueprints/department_blueprint.rb
+++ b/app/blueprints/department_blueprint.rb
@@ -1,4 +1,4 @@
-class DepartmentBlueprint < Blueprinter::Base
+class DepartmentBlueprint < ApplicationBlueprint
   identifier :id
   fields :number, :capital, :region, :carnet_de_bord_deploiement_id
 

--- a/app/blueprints/follow_up_blueprint.rb
+++ b/app/blueprints/follow_up_blueprint.rb
@@ -1,4 +1,4 @@
-class FollowUpBlueprint < Blueprinter::Base
+class FollowUpBlueprint < ApplicationBlueprint
   identifier :id
   fields :status, :human_status, :motif_category_id, :closed_at
   association :participations, blueprint: ParticipationBlueprint

--- a/app/blueprints/invitation_blueprint.rb
+++ b/app/blueprints/invitation_blueprint.rb
@@ -1,4 +1,4 @@
-class InvitationBlueprint < Blueprinter::Base
+class InvitationBlueprint < ApplicationBlueprint
   identifier :id
   fields :format, :clicked, :rdv_with_referents, :created_at, :delivery_status, :delivered_at
   association :motif_category, blueprint: MotifCategoryBlueprint

--- a/app/blueprints/lieu_blueprint.rb
+++ b/app/blueprints/lieu_blueprint.rb
@@ -1,4 +1,4 @@
-class LieuBlueprint < Blueprinter::Base
+class LieuBlueprint < ApplicationBlueprint
   identifier :rdv_solidarites_lieu_id
   fields :name, :address, :phone_number
 end

--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -1,4 +1,4 @@
-class MotifBlueprint < Blueprinter::Base
+class MotifBlueprint < ApplicationBlueprint
   identifier :rdv_solidarites_motif_id
   fields :name, :collectif, :location_type, :follow_up
   association :motif_category, blueprint: MotifCategoryBlueprint

--- a/app/blueprints/motif_category_blueprint.rb
+++ b/app/blueprints/motif_category_blueprint.rb
@@ -1,4 +1,4 @@
-class MotifCategoryBlueprint < Blueprinter::Base
+class MotifCategoryBlueprint < ApplicationBlueprint
   identifier :id
   fields :short_name, :name
 end

--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -1,4 +1,4 @@
-class OrganisationBlueprint < Blueprinter::Base
+class OrganisationBlueprint < ApplicationBlueprint
   identifier :id
   fields :name, :email, :phone_number, :department_number, :rdv_solidarites_organisation_id
   association :motif_categories, blueprint: MotifCategoryBlueprint

--- a/app/blueprints/participation_blueprint.rb
+++ b/app/blueprints/participation_blueprint.rb
@@ -1,4 +1,4 @@
-class ParticipationBlueprint < Blueprinter::Base
+class ParticipationBlueprint < ApplicationBlueprint
   identifier :id
   fields :status, :created_by, :created_at, :starts_at
   association :user, blueprint: UserBlueprint

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -9,5 +9,6 @@ class RdvBlueprint < Blueprinter::Base
     association :motif, blueprint: MotifBlueprint
     association :users, blueprint: UserBlueprint
     association :organisation, blueprint: OrganisationBlueprint
+    association :participations, blueprint: ParticipationBlueprint
   end
 end

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -1,4 +1,4 @@
-class RdvBlueprint < Blueprinter::Base
+class RdvBlueprint < ApplicationBlueprint
   identifier :id
   fields :starts_at, :duration_in_min, :cancelled_at, :address, :uuid, :created_by,
          :status, :users_count, :max_participants_count, :rdv_solidarites_rdv_id

--- a/app/blueprints/tag_blueprint.rb
+++ b/app/blueprints/tag_blueprint.rb
@@ -1,4 +1,4 @@
-class TagBlueprint < Blueprinter::Base
+class TagBlueprint < ApplicationBlueprint
   identifier :id
   fields :value
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -1,4 +1,4 @@
-class UserBlueprint < Blueprinter::Base
+class UserBlueprint < ApplicationBlueprint
   identifier :id
   fields  :uid, :affiliation_number, :role, :created_at, :department_internal_id,
           :first_name, :last_name, :title, :address, :phone_number, :email, :birth_date, :rights_opening_date,
@@ -13,22 +13,8 @@ class UserBlueprint < Blueprinter::Base
     association :referents, blueprint: AgentBlueprint
     association :archives, blueprint: ArchiveBlueprint
 
-    association :invitations, blueprint: InvitationBlueprint do |user, _options|
-      user.invitations.select do |invitation|
-        Pundit.policy!(Current.agent, invitation).show?
-      end
-    end
-
-    association :follow_ups, blueprint: FollowUpBlueprint do |user, _options|
-      user.follow_ups.select do |follow_up|
-        Pundit.policy!(Current.agent, follow_up).show?
-      end
-    end
-
-    association :tags, blueprint: TagBlueprint do |user, _options|
-      user.tags.select do |tag|
-        Pundit.policy!(Current.agent, tag).show?
-      end
-    end
+    policy_scoped_association :invitations, blueprint: InvitationBlueprint
+    policy_scoped_association :follow_ups, blueprint: FollowUpBlueprint
+    policy_scoped_association :tags, blueprint: TagBlueprint
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -317,4 +317,54 @@ describe User do
       end
     end
   end
+
+  describe "#as_json" do
+    subject { user.as_json }
+
+    before do
+      allow(Current).to receive(:agent).and_return(agent)
+    end
+
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:department) { create(:department) }
+    let!(:organisation) do
+      create(
+        :organisation,
+        category_configurations: [create(:category_configuration, motif_category:)],
+        department:
+      )
+    end
+    let!(:other_organisation) do
+      create(
+        :organisation,
+        category_configurations: [create(:category_configuration, motif_category: other_motif_category)],
+        department:
+      )
+    end
+
+    let!(:user) do
+      create(
+        :user,
+        organisations: [organisation, other_organisation]
+      )
+    end
+
+    let!(:motif_category) { create(:motif_category) }
+    let!(:other_motif_category) { create(:motif_category) }
+
+    let!(:invitation) { create(:invitation, user:, follow_up:) }
+    let!(:other_invitation) { create(:invitation, user:, follow_up: other_follow_up) }
+
+    let!(:follow_up) { create(:follow_up, user:, motif_category:) }
+    let!(:other_follow_up) { create(:follow_up, user:, motif_category: other_motif_category) }
+
+    let!(:tag) { create(:tag, users: [user], organisations: [organisation]) }
+    let!(:other_tag) { create(:tag, users: [user], organisations: [other_organisation]) }
+
+    it "restricts the visible ressources" do
+      expect(subject["follow_ups"].pluck("id")).to contain_exactly(follow_up.id)
+      expect(subject["invitations"].pluck("id")).to contain_exactly(invitation.id)
+      expect(subject["tags"].pluck("id")).to contain_exactly(tag.id)
+    end
+  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -50,6 +50,10 @@ RSpec.configure do |config|
                 type: "array",
                 items: { "$ref" => "#/components/schemas/agent" }
               },
+              participations: {
+                type: "array",
+                items: { "$ref" => "#/components/schemas/participation" }
+              },
               cancelled_at: { type: "string", format: "date", nullable: true },
               collectif: { type: "boolean" },
               created_by: { type: "string", enum: %w[agent user prescripteur] },
@@ -277,11 +281,12 @@ RSpec.configure do |config|
             type: "object",
             properties: {
               id: { type: "integer" },
-              status: { type: "string" },
-              created_by: { type: "string" },
+              status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
+              created_by: { type: "string", enum: %w[agent user prescripteur] },
               created_at: { type: "string", format: "date" },
-              user: { "$ref" => "#/components/schemas/user" }
-            }
+              user: { "$ref" => "#/components/schemas/user" },
+            },
+            required: %w[status created_by created_at]
           },
           invitations: {
             type: "object",

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -284,7 +284,7 @@ RSpec.configure do |config|
               status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
               created_by: { type: "string", enum: %w[agent user prescripteur] },
               created_at: { type: "string", format: "date" },
-              user: { "$ref" => "#/components/schemas/user" },
+              user: { "$ref" => "#/components/schemas/user" }
             },
             required: %w[status created_by created_at]
           },

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -39,6 +39,12 @@
               "$ref": "#/components/schemas/agent"
             }
           },
+          "participations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/participation"
+            }
+          },
           "cancelled_at": {
             "type": "string",
             "format": "date",
@@ -615,10 +621,22 @@
             "type": "integer"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "unknown",
+              "seen",
+              "excused",
+              "revoked",
+              "noshow"
+            ]
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "agent",
+              "user",
+              "prescripteur"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -627,7 +645,12 @@
           "user": {
             "$ref": "#/components/schemas/user"
           }
-        }
+        },
+        "required": [
+          "status",
+          "created_by",
+          "created_at"
+        ]
       },
       "invitations": {
         "type": "object",
@@ -1010,14 +1033,14 @@
                   "succès": {
                     "value": {
                       "department": {
-                        "id": 83,
+                        "id": 1,
                         "number": "13",
                         "capital": "Marseille",
                         "region": "Provence-Alpes-Côte d'Azur",
                         "carnet_de_bord_deploiement_id": null,
                         "organisations": [
                           {
-                            "id": 66,
+                            "id": 2,
                             "name": "Pôle Parcours",
                             "email": "pole-parcours@departement13.fr",
                             "phone_number": "0101010101",
@@ -1025,7 +1048,7 @@
                             "rdv_solidarites_organisation_id": 2,
                             "motif_categories": [
                               {
-                                "id": 223,
+                                "id": 1,
                                 "short_name": "rsa_orientation",
                                 "name": "RSA orientation"
                               }
@@ -1038,7 +1061,7 @@
                                 "location_type": "public_office",
                                 "follow_up": false,
                                 "motif_category": {
-                                  "id": 223,
+                                  "id": 1,
                                   "short_name": "rsa_orientation",
                                   "name": "RSA orientation"
                                 }
@@ -1190,12 +1213,12 @@
                   "Renvoie le rdv": {
                     "value": {
                       "rdv": {
-                        "id": 7,
-                        "starts_at": "2024-07-06T14:33:19.689+02:00",
+                        "id": 2,
+                        "starts_at": "2024-07-13T20:55:42.495+02:00",
                         "duration_in_min": 30,
                         "cancelled_at": null,
                         "address": "2O avenue de Ségur, 75007 Paris",
-                        "uuid": "cc362b84-ef46-4085-84ae-194ed199512d",
+                        "uuid": "0a3a7a9e-a058-4ef6-bf6a-f8ff26ef73cf",
                         "created_by": "user",
                         "status": "unknown",
                         "users_count": 0,
@@ -1203,11 +1226,11 @@
                         "rdv_solidarites_rdv_id": 2,
                         "agents": [
                           {
-                            "id": 55,
+                            "id": 7,
                             "email": "agent7@gouv.fr",
                             "first_name": "jane7",
                             "last_name": "doe7",
-                            "rdv_solidarites_agent_id": 1458335135
+                            "rdv_solidarites_agent_id": 2622871369
                           }
                         ],
                         "lieu": {
@@ -1223,19 +1246,19 @@
                           "location_type": "public_office",
                           "follow_up": false,
                           "motif_category": {
-                            "id": 334,
+                            "id": 112,
                             "short_name": "rsa_orientation",
                             "name": "RSA orientation"
                           }
                         },
                         "users": [
                           {
-                            "id": 40,
+                            "id": 3,
                             "uid": "bnVtZXJvXzMgLSBkZW1hbmRldXI=",
                             "affiliation_number": "numero_3",
                             "role": "demandeur",
                             "created_at": "0024-12-02T22:22:00.000+00:09",
-                            "department_internal_id": "4223",
+                            "department_internal_id": "4050",
                             "first_name": "john3",
                             "last_name": "doe3",
                             "title": "monsieur",
@@ -1252,7 +1275,7 @@
                           }
                         ],
                         "organisation": {
-                          "id": 79,
+                          "id": 15,
                           "name": "Organisation n°11",
                           "email": "organisation11@rdv-insertion.fr",
                           "phone_number": "0101010101",
@@ -1260,12 +1283,42 @@
                           "rdv_solidarites_organisation_id": 15,
                           "motif_categories": [
                             {
-                              "id": 334,
+                              "id": 112,
                               "short_name": "rsa_orientation",
                               "name": "RSA orientation"
                             }
                           ]
-                        }
+                        },
+                        "participations": [
+                          {
+                            "id": 2,
+                            "status": "unknown",
+                            "created_by": "user",
+                            "created_at": "2024-07-10T20:55:42.745+02:00",
+                            "starts_at": "2024-07-13T20:55:42.495+02:00",
+                            "user": {
+                              "id": 3,
+                              "uid": "bnVtZXJvXzMgLSBkZW1hbmRldXI=",
+                              "affiliation_number": "numero_3",
+                              "role": "demandeur",
+                              "created_at": "0024-12-02T22:22:00.000+00:09",
+                              "department_internal_id": "4050",
+                              "first_name": "john3",
+                              "last_name": "doe3",
+                              "title": "monsieur",
+                              "address": "27 avenue de Ségur 75007 Paris",
+                              "phone_number": "+33782605941",
+                              "email": "johndoe3@yahoo.fr",
+                              "birth_date": null,
+                              "rights_opening_date": null,
+                              "birth_name": null,
+                              "rdv_solidarites_user_id": 3,
+                              "nir": null,
+                              "carnet_de_bord_carnet_id": null,
+                              "france_travail_id": null
+                            }
+                          }
+                        ]
                       }
                     }
                   }
@@ -1559,7 +1612,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180154296694435",
+                        "nir": "180258533559478",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1579,7 +1632,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180485683538914",
+                        "nir": "180747327658456",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1604,7 +1657,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180328824895134",
+                        "nir": "180284212481920",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1624,7 +1677,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180647898581189",
+                        "nir": "180568715417267",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1649,7 +1702,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180483859966925",
+                        "nir": "180114495619692",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1669,7 +1722,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180593655913153",
+                        "nir": "180367725888465",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1694,7 +1747,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180467117536303",
+                        "nir": "180637172531324",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1714,7 +1767,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180226988296772",
+                        "nir": "180672687551890",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1739,7 +1792,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180779148758379",
+                        "nir": "180262481256867",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1759,7 +1812,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180327653225206",
+                        "nir": "180291199163969",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1784,7 +1837,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180176654389434",
+                        "nir": "180821533476226",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1804,7 +1857,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180497891352663",
+                        "nir": "180436777543830",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1829,7 +1882,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1847,7 +1900,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1865,7 +1918,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1883,7 +1936,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1901,7 +1954,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1919,7 +1972,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1937,7 +1990,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1955,7 +2008,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1973,7 +2026,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1991,7 +2044,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2009,7 +2062,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2027,7 +2080,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2045,7 +2098,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2063,7 +2116,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2081,7 +2134,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2099,7 +2152,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2117,7 +2170,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2135,7 +2188,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2153,7 +2206,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2171,7 +2224,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2189,7 +2242,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2207,7 +2260,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2225,7 +2278,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2243,7 +2296,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2261,7 +2314,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2279,7 +2332,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2297,7 +2350,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2315,7 +2368,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2333,7 +2386,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2351,7 +2404,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180682623899617",
+                        "nir": "180461549526762",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2376,7 +2429,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180849919191188",
+                        "nir": "180996554277963",
                         "referents_to_add": [
                           {
                             "email": "agentnontrouve@nomdedomaine.fr"
@@ -2396,7 +2449,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180749279533434",
+                        "nir": "180779163496243",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -2484,7 +2537,7 @@
                     "value": {
                       "success": true,
                       "user": {
-                        "id": 48,
+                        "id": 11,
                         "uid": "MTA0OTIzOSAtIGRlbWFuZGV1cg==",
                         "affiliation_number": "1049239",
                         "role": "demandeur",
@@ -2500,44 +2553,44 @@
                         "rights_opening_date": null,
                         "birth_name": null,
                         "rdv_solidarites_user_id": 11,
-                        "nir": "180948931812120",
+                        "nir": "180472165586844",
                         "carnet_de_bord_carnet_id": null,
                         "france_travail_id": null,
                         "referents": [
                           {
-                            "id": 79,
+                            "id": 31,
                             "email": "agentreferent@nomdedomaine.fr",
                             "first_name": "jane31",
                             "last_name": "doe31",
-                            "rdv_solidarites_agent_id": 1642450644
+                            "rdv_solidarites_agent_id": 5236502642
                           }
                         ]
                       },
                       "invitations": [
                         {
-                          "id": 20,
+                          "id": 2,
                           "format": "sms",
                           "clicked": false,
                           "rdv_with_referents": false,
-                          "created_at": "2024-07-03T14:33:20.546+02:00",
+                          "created_at": "2024-07-10T20:55:59.021+02:00",
                           "delivery_status": null,
                           "delivered_at": null,
                           "motif_category": {
-                            "id": 428,
+                            "id": 206,
                             "short_name": "rsa_orientation_8",
                             "name": "RSA orientation"
                           }
                         },
                         {
-                          "id": 19,
+                          "id": 1,
                           "format": "email",
                           "clicked": false,
                           "rdv_with_referents": false,
-                          "created_at": "2024-07-03T14:33:20.523+02:00",
+                          "created_at": "2024-07-10T20:55:58.452+02:00",
                           "delivery_status": null,
                           "delivered_at": null,
                           "motif_category": {
-                            "id": 427,
+                            "id": 205,
                             "short_name": "rsa_orientation_7",
                             "name": "RSA orientation"
                           }
@@ -2725,7 +2778,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180948931812120",
+                      "nir": "180472165586844",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2753,7 +2806,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180381315269355",
+                      "nir": "180695617385157",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2781,7 +2834,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180651412231985",
+                      "nir": "180934879485268",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2809,7 +2862,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180417137739341",
+                      "nir": "180573196555268",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2837,7 +2890,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180675914142371",
+                      "nir": "180153291383465",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2865,7 +2918,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180732631266551",
+                      "nir": "180998465791835",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2893,7 +2946,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180563854724996",
+                      "nir": "180753916347824",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2921,7 +2974,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180229321897137",
+                      "nir": "180662113797369",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2949,7 +3002,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180851928737913",
+                      "nir": "180484697438201",
                       "referents_to_add": [
                         {
                           "email": "agentnontrouve@nomdedomaine.fr"


### PR DESCRIPTION
closes #2142 

J'ajoute les participations aux webhooks pour pouvoir s'adapter aux rdvs collectifs. Le commit qui correspond à ce développement: https://github.com/gip-inclusion/rdv-insertion/commit/57b36b8094116c25a36d406c728298b8542a53d9

J'en ai profité pour mettre les associations qui étaient scopées à l'agent dans une méthode dans une nouvelle classe `ApplicationBlueprint`