### PR TITLE
refactor(notifications): Destroy notifications with participations

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -6,7 +6,7 @@ class Notification < ApplicationRecord
 
   attr_accessor :content
 
-  belongs_to :participation, optional: true
+  belongs_to :participation
 
   enum event: {
     participation_created: "participation_created",
@@ -18,8 +18,9 @@ class Notification < ApplicationRecord
 
   validates :format, :event, :rdv_solidarites_rdv_id, presence: true
 
-  delegate :department, :user, :rdv, :motif_category, :instruction_for_rdv, :follow_up, to: :participation
-  delegate :organisation, to: :rdv, allow_nil: true
+  delegate :department, :user, :rdv, :motif_category, :instruction_for_rdv, :follow_up,
+           to: :participation
+  delegate :organisation, to: :rdv
   delegate :messages_configuration, :category_configurations, to: :organisation
 
   def send_to_user

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -12,7 +12,7 @@ class Participation < ApplicationRecord
              foreign_key: "rdv_solidarites_agent_prescripteur_id",
              optional: true
 
-  has_many :notifications, dependent: :nullify
+  has_many :notifications, dependent: :destroy
   has_many :follow_up_invitations, through: :follow_up, source: :invitations
 
   has_one :organisation, through: :rdv


### PR DESCRIPTION
Closes #2222 

Jusqu'à présent on ne supprimait pas les notifications liés à un rdv lorsque ce rdv est supprimé.
Cela est dû il me semble à l'implémentation initiale où une notification était envoyée lorsque le rdv était supprimé (ce n'est plus le cas aujourd'hui comme ce ne l'est pas sur rdvsp).
Il n'y a pas grand intérêt à garder cette donnée si elle ne peut pas être liée à une participation (et donc à un usager), je décide donc de supprimer les notifications sans participations et ainsi éviter les erreurs comme [celle-ci](https://sentry.incubateur.net/organizations/betagouv/issues/112149/?environment=production&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=6)