### PR TITLE
fix(stats): prevent showing empty start numbers

### DIFF
--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -14,7 +14,7 @@ module Stats
             initial_value = stat.send(attribute_name) || {}
             sorted_values = initial_value.merge({ date.strftime("%m/%Y") => result })
                                          .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
-                                         .drop_while { |_, v| v.zero? }
+                                         .drop_while { |d, v| d.ends_with?("2022") && v.zero? }
                                          .to_h
 
             stat.update!(attribute_name => sorted_values)

--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -12,14 +12,18 @@ module Stats
           Stat.transaction do
             stat.reload(lock: true)
             initial_value = stat.send(attribute_name) || {}
-            sorted_values = initial_value.merge({ date.strftime("%m/%Y") => result })
-                                         .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
-                                         .drop_while { |d, v| d.ends_with?("2022") && v.zero? }
-                                         .to_h
-
-            stat.update!(attribute_name => sorted_values)
+            stat.update!(attribute_name => new_values_with_result(initial_value, result))
           end
         end
+      end
+
+      private
+
+      def new_values_with_result(initial_value, result)
+        initial_value.merge({ date.strftime("%m/%Y") => result })
+                     .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
+                     .drop_while { |d, v| d.ends_with?("2022") && v.zero? }
+                     .to_h
       end
     end
   end

--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -12,14 +12,14 @@ module Stats
           Stat.transaction do
             stat.reload(lock: true)
             initial_value = stat.send(attribute_name) || {}
-            stat.update!(attribute_name => new_values_with_result(initial_value, result))
+            stat.update!(attribute_name => new_values_with_result(date, initial_value, result))
           end
         end
       end
 
       private
 
-      def new_values_with_result(initial_value, result)
+      def new_values_with_result(date, initial_value, result)
         initial_value.merge({ date.strftime("%m/%Y") => result })
                      .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
                      .drop_while { |d, v| d.ends_with?("2022") && v.zero? }

--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -22,7 +22,6 @@ module Stats
       def new_values_with_result(date, initial_value, result)
         initial_value.merge({ date.strftime("%m/%Y") => result })
                      .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
-                     .drop_while { |d, v| d.ends_with?("2022") && v.zero? }
                      .to_h
       end
     end

--- a/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/compute_and_save_single_stat_job.rb
@@ -8,21 +8,8 @@ module Stats
           date = date.to_datetime
           stat = Stat.find(stat_id)
           result = Stats::MonthlyStats::ComputeForFocusedMonth.new(stat:, date:).send(attribute_name)
-
-          Stat.transaction do
-            stat.reload(lock: true)
-            initial_value = stat.send(attribute_name) || {}
-            stat.update!(attribute_name => new_values_with_result(date, initial_value, result))
-          end
+          stat.insert_month_result!(attribute_name, date, result)
         end
-      end
-
-      private
-
-      def new_values_with_result(date, initial_value, result)
-        initial_value.merge({ date.strftime("%m/%Y") => result })
-                     .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
-                     .to_h
       end
     end
   end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -126,14 +126,14 @@ class Stat < ApplicationRecord
             .distinct
   end
 
-  def insert_month_result!(attribute_name, date, values)
+  def insert_month_result!(attribute_name, date, result)
     raise "Invalid attribute name" unless MONTHLY_STAT_ATTRIBUTES.include?(attribute_name)
 
     Stat.transaction do
       reload(lock: true)
 
       new_value = (send(attribute_name) || {})
-                  .merge({ date.strftime("%m/%Y") => values })
+                  .merge({ date.strftime("%m/%Y") => result })
                   .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
                   .to_h
 

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -125,4 +125,18 @@ class Stat < ApplicationRecord
             .preload(participations: :rdv)
             .distinct
   end
+
+  def insert_month_result!(attribute_name, date, values)
+    Stat.transaction do
+      reload(lock: true)
+      raise "Invalid attribute name" unless MONTHLY_STAT_ATTRIBUTES.include?(attribute_name)
+
+      new_value = (send(attribute_name) || {})
+                  .merge({ date.strftime("%m/%Y") => values })
+                  .sort_by { |d, _v| Date.strptime(d, "%m/%Y") }
+                  .to_h
+
+      update!(attribute_name => new_value)
+    end
+  end
 end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -127,9 +127,10 @@ class Stat < ApplicationRecord
   end
 
   def insert_month_result!(attribute_name, date, values)
+    raise "Invalid attribute name" unless MONTHLY_STAT_ATTRIBUTES.include?(attribute_name)
+
     Stat.transaction do
       reload(lock: true)
-      raise "Invalid attribute name" unless MONTHLY_STAT_ATTRIBUTES.include?(attribute_name)
 
       new_value = (send(attribute_name) || {})
                   .merge({ date.strftime("%m/%Y") => values })

