### PR TITLE
fix(user): Improve user creation origin mechanism

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -19,7 +19,8 @@ class UserDashboard < Administrate::BaseDashboard
     created_through: Field::Select.with_options(
       searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }
     ),
-    created_from_structure: Field::BelongsTo,
+    created_from_structure_id: Field::String,
+    created_from_structure_type: Field::String,
     deleted_at: Field::DateTime,
     department_internal_id: Field::String,
     departments: Field::HasMany,
@@ -88,6 +89,9 @@ class UserDashboard < Administrate::BaseDashboard
     :rights_opening_date,
     :organisations,
     :tags,
+    :created_through,
+    :created_from_structure_id,
+    :created_from_structure_type,
     :created_at,
     :updated_at
   ].freeze

--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -496,9 +496,9 @@ export default class User {
       ...(this.currentConfiguration && {
         follow_ups_attributes: [{ motif_category_id: this.currentConfiguration.motif_category_id }],
       }),
-      created_through: "rdv_insertion_upload_page",
-      created_from_structure_type: this.list.isDepartmentLevel ? "Department" : "Organisation",
-      created_from_structure_id: this.list.isDepartmentLevel ? this.department.id : this.currentOrganisation.id,
+      ...(!this.createdAt && { created_through: "rdv_insertion_upload_page" }),
+      ...(!this.createdAt && { created_from_structure_type: this.list.isDepartmentLevel ? "Department" : "Organisation" }),
+      ...(!this.createdAt && { created_from_structure_id: this.list.isDepartmentLevel ? this.department.id : this.currentOrganisation.id }),
     };
   }
 }

--- a/app/models/concerns/user/creation_origin.rb
+++ b/app/models/concerns/user/creation_origin.rb
@@ -13,10 +13,20 @@ module User::CreationOrigin
 
     validates :created_through, :created_from_structure, presence: true, on: :create
 
+    before_update :reset_origin_attributes_if_changed
+
     scope :created_through_rdv_solidarites, -> { where(created_through: "rdv_solidarites_webhook") }
   end
 
   def created_through_rdv_solidarites? = created_through_rdv_solidarites_webhook?
 
   def created_through_rdv_insertion? = !created_through_rdv_solidarites?
+
+  private
+
+  def reset_origin_attributes_if_changed
+    [:created_through, :created_from_structure_id, :created_from_structure_type].each do |attribute_name|
+      public_send("#{attribute_name}=", attribute_was(attribute_name)) if attribute_changed?(attribute_name)
+    end
+  end
 end

--- a/app/models/concerns/user/creation_origin.rb
+++ b/app/models/concerns/user/creation_origin.rb
@@ -1,6 +1,8 @@
 module User::CreationOrigin
   extend ActiveSupport::Concern
 
+  ORIGIN_ATTRIBUTES = [:created_through, :created_from_structure_type, :created_from_structure_id].freeze
+
   included do
     enum created_through: {
       rdv_insertion_upload_page: "rdv_insertion_upload_page",
@@ -13,7 +15,8 @@ module User::CreationOrigin
 
     validates :created_through, :created_from_structure, presence: true, on: :create
 
-    before_update :reset_origin_attributes_if_changed
+    # prevent these attributes from being updated
+    attr_readonly(*ORIGIN_ATTRIBUTES)
 
     scope :created_through_rdv_solidarites, -> { where(created_through: "rdv_solidarites_webhook") }
   end
@@ -21,12 +24,4 @@ module User::CreationOrigin
   def created_through_rdv_solidarites? = created_through_rdv_solidarites_webhook?
 
   def created_through_rdv_insertion? = !created_through_rdv_solidarites?
-
-  private
-
-  def reset_origin_attributes_if_changed
-    [:created_through, :created_from_structure_id, :created_from_structure_type].each do |attribute_name|
-      public_send("#{attribute_name}=", attribute_was(attribute_name)) if attribute_changed?(attribute_name)
-    end
-  end
 end

--- a/app/services/users/upsert.rb
+++ b/app/services/users/upsert.rb
@@ -8,6 +8,7 @@ module Users
     def call
       @user = find_or_initialize_user.user
       result.user = @user
+      filter_origin_attributes if @user.persisted?
       @user.assign_attributes(**@user_attributes.compact_blank)
       save_user!
     end
@@ -20,6 +21,10 @@ module Users
         attributes: @user_attributes,
         department_id: @organisation.department_id
       )
+    end
+
+    def filter_origin_attributes
+      @user_attributes.except!(*User::ORIGIN_ATTRIBUTES)
     end
 
     def save_user!

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -12,9 +12,11 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-start flex-wrap">
       <%= f.hidden_field :organisation_ids if !@user.persisted? && department_level? %>
