### PR TITLE
fix(user): prevent displaying remove org button

### DIFF
--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -28,6 +28,10 @@ class OrganisationPolicy < ApplicationPolicy
       !record.department.number.in?(ENV.fetch("DEPARTMENTS_WHERE_PARCOURS_DISABLED", "").split(","))
   end
 
+  def unassign?
+    access?
+  end
+
   def configure?
     pundit_user.admin_organisations_ids.include?(record.id)
   end

--- a/app/views/users/_user_organisations_list.html.erb
+++ b/app/views/users/_user_organisations_list.html.erb
@@ -14,24 +14,26 @@
             </span>
           <% end %>
         </span>
-        <%
-          if user.organisations.count > 1
-            data = {
-              turbo_confirm: "Retirer l'usager de cette organisation ?",
-              turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer l'usager <b>#{user}</b> de l'organisation <b>#{organisation.name}</b> ?",
-              turbo_confirm_text_action: "- Retirer",
-              turbo_method: :delete,
-            }
-          else
-            data = {
-              turbo_confirm: true,
-              turbo_confirm_template: raw(render("users/user_remove_from_last_organisation_confirm", user: user, organisation: organisation)),
-              turbo_method: :delete,
-            }
-          end
-        %>
-        <%= link_to(structure_users_organisations_path(user.id, users_organisation: { user_id: user.id, organisation_id: organisation.id }), data:, class: 'text-dark-grey-alt ms-2' ) do %>
-          <i class="fas fa-times"></i>
+        <% if policy(organisation).access? %>
+          <%
+            if user.organisations.count > 1
+              data = {
+                turbo_confirm: "Retirer l'usager de cette organisation ?",
+                turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer l'usager <b>#{user}</b> de l'organisation <b>#{organisation.name}</b> ?",
+                turbo_confirm_text_action: "- Retirer",
+                turbo_method: :delete,
+              }
+            else
+              data = {
+                turbo_confirm: true,
+                turbo_confirm_template: raw(render("users/user_remove_from_last_organisation_confirm", user: user, organisation: organisation)),
+                turbo_method: :delete,
+              }
+            end
+          %>
+          <%= link_to(structure_users_organisations_path(user.id, users_organisation: { user_id: user.id, organisation_id: organisation.id }), data:, class: 'text-dark-grey-alt ms-2' ) do %>
+            <i class="fas fa-times"></i>
+          <% end %>
         <% end %>
       </span>
     <% end %>

--- a/app/views/users/_user_organisations_list.html.erb
+++ b/app/views/users/_user_organisations_list.html.erb
@@ -14,7 +14,7 @@
             </span>
           <% end %>
         </span>
-        <% if policy(organisation).access? %>
+        <% if policy(organisation).unassign? %>
           <%
             if user.organisations.count > 1
               data = {


### PR DESCRIPTION
Cette PR permet de ne pas afficher le bouton de suppression d'orga si le current agent n'appartient pas à celle-ci 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2215