### PR TITLE
fix(address): Fix parser adress parsed_city method

### DIFF
--- a/app/models/address/parser.rb
+++ b/app/models/address/parser.rb
@@ -21,7 +21,8 @@ module Address
     def parsed_city
       return if split_address_from_post_code.blank?
 
-      split_address_from_post_code[3].strip
+      city = split_address_from_post_code[3].strip
+      city.gsub(/\A[\s,]+/, "") # This removes leading spaces and commas
     end
 
     def parsed_post_code_and_city

--- a/spec/models/address/parser_spec.rb
+++ b/spec/models/address/parser_spec.rb
@@ -46,4 +46,12 @@ describe Address::Parser do
       expect(subject.parsed_city).to eq("Paris Avenue de ségur")
     end
   end
+
+  context "when the post code is followed by commas" do
+    let!(:address) { "20 avenue de ségur, Pyrénées-Atlantiques, 64460, Labatut" }
+
+    it "parses the city accordingly" do
+      expect(subject.parsed_city).to eq("Labatut")
+    end
+  end
 end


### PR DESCRIPTION
Lorsqu'on a une adresse où le code postal est suivi d'une `,`, la méthode `parsed_city` du parser retourne une chaine de caractère qui commence par cette virgule, ce qui cause un problème au moment de l'appel à l'API adresse.