### PR TITLE
feat(db): Add organisation id to webhook endpoints

### DIFF
--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,4 +1,5 @@
 class WebhookEndpoint < ApplicationRecord
+  belongs_to :organisation
   has_and_belongs_to_many :organisations
 
   enum signature_type: { hmac: "hmac", jwt: "jwt" }

--- a/db/migrate/20240723171205_add_organisation_reference_to_webhook_endpoints.rb
+++ b/db/migrate/20240723171205_add_organisation_reference_to_webhook_endpoints.rb
@@ -1,0 +1,23 @@
+class AddOrganisationReferenceToWebhookEndpoints < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :webhook_endpoints, :organisation
+    add_column :webhook_endpoints, :old_webhook_endpoint_id, :integer
+
+    WebhookEndpoint.includes(:organisations).find_each do |webhook_endpoint|
+      ## creating new endpoints
+      webhook_endpoint.organisations.each do |organisation|
+        new_webhook_endpoint = webhook_endpoint.dup
+        new_webhook_endpoint.organisation_id = organisation.id
+        new_webhook_endpoint.old_webhook_endpoint_id = webhook_endpoint.id
+        new_webhook_endpoint.save!
+      end
+    end
+  end
+
+  def down
+    WebhookEndpoint.where.not(organisation_id: nil).destroy_all
+
+    remove_reference :webhook_endpoints, :organisation
+    remove_column :webhook_endpoints, :old_webhook_endpoint_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_11_083143) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_171205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -531,6 +531,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_11_083143) do
     t.datetime "updated_at", null: false
     t.string "subscriptions", array: true
     t.string "signature_type", default: "hmac"
+    t.bigint "organisation_id"
+    t.integer "old_webhook_endpoint_id"
+    t.index ["organisation_id"], name: "index_webhook_endpoints_on_organisation_id"
   end
 
   create_table "webhook_receipts", force: :cascade do |t|


### PR DESCRIPTION
Aujourd'hui un `webhook_endpoint` peut être liés à plusieurs organisations via une relation many:many.
L'idée est de changer ce comportement est d'avoir une relation 1:many pour pouvoir lier un `webhook_endpoint` à une seule organisation. 
Il y a plusieurs avantages à cela: 

* On peut lier un `webhook_receipt` à une organisation spécifique
* On peut récupérer l'organisation pour laquelle on envoie le webhook et ajuster les données à envoyer en fonction de cela

Cette PR est la première d'un set de 2 PRs visant à faire cette migration.