### PR TITLE
fix(api): Call adresse API properly

### DIFF
--- a/app/clients/api_adresse_client.rb
+++ b/app/clients/api_adresse_client.rb
@@ -2,6 +2,8 @@ class ApiAdresseClient
   URL = "https://api-adresse.data.gouv.fr/search/".freeze
 
   def self.get_geocoding(address, **params)
+    # the endpoint accepts only queries starting with an alphanumeric character
+    address = address.gsub(/\A[^\p{Alnum}]+/, "")
     Faraday.get(URL, { q: address }.merge(params), { "Content-Type" => "application/json" })
   end
 end

--- a/app/models/address/parser.rb
+++ b/app/models/address/parser.rb
@@ -21,8 +21,7 @@ module Address
     def parsed_city
       return if split_address_from_post_code.blank?
 
-      city = split_address_from_post_code[3].strip
-      city.gsub(/\A[\s,]+/, "") # This removes leading spaces and commas
+      split_address_from_post_code[3].strip.gsub(/\A[\s,]+/, "")
     end
 
     def parsed_post_code_and_city


### PR DESCRIPTION
L'endpoint de l'API adresse n'accepte pas les queries qui ne commence pas par un caractère alpha numérique. 
Je filtre donc les caractères non alpha numériques avant d'appeler l'API.