### PR TITLE
feat(org): allow linking org without being agent

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,7 +8,6 @@ class Organisation < ApplicationRecord
   before_create { build_messages_configuration }
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
-  validates :name, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
   validate :validate_organisation_phone_number
 

--- a/spec/services/organisations/create_spec.rb
+++ b/spec/services/organisations/create_spec.rb
@@ -38,17 +38,6 @@ describe Organisations::Create, type: :service do
       is_a_success
     end
 
-    it "tries to retrieve an organisation from rdvs" do
-      expect(RdvSolidaritesApi::RetrieveOrganisation).to receive(:call)
-      subject
-    end
-
-    it "assigns attributes to the organisation" do
-      subject
-      expect(organisation.reload.name).to eq("Nouvelle org")
-      expect(organisation.reload.phone_number).to eq("0102030405")
-    end
-
     it "saves the organisation in db" do
       subject
       expect(Organisation.count).to eq(organisation_count_before + 1)
@@ -68,21 +57,6 @@ describe Organisations::Create, type: :service do
 
     it "calls the create webhook endpoint service" do
       expect(RdvSolidaritesApi::CreateWebhookEndpoint).to receive(:call)
-      subject
-    end
-
-    it "calls the update webhook endpoint service (for verticale attribute)" do
-      expect(RdvSolidaritesApi::UpdateOrganisation).to receive(:call).with(
-        hash_including(
-          {
-            organisation_attributes: hash_including(
-              {
-                "verticale" => "rdv_insertion"
-              }
-            )
-          }
-        )
-      )
       subject
     end
 
@@ -116,25 +90,6 @@ describe Organisations::Create, type: :service do
           .and_return(false)
         allow(organisation).to receive_message_chain(:errors, :full_messages, :to_sentence)
           .and_return("some error")
-      end
-
-      it "is a failure" do
-        is_a_failure
-      end
-
-      it "stores the error" do
-        expect(subject.errors).to eq(["some error"])
-      end
-
-      it "does not call the TriggerRdvSolidaritesWebhooksJob" do
-        expect(TriggerRdvSolidaritesWebhooksJob).not_to receive(:perform_async)
-      end
-    end
-
-    context "when the rdv solidarites organisation update fails" do
-      before do
-        allow(RdvSolidaritesApi::RetrieveOrganisation).to receive(:call)
-          .and_return(OpenStruct.new(errors: ["some error"], success?: false))
       end
 
       it "is a failure" do


### PR DESCRIPTION
Cette PR permet de linker une orga RDVSP et RDVI sans avoir besoin d'être agent côté Rdvsp. 

Cela rajoute quand même quelques contraintes : 
- les infos de l'org (name, etc) ne sont remplies qu'à réception du webhook
- la verticale n'est pas mise à jour côté rdvsp

fix https://github.com/gip-inclusion/rdv-insertion/issues/2149