### PR TITLE
fix(geocoding): Fix adresse api calls

### DIFF
--- a/app/clients/api_adresse_client.rb
+++ b/app/clients/api_adresse_client.rb
@@ -2,8 +2,6 @@ class ApiAdresseClient
   URL = "https://api-adresse.data.gouv.fr/search/".freeze
 
   def self.get_geocoding(address, **params)
-    # the endpoint accepts only queries starting with an alphanumeric character
-    address = address.gsub(/\A[^\p{Alnum}]+/, "")
     Faraday.get(URL, { q: address }.merge(params), { "Content-Type" => "application/json" })
   end
 end

--- a/app/models/geo_json/feature.rb
+++ b/app/models/geo_json/feature.rb
@@ -61,7 +61,7 @@ class GeoJson::Feature
   end
 
   def matches_post_code?(address:, department_number:)
-    address.include?(post_code) && matches_department?(department_number)
+    post_code.present? && address.include?(post_code) && matches_department?(department_number)
   end
 
   def matches_department?(matching_department_number)

--- a/app/services/retrieve_address_geocoding_params.rb
+++ b/app/services/retrieve_address_geocoding_params.rb
@@ -16,9 +16,11 @@ class RetrieveAddressGeocodingParams < BaseService
 
   def geocoding_params_matching_city
     [@address, parsed_post_code_and_city, parsed_city].find do |query|
+      # the endpoint accepts only queries starting with an alphanumeric character
+      query = query.gsub(/\A[^\p{Alnum}]+/, "")
       next if query.blank?
 
-      response = ApiAdresseClient.get_geocoding(query)
+      response = ApiAdresseClient.get_geocoding(query) # This removes leading non alpha numerical character
       fail!("Impossible d'appeler l'API addresse!\n response body: #{response.body}") unless response.success?
 
       feature_collection = ::GeoJson::FeatureCollection.new(JSON.parse(response.body)["features"])


### PR DESCRIPTION
Je fais un dernier fix sur le traitement des appels à l'API adresse pour:

* Ne pas l'appeler avec des chaines de caractères vides ou commencant par des caractères alphanumériques
* Ne pas faire le check sur le code postal si dans la réponse de l'API on a pas de code postal