### PR TITLE
fix(sidekiq): make sure a maximum of 2 stats jobs run in parallel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem "sidekiq"
 # Job scheduling
 gem "sidekiq-cron"
 
+# Advance queue management
+gem 'sidekiq-limit_fetch'
+
 # Hotwire
 gem "turbo-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "sidekiq"
 gem "sidekiq-cron"
 
 # Advance queue management
-gem 'sidekiq-limit_fetch'
+gem "sidekiq-limit_fetch"
 
 # Hotwire
 gem "turbo-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,8 @@ GEM
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)
+    sidekiq-limit_fetch (4.4.1)
+      sidekiq (>= 6)
     skylight (5.3.4)
       activesupport (>= 5.2.0)
     spring (3.0.0)
@@ -579,6 +581,7 @@ DEPENDENCIES
   sib-api-v3-sdk
   sidekiq
   sidekiq-cron
+  sidekiq-limit_fetch
   skylight
   spring (~> 3.0.0)
   turbo-rails

--- a/app/jobs/stats/global_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stat_job.rb
@@ -1,7 +1,7 @@
 module Stats
   module GlobalStats
     class UpsertStatJob < ApplicationJob
-      sidekiq_options retry: 3
+      sidekiq_options queue: :stats, retry: 3
 
       def perform(structure_type, structure_id, stat_name)
         Timeout.timeout(30.minutes) do

--- a/app/jobs/stats/global_stats/upsert_stats_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stats_job.rb
@@ -1,6 +1,8 @@
 module Stats
   module GlobalStats
     class UpsertStatsJob < ApplicationJob
+      sidekiq_options queue: :stats
+
       def perform
         upsert_stat("Department", nil)
 

--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -1,7 +1,7 @@
 module Stats
   module MonthlyStats
     class ComputeAndSaveSingleStatJob < ApplicationJob
-      sidekiq_options retry: 3
+      sidekiq_options queue: :stats, retry: 3
 
       def perform(stat_id, attribute_name, date)
         Timeout.timeout(20.minutes) do

--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -1,6 +1,8 @@
 module Stats
   module MonthlyStats
     class UpsertStatJob < ApplicationJob
+      sidekiq_options queue: :stats
+
       def perform(structure_type, structure_id, until_date_string)
         @stat = Stat.find_or_initialize_by(statable_type: structure_type, statable_id: structure_id)
         @date = @stat.statable&.created_at || DateTime.parse("01/01/2022")

--- a/app/jobs/stats/monthly_stats/upsert_stats_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stats_job.rb
@@ -1,6 +1,8 @@
 module Stats
   module MonthlyStats
     class UpsertStatsJob < ApplicationJob
+      sidekiq_options queue: :stats
+
       def perform
         Stats::MonthlyStats::UpsertStatJob.perform_async("Department", nil, Time.zone.now)
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+---
+:queues:
+  - default
+  - stats
+
+:limits:
+  stats: 2


### PR DESCRIPTION
Cette PR permet de garantir qu'un maximum de 2 jobs de stats peuvent tourner en parallèle. Ceci dans le but de réduire et étaler le load des stats sur la DB