### PR TITLE
fix(migration): Fix archive migration new attempt

### DIFF
--- a/db/migrate/20240628171109_archive_users_by_organisation_rather_than_by_department.rb
+++ b/db/migrate/20240628171109_archive_users_by_organisation_rather_than_by_department.rb
@@ -16,7 +16,9 @@ class ArchiveUsersByOrganisationRatherThanByDepartment < ActiveRecord::Migration
   # rubocop:disable Metrics/AbcSize
   def migrate_current_archives_to_organisations
     # we do that to avoid the archive created in the loop to be processed by the find_each
-    Archive.find_each do |archive|
+    archive_ids = Archive.pluck(:id)
+    archive_ids.each do |archive_id|
+      archive = Archive.find(archive_id)
       user = archive.user
       department = Department.find(archive.department_id)
       organisations_where_user_should_be_archived = department.organisations & user.organisations


### PR DESCRIPTION
En regardant les extra datas ajoutés dans #2296 il semblerait que [l'on itère à un moment donné sur des archives nouvellement créés](https://sentry.incubateur.net/organizations/betagouv/issues/118225/?project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0).
J'essaie de résoudre le problème ici en preloadant les ids des archives en BDD.