### PR TITLE
script(rdvsp): add an export script for checking data coherence with rdvsp

### DIFF
--- a/scripts/export_organisations_rdvsp_ids.rb
+++ b/scripts/export_organisations_rdvsp_ids.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require "json"
+require_relative "../config/environment"
+
+organisations_data = Organisation.all.map do |organisation|
+  {
+    rdv_solidarites_organisation_id: organisation.rdv_solidarites_organisation_id
+  }
+end
+
+json_data = JSON.pretty_generate(organisations_data)
+file_path = Rails.root.join("rdvsp_organisations_ids.json")
+File.write(file_path, json_data)
+
+puts "Le fichier JSON a été généré et sauvegardé à l'emplacement suivant : #{file_path}"

--- a/scripts/export_users_rdvsp_ids.rb
+++ b/scripts/export_users_rdvsp_ids.rb
@@ -16,7 +16,7 @@ users_data = User.active.where.not(rdv_solidarites_user_id: nil).includes(:organ
     rdv_solidarites_user_id: user.rdv_solidarites_user_id,
     rdv_solidarites_organisation_ids: rdv_solidarites_organisation_ids
   }
-end
+end.compact
 
 json_data = JSON.pretty_generate(users_data)
 file_path = Rails.root.join("rdvsp_users_ids.json")

--- a/scripts/export_users_rdvsp_ids.rb
+++ b/scripts/export_users_rdvsp_ids.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require "json"
+require_relative "../config/environment"
+
+# .active n'est pas suffisant car vérifie uniquement le champ deleted_at
+# Or on a des usagers qui n'ont pas de deleted_at et qui n'ont pas de rdv_solidarites_user_id Pourquoi ?
+# Il faudrait ajouter d'autres scopes si nécessaire
+# On a aussi 30 users avec un rdv_solidarites_user_id mais qui n'ont pas d'organisation en prod ? (on les skip ligne 13)
+
+users_data = User.active.where.not(rdv_solidarites_user_id: nil).includes(:organisations).map do |user|
+  rdv_solidarites_organisation_ids = user.organisations.pluck(:rdv_solidarites_organisation_id)
+  next if rdv_solidarites_organisation_ids.empty?
+
+  {
+    rdv_solidarites_user_id: user.rdv_solidarites_user_id,
+    rdv_solidarites_organisation_ids: rdv_solidarites_organisation_ids
+  }
+end
+
+json_data = JSON.pretty_generate(users_data)
+file_path = Rails.root.join("rdvsp_users_ids.json")
+File.write(file_path, json_data)
+
+puts "Le fichier JSON a été généré et sauvegardé à l'emplacement suivant : #{file_path}"


### PR DESCRIPTION
Close https://github.com/gip-inclusion/rdv-insertion/issues/2148
PR coté RDVSP : https://github.com/betagouv/rdv-service-public/pull/4452

J'ai remarqué certaines choses en lançant les scripts sur un dump local anonymisé : 
Le scope `.active` n'est pas suffisant car vérifie uniquement le champ `deleted_at`, or on a des usagers qui n'ont pas de `deleted_at` et qui n'ont pas de `rdv_solidarites_user_id`. Je ne comprend pas bien ce cas. Il faudrait peut être ajouter d'autres scopes pour éclaircir cela.
On a aussi 30 users en production avec un `rdv_solidarites_user_id` mais qui n'ont pas d'organisation (on les skip ligne 13). Ils auraient du être supprimés je pense.

Le script `scripts/export_organisations_rdvsp_ids.rb`m'a servi pour vérifier que toutes les organisations ont bien la verticale `rdv_insertion` dans rdvsp (c'est le cas).

## Utilisation : 

On génére les json avec les scripts de cette PR :

`./scripts/export_organisations_rdvsp_ids.rb`
`./scripts/export_users_rdvsp_ids.rb`

Copier les json générés à la racine du dossier de `rdv-solidarites` et lancer les scripts rdvsp ([dans la PR](https://github.com/betagouv/rdv-service-public/pull/4452)) : 

`./scripts/check_rdvi_organisations_verticales.rb`
`./scripts/check_rdvi_rdvsp_users_organisations.rb`