--- a/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
@@ -23,5 +23,29 @@ describe Stats::MonthlyStats::ComputeAndSaveSingleStatJob, type: :service do
     it "computes and saves the single stat" do
       expect { subject }.to change { stat.reload[method] }.from({}).to({ "05/2022" => 5 })
     end
+
+    context "over mutliple months" do
+      it "computes and saves the single stat for each month" do
+        allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
+          .and_return(OpenStruct.new({ users_count_grouped_by_month: 0 }))
+        described_class.new.perform(stat.id, method, "2022-05-01 12:00:00 +0100")
+
+        allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
+          .and_return(OpenStruct.new({ users_count_grouped_by_month: 0 }))
+        described_class.new.perform(stat.id, method, "2022-06-01 12:00:00 +0100")
+
+        allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
+          .and_return(OpenStruct.new({ users_count_grouped_by_month: 4 }))
+        described_class.new.perform(stat.id, method, "2022-07-01 12:00:00 +0100")
+        described_class.new.perform(stat.id, method, "2022-08-01 12:00:00 +0100")
+
+        expect(stat.reload[method]).to eq(
+          {
+            "07/2022" => 4,
+            "08/2022" => 4
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
@@ -29,14 +29,14 @@ describe Stats::MonthlyStats::ComputeAndSaveSingleStatJob, type: :service do
         allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
           .and_return(OpenStruct.new({ users_count_grouped_by_month: 0 }))
 
-        described_class.new.perform(stat.id, method, "2022-05-01 12:00:00 +0100")
         described_class.new.perform(stat.id, method, "2022-06-01 12:00:00 +0100")
+        described_class.new.perform(stat.id, method, "2022-05-01 12:00:00 +0100")
 
         allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
           .and_return(OpenStruct.new({ users_count_grouped_by_month: 4 }))
 
-        described_class.new.perform(stat.id, method, "2022-07-01 12:00:00 +0100")
         described_class.new.perform(stat.id, method, "2022-08-01 12:00:00 +0100")
+        described_class.new.perform(stat.id, method, "2022-07-01 12:00:00 +0100")
 
         expect(stat.reload[method]).to eq(
           {

--- a/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
@@ -40,6 +40,8 @@ describe Stats::MonthlyStats::ComputeAndSaveSingleStatJob, type: :service do
 
         expect(stat.reload[method]).to eq(
           {
+            "05/2022" => 0,
+            "06/2022" => 0,
             "07/2022" => 4,
             "08/2022" => 4
           }

--- a/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/compute_and_save_single_stat_job_spec.rb
@@ -28,14 +28,13 @@ describe Stats::MonthlyStats::ComputeAndSaveSingleStatJob, type: :service do
       it "computes and saves the single stat for each month" do
         allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
           .and_return(OpenStruct.new({ users_count_grouped_by_month: 0 }))
-        described_class.new.perform(stat.id, method, "2022-05-01 12:00:00 +0100")
 
-        allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
-          .and_return(OpenStruct.new({ users_count_grouped_by_month: 0 }))
+        described_class.new.perform(stat.id, method, "2022-05-01 12:00:00 +0100")
         described_class.new.perform(stat.id, method, "2022-06-01 12:00:00 +0100")
 
         allow(Stats::MonthlyStats::ComputeForFocusedMonth).to receive(:new)
           .and_return(OpenStruct.new({ users_count_grouped_by_month: 4 }))
+
         described_class.new.perform(stat.id, method, "2022-07-01 12:00:00 +0100")
         described_class.new.perform(stat.id, method, "2022-08-01 12:00:00 +0100")
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -480,5 +480,22 @@ describe Stat do
         end
       end
     end
+
+    describe "#insert_month_result!" do
+      let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
+      let(:date) { "07/2023".to_date }
+
+      it "inserts the result in the stat record" do
+        stat.insert_month_result!("users_count_grouped_by_month", date, 4)
+        stat.insert_month_result!("users_count_grouped_by_month", date - 1.month, 2)
+        stat.insert_month_result!("users_count_grouped_by_month", date + 1.month, 6)
+
+        expect(stat.users_count_grouped_by_month).to eq({
+                                                          "06/2023" => 2,
+                                                          "07/2023" => 4,
+                                                          "08/2023" => 6
+                                                        })
+      end
+    end
   end
 end


### PR DESCRIPTION
Suite au déploiement du split du calcul en plusieurs jobs ce sont désormais dans n'importe quel ordre que les stats sont mises à jour. Cette PR permet donc de reclasser la hash d'un stat au moment de la sauvegarde et de supprimer les valeurs de départ du hash si elles sont égales à zéro