### PR TITLE
fix(sidekiq): keep agent context upon retries

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,10 +6,10 @@ Sidekiq.configure_server do |config|
   config.logger.level = Logger::INFO
   # when jobs are pushing other jobs to Sidekiq they are acting as clients, so we need to add the middleware here
   config.client_middleware do |chain|
-    chain.add Sidekiq::Middleware::CaptureCurrentAgent
+    chain.prepend Sidekiq::Middleware::CaptureCurrentAgent
   end
   config.server_middleware do |chain|
-    chain.add Sidekiq::Middleware::SetCurrentAgent
+    chain.prepend Sidekiq::Middleware::SetCurrentAgent
   end
 
   Rails.logger = Sidekiq.logger
@@ -23,6 +23,6 @@ Sidekiq.strict_args!(false)
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV["REDIS_URL"] || "redis://localhost:6379/0" }
   config.client_middleware do |chain|
-    chain.add Sidekiq::Middleware::CaptureCurrentAgent
+    chain.prepend Sidekiq::Middleware::CaptureCurrentAgent
   end
 end

--- a/config/middlewares/sidekiq/capture_current_agent.rb
+++ b/config/middlewares/sidekiq/capture_current_agent.rb
@@ -3,7 +3,7 @@ module Sidekiq
     class CaptureCurrentAgent
       def call(_worker_class, job, _queue, _redis_pool)
         # Store the current agent id in the job payload
-        job["current_agent_id"] = Current.agent&.id || job["current_agent_id"]
+        job["current_agent_id"] = Current.agent&.id if job["current_agent_id"].nil?
         yield
       end
     end

--- a/config/middlewares/sidekiq/capture_current_agent.rb
+++ b/config/middlewares/sidekiq/capture_current_agent.rb
@@ -3,7 +3,7 @@ module Sidekiq
     class CaptureCurrentAgent
       def call(_worker_class, job, _queue, _redis_pool)
         # Store the current agent id in the job payload
-        job["current_agent_id"] = Current.agent&.id
+        job["current_agent_id"] = Current.agent&.id || job["current_agent_id"]
         yield
       end
     end


### PR DESCRIPTION
Cette PR permet de conserver le Current.agent même lors d'un retry Sidekiq. Pour cela, je fais en sorte de set et récuperer le Current.agent avant de déclencher les middleware de Sidekiq Retry. 
Lors du lancement du job je fais en sorte de ne pas mettre le job['current_agent_id'] à nil s'il avait déjà une précédente valeur

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2218