### PR TITLE
Update invitation api doc delivery statuses

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -308,9 +308,7 @@ RSpec.configure do |config|
               created_at: { type: "string" },
               motif_category: { "$ref" => "#/components/schemas/motif_category" },
               delivery_status: { type: "string",
-                                 enum: %w[accepted sent request click deferred delivered hard_bounce soft_bounce
-                                          spam unique_opened opened reply invalid_email blocked error unsubscribe
-                                          proxy_open],
+                                 enum: %w[soft_bounce hard_bounce blocked invalid_email error delivered],
                                  nullable: true },
               delivered_at: { type: "string", format: "date", nullable: true }
             },

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -695,23 +695,12 @@
           "delivery_status": {
             "type": "string",
             "enum": [
-              "accepted",
-              "sent",
-              "request",
-              "click",
-              "deferred",
-              "delivered",
-              "hard_bounce",
               "soft_bounce",
-              "spam",
-              "unique_opened",
-              "opened",
-              "reply",
-              "invalid_email",
+              "hard_bounce",
               "blocked",
+              "invalid_email",
               "error",
-              "unsubscribe",
-              "proxy_open"
+              "delivered"
             ],
             "nullable": true
           },
@@ -1033,14 +1022,14 @@
                   "succès": {
                     "value": {
                       "department": {
-                        "id": 83,
+                        "id": 165,
                         "number": "13",
                         "capital": "Marseille",
                         "region": "Provence-Alpes-Côte d'Azur",
                         "carnet_de_bord_deploiement_id": null,
                         "organisations": [
                           {
-                            "id": 66,
+                            "id": 130,
                             "name": "Pôle Parcours",
                             "email": "pole-parcours@departement13.fr",
                             "phone_number": "0101010101",
@@ -1048,7 +1037,7 @@
                             "rdv_solidarites_organisation_id": 2,
                             "motif_categories": [
                               {
-                                "id": 223,
+                                "id": 445,
                                 "short_name": "rsa_orientation",
                                 "name": "RSA orientation"
                               }
@@ -1061,7 +1050,7 @@
                                 "location_type": "public_office",
                                 "follow_up": false,
                                 "motif_category": {
-                                  "id": 223,
+                                  "id": 445,
                                   "short_name": "rsa_orientation",
                                   "name": "RSA orientation"
                                 }
@@ -1213,12 +1202,12 @@
                   "Renvoie le rdv": {
                     "value": {
                       "rdv": {
-                        "id": 7,
-                        "starts_at": "2024-07-18T14:41:59.925+02:00",
+                        "id": 12,
+                        "starts_at": "2024-07-18T15:52:40.595+02:00",
                         "duration_in_min": 30,
                         "cancelled_at": null,
                         "address": "2O avenue de Ségur, 75007 Paris",
-                        "uuid": "19ee7986-b019-47a3-8814-20d42a009620",
+                        "uuid": "19c25c20-b3f1-4da9-b5b0-f1da51af1435",
                         "created_by": "user",
                         "status": "unknown",
                         "users_count": 0,
@@ -1226,11 +1215,11 @@
                         "rdv_solidarites_rdv_id": 2,
                         "agents": [
                           {
-                            "id": 55,
+                            "id": 103,
                             "email": "agent7@gouv.fr",
                             "first_name": "jane7",
                             "last_name": "doe7",
-                            "rdv_solidarites_agent_id": 9847253813
+                            "rdv_solidarites_agent_id": 8231110965
                           }
                         ],
                         "lieu": {
@@ -1246,19 +1235,19 @@
                           "location_type": "public_office",
                           "follow_up": false,
                           "motif_category": {
-                            "id": 334,
+                            "id": 556,
                             "short_name": "rsa_orientation",
                             "name": "RSA orientation"
                           }
                         },
                         "users": [
                           {
-                            "id": 40,
+                            "id": 77,
                             "uid": "bnVtZXJvXzMgLSBkZW1hbmRldXI=",
                             "affiliation_number": "numero_3",
                             "role": "demandeur",
                             "created_at": "0024-12-02T22:22:00.000+00:09",
-                            "department_internal_id": "4977",
+                            "department_internal_id": "4140",
                             "first_name": "john3",
                             "last_name": "doe3",
                             "title": "monsieur",
@@ -1275,7 +1264,7 @@
                           }
                         ],
                         "organisation": {
-                          "id": 79,
+                          "id": 143,
                           "name": "Organisation n°11",
                           "email": "organisation11@rdv-insertion.fr",
                           "phone_number": "0101010101",
@@ -1283,7 +1272,7 @@
                           "rdv_solidarites_organisation_id": 15,
                           "motif_categories": [
                             {
-                              "id": 334,
+                              "id": 556,
                               "short_name": "rsa_orientation",
                               "name": "RSA orientation"
                             }
@@ -1291,18 +1280,18 @@
                         },
                         "participations": [
                           {
-                            "id": 7,
+                            "id": 12,
                             "status": "unknown",
                             "created_by": "user",
-                            "created_at": "2024-07-15T14:41:59.969+02:00",
-                            "starts_at": "2024-07-18T14:41:59.925+02:00",
+                            "created_at": "2024-07-15T15:52:40.639+02:00",
+                            "starts_at": "2024-07-18T15:52:40.595+02:00",
                             "user": {
-                              "id": 40,
+                              "id": 77,
                               "uid": "bnVtZXJvXzMgLSBkZW1hbmRldXI=",
                               "affiliation_number": "numero_3",
                               "role": "demandeur",
                               "created_at": "0024-12-02T22:22:00.000+00:09",
-                              "department_internal_id": "4977",
+                              "department_internal_id": "4140",
                               "first_name": "john3",
                               "last_name": "doe3",
                               "title": "monsieur",
@@ -1612,7 +1601,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180925997766479",
+                        "nir": "180835579534205",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1632,7 +1621,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180265765416155",
+                        "nir": "180365663897703",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1657,7 +1646,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180388491986777",
+                        "nir": "180336856486325",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1677,7 +1666,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180333272521912",
+                        "nir": "180875251435234",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1702,7 +1691,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180385859888611",
+                        "nir": "180576824231445",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1722,7 +1711,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180174653364655",
+                        "nir": "180745969591348",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1747,7 +1736,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180728931538378",
+                        "nir": "180574922268610",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1767,7 +1756,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180499913724271",
+                        "nir": "180756964298947",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1792,7 +1781,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180922217627781",
+                        "nir": "180611292217581",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1812,7 +1801,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180782819122276",
+                        "nir": "180368659566717",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1837,7 +1826,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180687559119857",
+                        "nir": "180558336986302",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1857,7 +1846,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180278882446637",
+                        "nir": "180468878648309",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -1882,7 +1871,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1900,7 +1889,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1918,7 +1907,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1936,7 +1925,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1954,7 +1943,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1972,7 +1961,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -1990,7 +1979,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2008,7 +1997,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2026,7 +2015,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2044,7 +2033,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2062,7 +2051,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2080,7 +2069,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2098,7 +2087,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2116,7 +2105,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2134,7 +2123,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2152,7 +2141,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2170,7 +2159,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2188,7 +2177,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2206,7 +2195,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2224,7 +2213,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2242,7 +2231,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2260,7 +2249,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2278,7 +2267,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2296,7 +2285,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2314,7 +2303,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2332,7 +2321,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2350,7 +2339,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2368,7 +2357,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2386,7 +2375,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2404,7 +2393,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180257898461282",
+                        "nir": "180616131865901",
                         "referents_to_add": [
                           {
                             "email": "agentreferent@nomdedomaine.fr"
@@ -2429,7 +2418,7 @@
                         "birth_date": "11/03/1978",
                         "address": "13 rue de la République 13001 MARSEILLE",
                         "department_internal_id": "11111444",
-                        "nir": "180817998512253",
+                        "nir": "180634159732110",
                         "referents_to_add": [
                           {
                             "email": "agentnontrouve@nomdedomaine.fr"
@@ -2449,7 +2438,7 @@
                         "address": "5 Avenue du Moulin des Baux, 13260 Cassis",
                         "department_internal_id": "22221111",
                         "france_travail_id": "22233333",
-                        "nir": "180975236385253",
+                        "nir": "180422784496549",
                         "invitation": {
                           "motif_category": {
                             "name": "RSA orientation"
@@ -2537,7 +2526,7 @@
                     "value": {
                       "success": true,
                       "user": {
-                        "id": 48,
+                        "id": 85,
                         "uid": "MTA0OTIzOSAtIGRlbWFuZGV1cg==",
                         "affiliation_number": "1049239",
                         "role": "demandeur",
@@ -2553,44 +2542,44 @@
                         "rights_opening_date": null,
                         "birth_name": null,
                         "rdv_solidarites_user_id": 11,
-                        "nir": "180776398479767",
+                        "nir": "180415948422638",
                         "carnet_de_bord_carnet_id": null,
                         "france_travail_id": null,
                         "referents": [
                           {
-                            "id": 79,
+                            "id": 127,
                             "email": "agentreferent@nomdedomaine.fr",
                             "first_name": "jane31",
                             "last_name": "doe31",
-                            "rdv_solidarites_agent_id": 2590631023
+                            "rdv_solidarites_agent_id": 4570481353
                           }
                         ]
                       },
                       "invitations": [
                         {
-                          "id": 20,
+                          "id": 38,
                           "format": "sms",
                           "clicked": false,
                           "rdv_with_referents": false,
-                          "created_at": "2024-07-15T14:42:01.787+02:00",
+                          "created_at": "2024-07-15T15:52:42.559+02:00",
                           "delivery_status": null,
                           "delivered_at": null,
                           "motif_category": {
-                            "id": 428,
+                            "id": 650,
                             "short_name": "rsa_orientation_8",
                             "name": "RSA orientation"
                           }
                         },
                         {
-                          "id": 19,
+                          "id": 37,
                           "format": "email",
                           "clicked": false,
                           "rdv_with_referents": false,
-                          "created_at": "2024-07-15T14:42:01.730+02:00",
+                          "created_at": "2024-07-15T15:52:42.511+02:00",
                           "delivery_status": null,
                           "delivered_at": null,
                           "motif_category": {
-                            "id": 427,
+                            "id": 649,
                             "short_name": "rsa_orientation_7",
                             "name": "RSA orientation"
                           }
@@ -2778,7 +2767,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180776398479767",
+                      "nir": "180415948422638",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2806,7 +2795,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180532317673638",
+                      "nir": "180233964378406",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2834,7 +2823,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180425142169839",
+                      "nir": "180956281983160",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2862,7 +2851,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180332227649788",
+                      "nir": "180963752667396",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2890,7 +2879,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180366126575627",
+                      "nir": "180799788529138",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2918,7 +2907,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180584412477901",
+                      "nir": "180349318446608",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2946,7 +2935,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180483921411772",
+                      "nir": "180238483112419",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -2974,7 +2963,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180478677665612",
+                      "nir": "180232486283991",
                       "referents_to_add": [
                         {
                           "email": "agentreferent@nomdedomaine.fr"
@@ -3002,7 +2991,7 @@
                       "birth_date": "11/03/1978",
                       "address": "13 rue de la République 13001 MARSEILLE",
                       "department_internal_id": "11111444",
-                      "nir": "180399992992113",
+                      "nir": "180888177493304",
                       "referents_to_add": [
                         {
                           "email": "agentnontrouve@nomdedomaine.fr"


### PR DESCRIPTION
La liste des statuts possibles n'avait pas été mise à jour dans la doc de l'API suite à #2182 . 
Je le fais ici