### PR TITLE
fix(participation): prevent crash when calling delegated property

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -33,8 +33,7 @@ class Participation < ApplicationRecord
            to: :rdv
   delegate :department, :department_id, to: :organisation
   delegate :phone_number_is_mobile?, :email?, to: :user
-  delegate :orientation?, to: :follow_up
-  delegate :motif_category, to: :follow_up, allow_nil: true
+  delegate :motif_category, :orientation?, to: :follow_up
 
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -33,7 +33,8 @@ class Participation < ApplicationRecord
            to: :rdv
   delegate :department, :department_id, to: :organisation
   delegate :phone_number_is_mobile?, :email?, to: :user
-  delegate :motif_category, :orientation?, to: :follow_up
+  delegate :orientation?, to: :follow_up
+  delegate :motif_category, to: :follow_up, allow_nil: true
 
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -24,7 +24,7 @@ class Participation < ApplicationRecord
 
   after_commit :refresh_follow_up_status
   after_commit :notify_user, if: :should_notify_user?, on: [:create, :update]
-  after_commit :notify_external, if: :should_notify_external?, on: [:create, :update, :destroy]
+  after_commit :notify_external, if: :should_notify_external?, on: [:create, :update]
 
   enum created_by: { agent: "agent", user: "user", prescripteur: "prescripteur" }, _prefix: :created_by
 


### PR DESCRIPTION
Cette PR permet d'éviter un crash quand on cherche à appeler motif_category sur un follow_up nil.
Ceci n'explique pas la raison de cette incohérence mais corrige le problème