### PR TITLE
feat(convocations): ensure convocations have a phone number

### DIFF
--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -7,7 +7,7 @@ class CategoryConfiguration < ApplicationRecord
 
   validates :organisation, uniqueness: { scope: :motif_category,
                                          message: "a déjà une category_configuration pour cette catégorie de motif" }
-  validate :delays_validity, :invitation_formats_validity
+  validate :delays_validity, :invitation_formats_validity, :phone_number_presence
 
   validates :email_to_notify_no_available_slots, :email_to_notify_rdv_changes,
             format: {
@@ -54,5 +54,12 @@ class CategoryConfiguration < ApplicationRecord
 
       errors.add(:base, "Les formats d'invitation ne peuvent être que : sms, email, postal")
     end
+  end
+
+  def phone_number_presence
+    return if phone_number.present? || organisation.phone_number.present?
+
+    errors.add(:base, "Vous devez renseigner un numéro de téléphone soit dans la configuration de la catégorie, " \
+                      "soit dans la configuration de l'organisation")
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -72,7 +72,7 @@ class Rdv < ApplicationRecord
   def phone_number
     return lieu.phone_number if lieu&.phone_number.present?
 
-    organisation.phone_number
+    current_category_configuration.phone_number
   end
 
   def motif_category

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -72,7 +72,7 @@ class Rdv < ApplicationRecord
   def phone_number
     return lieu.phone_number if lieu&.phone_number.present?
 
-    current_category_configuration.phone_number
+    current_category_configuration&.phone_number
   end
 
   def motif_category

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -72,7 +72,7 @@ class Rdv < ApplicationRecord
   def phone_number
     return lieu.phone_number if lieu&.phone_number.present?
 
-    current_category_configuration&.phone_number
+    current_category_configuration&.phone_number || organisation.phone_number
   end
 
   def motif_category

--- a/spec/models/category_configuration_spec.rb
+++ b/spec/models/category_configuration_spec.rb
@@ -1,4 +1,37 @@
 describe CategoryConfiguration do
+  describe "phone number validation" do
+    context "organisation phone number is blank" do
+      let(:category_configuration) do
+        build(:category_configuration, phone_number: nil, convene_user: true,
+                                       organisation: create(:organisation, phone_number: nil))
+      end
+
+      it "adds errors" do
+        expect(category_configuration).not_to be_valid
+        expect(category_configuration.errors.full_messages.to_sentence)
+          .to include("téléphone")
+      end
+    end
+
+    context "organisation has a phone number" do
+      let(:category_configuration) do
+        build(:category_configuration, phone_number: nil, convene_user: true,
+                                       organisation: create(:organisation, phone_number: "0123456789"))
+      end
+
+      it { expect(category_configuration).to be_valid }
+    end
+
+    context "category configuration has a phone number" do
+      let(:category_configuration) do
+        build(:category_configuration, phone_number: "0123456789", convene_user: true,
+                                       organisation: create(:organisation, phone_number: nil))
+      end
+
+      it { expect(category_configuration).to be_valid }
+    end
+  end
+
   describe "delays validation" do
     context "number_of_days_before_action_required is superior to 3" do
       let(:category_configuration) do


### PR DESCRIPTION
Cette PR permet de s'assurer que les convocations aient toujours un numéro de téléphone disponible. Elle permet également de faire en sorte que celui-ci soit réellement utilisé lorsqu'il est renseigné au niveau de la catégorie. 
Ce qui bizarrement 🤔 n'est pas le cas aujourd'hui ?

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2260