### PR TITLE
fix(notifications): prevent sending notifs when empty sender phone number

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ INCLUSION_CONNECT_CLIENT_SECRET=password
 # Mattermost
 MATTERMOST_NOTIFICATIONS_CHANNEL_URL=mattermost_notif_channel_url
 MATTERMOST_MAIN_CHANNEL_URL=mattermost_main_channel_url
+MATTERMOST_PRIVATE_CHANNEL_URL=mattermost_private_channel_url
 # Carnet de bord
 CARNET_DE_BORD_URL=https://demo.carnetdebord.inclusion.beta.gouv.fr
 CARNET_DE_BORD_API_SECRET=secret_api_token

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -8,6 +8,10 @@ class MattermostClient
       send_message(ENV["MATTERMOST_MAIN_CHANNEL_URL"], text)
     end
 
+    def send_to_private_channel(text)
+      send_message(ENV["MATTERMOST_PRIVATE_CHANNEL_URL"], text)
+    end
+
     private
 
     def send_message(url, text)

--- a/app/services/concerns/messengers/send_sms.rb
+++ b/app/services/concerns/messengers/send_sms.rb
@@ -10,6 +10,12 @@ module Messengers::SendSms
     fail!("Le numéro de téléphone doit être un mobile") unless sendable.phone_number_is_mobile?
   end
 
+  def verify_sender_phone_number!(sender_phone_number)
+    return if sender_phone_number.present?
+
+    fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
+  end
+
   def send_sms(sms_sender_name, phone_number, content, record_identifier)
     return Rails.logger.info(content) if Rails.env.development?
 

--- a/app/services/concerns/messengers/send_sms.rb
+++ b/app/services/concerns/messengers/send_sms.rb
@@ -10,12 +10,6 @@ module Messengers::SendSms
     fail!("Le numéro de téléphone doit être un mobile") unless sendable.phone_number_is_mobile?
   end
 
-  def verify_sender_phone_number!(sender_phone_number)
-    return if sender_phone_number.present?
-
-    fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
-  end
-
   def send_sms(sms_sender_name, phone_number, content, record_identifier)
     return Rails.logger.info(content) if Rails.env.development?
 

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -1,9 +1,14 @@
 module Notifications
   module SenderPhoneNumberValidation
-    def verify_sender_phone_number!(sender_phone_number)
-      return if sender_phone_number.present?
+    def verify_sender_phone_number!(notification)
+      return if notification.rdv.phone_number.present?
 
       fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
+      MattermostClient.send_to_main_channel(
+        "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
+        "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
+        " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
+      )
     end
   end
 end

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -4,7 +4,7 @@ module Notifications
       return if notification.rdv.phone_number.present?
 
       fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
-      MattermostClient.send_to_main_channel(
+      MattermostClient.send_to_private_channel(
         "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
         "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
         " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -1,0 +1,9 @@
+module Notifications
+  module SenderPhoneNumberValidation
+    def verify_sender_phone_number!(sender_phone_number)
+      return if sender_phone_number.present?
+
+      fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
+    end
+  end
+end

--- a/app/services/notifications/send_email.rb
+++ b/app/services/notifications/send_email.rb
@@ -11,7 +11,7 @@ module Notifications
 
     def call
       verify_format!(@notification)
-      verify_sender_phone_number!(@notification.rdv.phone_number)
+      verify_sender_phone_number!(@notification)
       verify_email!(@notification)
 
       NotificationMailer.with(

--- a/app/services/notifications/send_email.rb
+++ b/app/services/notifications/send_email.rb
@@ -3,6 +3,7 @@ class EmailNotificationError < StandardError; end
 module Notifications
   class SendEmail < BaseService
     include Messengers::SendEmail
+    include Notifications::SenderPhoneNumberValidation
 
     def initialize(notification:)
       @notification = notification
@@ -10,6 +11,7 @@ module Notifications
 
     def call
       verify_format!(@notification)
+      verify_sender_phone_number!(@notification.rdv.phone_number)
       verify_email!(@notification)
 
       NotificationMailer.with(

--- a/app/services/notifications/send_sms.rb
+++ b/app/services/notifications/send_sms.rb
@@ -15,7 +15,7 @@ module Notifications
     def call
       verify_format!(notification)
       verify_phone_number!(notification)
-      verify_sender_phone_number!(phone_number)
+      verify_sender_phone_number!(notification)
       send_sms(notification.sms_sender_name, notification.phone_number, content, notification.record_identifier)
     end
 

--- a/app/services/notifications/send_sms.rb
+++ b/app/services/notifications/send_sms.rb
@@ -3,6 +3,7 @@ class SmsNotificationError < StandardError; end
 module Notifications
   class SendSms < BaseService
     include Notifications::SmsContent
+    include Notifications::SenderPhoneNumberValidation
     include Messengers::SendSms
 
     attr_reader :notification

--- a/app/services/notifications/send_sms.rb
+++ b/app/services/notifications/send_sms.rb
@@ -14,6 +14,7 @@ module Notifications
     def call
       verify_format!(notification)
       verify_phone_number!(notification)
+      verify_sender_phone_number!(phone_number)
       send_sms(notification.sms_sender_name, notification.phone_number, content, notification.record_identifier)
     end
 

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -26,7 +26,7 @@ describe Notifications::SendEmail, type: :service do
         :rdv,
         motif:,
         lieu:,
-        organisation:,
+        organisation:
       )
     end
     let!(:lieu) do

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -20,11 +20,17 @@ describe Notifications::SendEmail, type: :service do
     end
 
     let!(:user) { create(:user) }
+    let!(:organisation) { create(:organisation) }
     let!(:rdv) do
       create(
         :rdv,
-        motif: motif
+        motif:,
+        lieu:,
+        organisation:,
       )
+    end
+    let!(:lieu) do
+      create(:lieu, name: "DINUM", address: "20 avenue de Ségur 75007 Paris", phone_number: "0101010101")
     end
     let!(:motif) { create(:motif, location_type: "public_office") }
     let!(:participation) do
@@ -137,6 +143,22 @@ describe Notifications::SendEmail, type: :service do
 
       it "returns an error" do
         expect(subject.errors).to eq(["Envoi d'un email alors que le format est sms"])
+      end
+    end
+
+    context "when the structure phone number is empty" do
+      let!(:lieu) do
+        create(:lieu, name: "DINUM", address: "20 avenue de Ségur 75007 Paris", phone_number: "")
+      end
+
+      let!(:organisation) { create(:organisation, phone_number: nil) }
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error" do
+        expect(subject.errors).to eq(
+          ["Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné"]
+        )
       end
     end
 

--- a/spec/services/notifications/send_sms_spec.rb
+++ b/spec/services/notifications/send_sms_spec.rb
@@ -78,6 +78,22 @@ describe Notifications::SendSms, type: :service do
       end
     end
 
+    context "when the structure phone number is empty" do
+      let!(:lieu) do
+        create(:lieu, name: "DINUM", address: "20 avenue de Ségur 75007 Paris", phone_number: "")
+      end
+
+      let!(:organisation) { create(:organisation, phone_number: nil) }
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error" do
+        expect(subject.errors).to eq(
+          ["Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné"]
+        )
+      end
+    end
+
     context "when the phone number is not a mobile" do
       let!(:phone_number) { "0142249062" }
 


### PR DESCRIPTION
Cette PR permet de bloquer l'envoi de SMS et de mails de notifications lorsqu'un numéro de téléphone n'est pas renseigné et nous en informe sur Mattermost

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2260