### PR TITLE
feat(db): drop webhook endpoint organisations join table

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -25,6 +25,7 @@ class Organisation < ApplicationRecord
   has_many :tag_organisations, dependent: :destroy
   has_many :orientations, dependent: :restrict_with_error
   has_many :csv_exports, as: :structure, dependent: :destroy
+  has_many :webhook_endpoints, dependent: :destroy
 
   has_many :users, through: :users_organisations
   has_many :agents, through: :agent_roles
@@ -33,7 +34,6 @@ class Organisation < ApplicationRecord
   has_many :tags, through: :tag_organisations
 
   has_and_belongs_to_many :invitations, dependent: :nullify
-  has_and_belongs_to_many :webhook_endpoints
 
   delegate :name, :name_with_region, :number, to: :department, prefix: true
 

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,6 +1,5 @@
 class WebhookEndpoint < ApplicationRecord
   belongs_to :organisation
-  has_and_belongs_to_many :organisations
 
   enum signature_type: { hmac: "hmac", jwt: "jwt" }
 end

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,5 +1,7 @@
 class WebhookEndpoint < ApplicationRecord
   belongs_to :organisation
 
+  validates :organisation_id, uniqueness: true
+
   enum signature_type: { hmac: "hmac", jwt: "jwt" }
 end

--- a/db/migrate/20240723232305_drop_webhook_endpoint_organisations_join_table.rb
+++ b/db/migrate/20240723232305_drop_webhook_endpoint_organisations_join_table.rb
@@ -1,0 +1,31 @@
+class DropWebhookEndpointOrganisationsJoinTable < ActiveRecord::Migration[7.1]
+  # rubocop:disable Metrics/AbcSize
+  def change
+    up_only do
+      ## updating existing receipts
+      WebhookEndpoint.where(organisation_id: nil).find_each do |webhook_endpoint|
+        WebhookReceipt.where(webhook_endpoint_id: webhook_endpoint.id).find_each do |webhook_receipt|
+          organisation_id = if webhook_receipt.resource_model == "Rdv"
+                              Rdv.find_by(id: webhook_receipt.resource_id)&.organisation_id
+                            end
+
+          new_webhook_endpoint = if organisation_id
+                                   WebhookEndpoint.find_by(organisation_id:)
+                                 else
+                                   WebhookEndpoint.find_by(old_webhook_endpoint_id: webhook_endpoint.id)
+                                 end
+          webhook_receipt.webhook_endpoint_id = new_webhook_endpoint.id
+          webhook_receipt.save!
+        end
+
+        ## destroying webhook endpoint
+        webhook_endpoint.destroy!
+      end
+    end
+
+    remove_column :webhook_endpoints, :old_webhook_endpoint_id, :integer
+
+    drop_join_table :webhook_endpoints, :organisations
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_23_171205) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_232305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -323,12 +323,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_171205) do
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
   end
 
-  create_table "organisations_webhook_endpoints", id: false, force: :cascade do |t|
-    t.bigint "organisation_id", null: false
-    t.bigint "webhook_endpoint_id", null: false
-    t.index ["organisation_id", "webhook_endpoint_id"], name: "index_webhook_orgas_on_orga_id_and_webhook_id", unique: true
-  end
-
   create_table "orientation_types", force: :cascade do |t|
     t.string "casf_category"
     t.string "name"
@@ -532,7 +526,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_171205) do
     t.string "subscriptions", array: true
     t.string "signature_type", default: "hmac"
     t.bigint "organisation_id"
-    t.integer "old_webhook_endpoint_id"
     t.index ["organisation_id"], name: "index_webhook_endpoints_on_organisation_id"
   end
 


### PR DESCRIPTION
Vient après #2230 .

Ici on enlève la table de jointure entre les `webhook_endpoints` et les `organisations`.