-      <%= f.hidden_field :created_through, value: "rdv_insertion_user_form" %>
-      <%= f.hidden_field :created_from_structure_type, value: current_structure_type.capitalize %>
-      <%= f.hidden_field :created_from_structure_id, value: current_structure_id %>
+      <% unless @user.persisted? %>
+        <%= f.hidden_field :created_through, value: "rdv_insertion_user_form" %>
+        <%= f.hidden_field :created_from_structure_type, value: current_structure_type.capitalize %>
+        <%= f.hidden_field :created_from_structure_id, value: current_structure_id %>
+      <% end %>
       <%= render "common/attribute_input", f:f, attribute: :first_name, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :last_name, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :title, mandatory: true, as: :select, collection: ["monsieur", "madame"] %>

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -27,3 +27,6 @@ fr:
         birth_name: Nom de naissance
         post_code: CP
         city: Ville
+        created_through: Créé via
+        created_from_structure_type: Type de structure depuis lequel il a été créé
+        created_from_structure_id: ID de la structure depuis lequel il a été créé

--- a/spec/features/agent_can_create_user_through_form_spec.rb
+++ b/spec/features/agent_can_create_user_through_form_spec.rb
@@ -171,6 +171,32 @@ describe "Agents can create user through form", :js do
           expect(User.count).to eq(1)
           expect(User.last.email).to eq("bob@kelso.com")
         end
+
+        context "for creation origin attributes" do
+          let!(:user) do
+            create(
+              :user,
+              nir: nir, email: nil, created_at: Time.zone.parse("04/05/2022"),
+              rdv_solidarites_user_id: rdv_solidarites_user_id,
+              created_through: "rdv_insertion_upload_page", created_from_structure: department
+            )
+          end
+
+          it "does not update them" do
+            visit new_organisation_user_path(organisation.id)
+
+            page.fill_in "user_first_name", with: "Bob"
+            page.fill_in "user_last_name", with: "Kelso"
+            page.fill_in "user_email", with: "bob@kelso.com"
+            page.fill_in "user_nir", with: nir
+
+            click_button("Enregistrer")
+            expect(page).to have_content("bob@kelso.com")
+            expect(User.count).to eq(1)
+            expect(User.last.created_through).to eq("rdv_insertion_upload_page")
+            expect(User.last.created_from_structure).to eq(department)
+          end
+        end
       end
 
       context "through department_internal_id" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,17 +195,12 @@ describe User do
     end
 
     context "cannot reassign attribute" do
-      let!(:department) { create(:department) }
-      let!(:user) { create(:user, created_through: "rdv_insertion_user_form", created_from_structure: department) }
+      let!(:user) { create(:user, created_through: "rdv_insertion_user_form") }
 
-      it "does not reassign" do
-        user.created_through = "rdv_insertion_upload_page"
-        user.created_from_structure = create(:organisation)
-
-        user.save!
-
-        expect(user.reload.created_through).to eq("rdv_insertion_user_form")
-        expect(user.reload.created_from_structure).to eq(department)
+      it "raises on reassign" do
+        expect do
+          user.assign_attributes(created_through: "rdv_insertion_upload_page")
+        end.to raise_error(ActiveRecord::ReadonlyAttributeError)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -193,6 +193,21 @@ describe User do
 
       it { expect(user).not_to be_valid }
     end
+
+    context "cannot reassign attribute" do
+      let!(:department) { create(:department) }
+      let!(:user) { create(:user, created_through: "rdv_insertion_user_form", created_from_structure: department) }
+
+      it "does not reassign" do
+        user.created_through = "rdv_insertion_upload_page"
+        user.created_from_structure = create(:organisation)
+
+        user.save!
+
+        expect(user.reload.created_through).to eq("rdv_insertion_user_form")
+        expect(user.reload.created_from_structure).to eq(department)
+      end
+    end
   end
 
   describe "nir validity" do


### PR DESCRIPTION
Cette PR fait suite à #2192  et répond à 2 problèmes: 

* Elle empêche les attributs d'origine de pouvoir être modifiés une fois que l'usager est persisté. En effet, vu qu'on fait des upsert d'usagers sur l'application, il est possible que ces attributs soient assignés à un usager persisté. Je fais en sorte ue ce soit impossible dans (https://github.com/gip-inclusion/rdv-insertion/commit/010775bc285310f3094db1aa2b5a3f0cefa9235d)
* J'affiche cette info dans le super admin dans https://github.com/gip-inclusion/rdv-insertion/commit/8f97ef02b6f24dca5dd4b3ef50f6bfda6f5ced8c