### PR TITLE
feat(notifications_tierces): improved ui for 3rd party notifs

### DIFF
--- a/app/views/category_configurations/show.html.erb
+++ b/app/views/category_configurations/show.html.erb
@@ -28,20 +28,13 @@
   </div>
 
   <h3>Notifications tierces</h3>
-  <p>
-  <% if @category_configuration.notify_no_available_slots? %>
-    L'email suivant est notifié en cas d'absence de créneaux disponibles : <%= @category_configuration.email_to_notify_no_available_slots %><br />
-  <% end %>
-  <% if @category_configuration.notify_rdv_changes? %>
-    L'email suivant est notifié en cas de création, modification, ou annulation de rendez-vous : <%= @category_configuration.email_to_notify_rdv_changes %>
-  <% end %>
-  <% if !@category_configuration.notify_no_available_slots? && !@category_configuration.notify_rdv_changes? %>
-    Aucune notification tierce n'est configurée.
-  <% end %>
-  </p>
+  <ul class="mt-3">
+    <li class="mb-2">Notifier sur toutes les prises de rendez-vous ayant lieu pour cette catégorie de motifs : <%= @category_configuration.email_to_notify_rdv_changes.presence || "aucune adresse email de renseignée" %></li>
+    <li>Notifier en cas de créneaux indisponibles sur les motifs de cette catégorie : <%= @category_configuration.email_to_notify_no_available_slots.presence || "aucune adresse email de renseignée" %></li>
+  </ul>
 
   <h3>Invitations périodiques</h3>
-  <p>
+  <p class="mt-3">
     <% if @category_configuration.periodic_invites_activated? %>
       Les invitations périodiques sont actives et sont envoyées
         <% if @category_configuration.number_of_days_between_periodic_invites.present? %>

--- a/spec/features/agent_can_edit_external_notifications_spec.rb
+++ b/spec/features/agent_can_edit_external_notifications_spec.rb
@@ -23,7 +23,7 @@ describe "Agents can edit organisation", :js do
 
       click_button "Enregistrer"
 
-      expect(page).to have_content("L'email suivant est notifié")
+      expect(page).to have_content("Notifier sur toutes les prises")
       expect(page).to have_content("test@test.com")
       expect(page).to have_content("test1@test.com")
     end


### PR DESCRIPTION
Cette PR améliore l'ui de la show des notifications tierces
<img width="902" alt="image" src="https://github.com/user-attachments/assets/8e6e67b3-fead-4dd5-9d85-b76e62b22fa2">

Fix: https://github.com/gip-inclusion/rdv-insertion/issues/2237