### PR TITLE
fix(index): add anchor for follow_up link

### DIFF
--- a/app/views/follow_ups/_follow_up_status_cell.html.erb
+++ b/app/views/follow_ups/_follow_up_status_cell.html.erb
@@ -1,7 +1,7 @@
 <td
   id="follow-up-status-<%= follow_up.id %>"
   class="<%= background_class_for_follow_up_status(follow_up, number_of_days_before_action_required) %>"
-  data-link-path="<%= structure_user_follow_ups_path(follow_up.user_id) %>"
+  data-link-path="<%= structure_user_follow_ups_path(follow_up.user_id, anchor: "follow_up_#{follow_up.id}") %>"
 >
   <%= display_follow_up_status(follow_up, number_of_days_before_action_required) %>
   <% if follow_up.rdv_pending? && follow_up.current_pending_rdv.present? %>


### PR DESCRIPTION
Quand on clique sur un statut de `follow_up` depuis la page index, on est redirigé sur l'onglet "Rendez-vous" de l'utilisateur, mais en haut de la page. Si l'utilisateur a plusieurs contextes et qu'on connait mal le fonctionnement de ce lien, on peut être perturbé par la redirection. Pour la rendre plus claire/plus intuitive, j'ajoute ici une ancre permettant de positionner l'usager sur le `follow_up` concerné plutôt qu'en haut de la page.