### PR TITLE
feat(preview): Add optional rdv subscription to previews

### DIFF
--- a/app/controllers/previews/invitations_controller.rb
+++ b/app/controllers/previews/invitations_controller.rb
@@ -83,7 +83,8 @@ module Previews
         mandatory_warning: @invitation.mandatory_warning,
         punishable_warning: @invitation.punishable_warning,
         custom_sentence: @invitation.custom_sentence,
-        signature_lines: @organisation.messages_configuration&.signature_lines
+        signature_lines: @organisation.messages_configuration&.signature_lines,
+        optional_rdv_subscription: @invitation.motif_category.optional_rdv_subscription?
       }
     end
 


### PR DESCRIPTION
closes #2209 
La phrase "dans les 3 jours" continuait de s'afficher dans les previews même après #2153 .
C'est parce que dans les previews il faut passer explicitement les variable d'instance instanciées dans le mailer, et on ne l'avait pas fait pour le nouvel attribut `optional_rdv_subscription`.