### PR TITLE
fix(ui): improve separation of email and inclusion connect

### DIFF
--- a/app/views/sessions/_login_form.html.erb
+++ b/app/views/sessions/_login_form.html.erb
@@ -27,7 +27,11 @@
     <div class=text-center>
       <%= form.submit "Se connecter", class: "btn btn-blue" %>
     </div>
-    <h4 class="text-center my-4 font-weight-bold">OU</h4>
+    <div class="d-flex justify-content-center align-items-center">
+      <hr class="flex-fill">
+      <h4 class="text-center my-4 font-weight-bold px-3">OU</h4>
+      <hr class="flex-fill">
+    </div>
     <%= render 'common/inclusion_connect_button' %>
   <% end %>
 </div>


### PR DESCRIPTION
Cette PR améliore la séparation visuelle entre les connexions email / mdp et inclusion connect

<img width="446" alt="image" src="https://github.com/user-attachments/assets/2832d138-2407-4b68-acf3-336465dd5163">

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2213