### PR TITLE
feat(csv): use geocoded post code and city for exports

### DIFF
--- a/app/models/concerns/user/address.rb
+++ b/app/models/concerns/user/address.rb
@@ -4,6 +4,7 @@ module User::Address
   included do
     squishes :address
     delegate :parsed_street_address, :parsed_post_code, :parsed_city, :parsed_post_code_and_city, to: :address_parser
+    delegate :post_code, :city, to: :address_geocoding, allow_nil: true, prefix: :geocoded
   end
 
   private

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -42,14 +42,14 @@ module Exporters
       @users =
         if @motif_category
           User.preload(
-            :archives, :organisations, :tags, :referents, :rdvs,
+            :archives, :organisations, :tags, :referents, :rdvs, :address_geocoding,
             participations: [:organisation, :follow_up],
             follow_ups: [:invitations, :motif_category, :notifications, { rdvs: [:motif, :participations, :users] }],
             orientations: [:orientation_type, :organisation]
           ).find(@user_ids)
         else
           User.preload(
-            :invitations, :notifications, :archives, :organisations, :tags, :referents,
+            :invitations, :notifications, :archives, :organisations, :tags, :referents, :address_geocoding,
             follow_ups: [:motif_category, :participations, :rdvs],
             participations: [:organisation, :rdv, { follow_up: :motif_category }],
             rdvs: [:motif, :participations],
@@ -58,7 +58,7 @@ module Exporters
         end
     end
 
-    def headers
+    def headers # rubocop:disable Metrics/AbcSize
       [User.human_attribute_name(:title),
        User.human_attribute_name(:last_name),
        User.human_attribute_name(:first_name),
@@ -67,6 +67,8 @@ module Exporters
        User.human_attribute_name(:france_travail_id),
        User.human_attribute_name(:email),
        User.human_attribute_name(:address),
+       User.human_attribute_name(:post_code),
+       User.human_attribute_name(:city),
        User.human_attribute_name(:phone_number),
        User.human_attribute_name(:birth_date),
        User.human_attribute_name(:created_at),
@@ -107,6 +109,8 @@ module Exporters
        user.france_travail_id,
        user.email,
        user.address,
+       user.geocoded_post_code,
+       user.geocoded_city,
        user.phone_number,
        display_date(user.birth_date),
        display_date(user.created_at),

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -21,9 +21,10 @@ module Exporters
     def preload_associations
       @participations =
         if @motif_category
-          Participation.preload(user: [:tags, :referents, :organisations])
+          Participation.preload(user: [:tags, :referents, :organisations, :address_geocoding])
         else
-          Participation.preload(user: [:tags, :referents, :organisations, :invitations, :notifications])
+          Participation.preload(user: [:tags, :referents, :organisations, :invitations, :notifications,
+                                       :address_geocoding])
         end
 
       @participations = @participations.preload(
@@ -54,6 +55,8 @@ module Exporters
        User.human_attribute_name(:france_travail_id),
        User.human_attribute_name(:email),
        User.human_attribute_name(:address),
+       User.human_attribute_name(:post_code),
+       User.human_attribute_name(:city),
        User.human_attribute_name(:phone_number),
        User.human_attribute_name(:birth_date),
        User.human_attribute_name(:created_at),
@@ -86,6 +89,8 @@ module Exporters
        user.france_travail_id,
        user.email,
        user.address,
+       user.geocoded_post_code,
+       user.geocoded_city,
        user.phone_number,
        display_date(user.birth_date),
        display_date(user.created_at),

--- a/app/services/retrieve_address_geocoding_params.rb
+++ b/app/services/retrieve_address_geocoding_params.rb
@@ -16,9 +16,9 @@ class RetrieveAddressGeocodingParams < BaseService
 
   def geocoding_params_matching_city
     [@address, parsed_post_code_and_city, parsed_city].find do |query|
-      # the endpoint accepts only queries starting with an alphanumeric character
+      # the endpoint accepts only queries starting with an alphanumeric character and less than 3 characters
       query = query&.gsub(/\A[^\p{Alnum}]+/, "")
-      next if query.blank?
+      next if query.blank? || query.length < 3
 
       response = ApiAdresseClient.get_geocoding(query) # This removes leading non alpha numerical character
       fail!("Impossible d'appeler l'API addresse!\n response body: #{response.body}") unless response.success?

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -25,3 +25,5 @@ fr:
         tags: Tags
         rdv_solidarites_user_id: ID de l'usager RDV-Solidarités
         birth_name: Nom de naissance
+        post_code: CP
+        city: Ville

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -25,7 +25,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
       nir: nir,
       france_travail_id: "DDAAZZ",
       email: "jane@doe.com",
-      address: "20 avenue de Ségur 75OO7 Paris",
+      address: "20 avenue de Ségur paris",
       phone_number: "+33610101010",
       birth_date: "20/12/1977",
       rights_opening_date: "18/05/2022",
@@ -35,6 +35,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
       referents: [referent]
     )
   end
+  let!(:address_geocoding) { create(:address_geocoding, user: user1, post_code: "75007", city: "Paris") }
   let(:user2) { create(:user, last_name: "Casubolo", organisations: [organisation]) }
   let(:user3) { create(:user, last_name: "Blanc", organisations: [organisation]) }
 
@@ -93,6 +94,9 @@ describe Exporters::GenerateUsersCsv, type: :service do
         expect(subject.csv).to include("ID interne au département")
         expect(subject.csv).to include("Email")
         expect(subject.csv).to include("Téléphone")
+        expect(subject.csv).to include("Adresse")
+        expect(subject.csv).to include("CP")
+        expect(subject.csv).to include("Ville")
         expect(subject.csv).to include("Date de naissance")
         expect(subject.csv).to include("Date de création")
         expect(subject.csv).to include("Date d'entrée flux")
@@ -145,7 +149,9 @@ describe Exporters::GenerateUsersCsv, type: :service do
           expect(subject.csv).to include("12345") # affiliation_number
           expect(subject.csv).to include("33333") # department_internal_id
           expect(subject.csv).to include("DDAAZZ") # france_travail_id
-          expect(subject.csv).to include("20 avenue de Ségur 75OO7 Paris")
+          expect(subject.csv).to include("20 avenue de Ségur paris")
+          expect(subject.csv).to include("75007")
+          expect(subject.csv).to include("Paris")
           expect(subject.csv).to include("jane@doe.com")
           expect(subject.csv).to include("+33610101010")
           expect(subject.csv).to include("20/12/1977") # birth_date

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -31,7 +31,7 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
       nir: nir,
       france_travail_id: "DDAAZZ",
       email: "jane@doe.com",
-      address: "20 avenue de Ségur 75OO7 Paris",
+      address: "20 avenue de Ségur paris",
       phone_number: "+33610101010",
       birth_date: "20/12/1977",
       rights_opening_date: "18/05/2022",
@@ -41,6 +41,7 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
       referents: [referent]
     )
   end
+  let!(:address_geocoding) { create(:address_geocoding, user: user1, post_code: "75007", city: "Paris") }
   let(:user2) { create(:user, last_name: "Casubolo", organisations: [organisation]) }
   let(:user3) { create(:user, last_name: "Blanc", organisations: [organisation]) }
   let!(:agent) { create(:agent, organisations: [organisation]) }
@@ -134,6 +135,8 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
         expect(csv).to include("ID interne au département")
         expect(csv).to include("Email")
         expect(csv).to include("Téléphone")
+        expect(csv).to include("CP")
+        expect(csv).to include("Ville")
         expect(csv).to include("Date de naissance")
         expect(csv).to include("Date de création")
         expect(csv).to include("Date d'entrée flux")
@@ -168,7 +171,9 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
           expect(csv).to include("12345") # affiliation_number
           expect(csv).to include("33333") # department_internal_id
           expect(csv).to include("DDAAZZ") # france_travail_id
-          expect(csv).to include("20 avenue de Ségur 75OO7 Paris")
+          expect(csv).to include("20 avenue de Ségur paris")
+          expect(csv).to include("75007")
+          expect(csv).to include("Paris")
           expect(csv).to include("jane@doe.com")
           expect(csv).to include("+33610101010")
           expect(csv).to include("20/12/1977") # birth_date


### PR DESCRIPTION
closes #1197 

J'utilise les geocodages nouvellement stockés en base de données pour ajouter un champ `CP` et `Ville` aux exports csv. 

N.B: J'en profite pour ajouter ce commit qui n'est pas directement lié à cette feature mais qui permet d'éviter d'appeler l'api adresse lorsque ce n'est pas possible https://github.com/gip-inclusion/rdv-insertion/commit/a81ecc15eabb8d71f88794f241717938ddf4bc9d