### PR TITLE
feat(webhooks): Add user to all his orgs when creating it from rdv webhook

### DIFF
--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -2,7 +2,7 @@ module RdvSolidarites
   class User < Base
     RECORD_ATTRIBUTES = [
       :id, :first_name, :last_name, :birth_date, :email, :phone_number,
-      :birth_name, :address, :affiliation_number
+      :birth_name, :address, :affiliation_number, :organisation_ids
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 


### PR DESCRIPTION
⚠️ ne pas merger avant https://github.com/betagouv/rdv-service-public/pull/4495

closes #2244

Je fais en sorte ici d'ajouter les usagers de rdvsp que l'on rappatrie sur rdvi dans toutes les orgas auxquelles ils appartiennent. 
Pour cela il faut d'abord que la PR côté rdvsp qui ajoute le champ `organisation_ids` dans les webhooks pour les `users` soit mergée. 