### PR TITLE
fix(tracking): Anonymize data for tracking

### DIFF
--- a/app/javascript/react/components/user/TableRow.jsx
+++ b/app/javascript/react/components/user/TableRow.jsx
@@ -11,7 +11,7 @@ function TableRow({ user }) {
         {user.list.columns.map((column) => {
           if (!column.visible || !column.content) return null
 
-          return <td key={column.name} className={user[`${column.key}Updated`] ? "table-success" : ""} data-matomo-mask>{column.content({ user })}</td>
+          return <td key={column.name} className={user[`${column.key}Updated`] ? "table-success" : ""}>{column.content({ user })}</td>
         })}
 
         {user.currentConfiguration && <InvitationCells user={user} />}

--- a/app/views/layouts/_application_base.html.erb
+++ b/app/views/layouts/_application_base.html.erb
@@ -41,7 +41,7 @@
     <%= content_for :head %>
   </head>
 
-  <body>
+  <body data-matomo-mask>
     <%= render 'common/confirm_modal' %>
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= content_for :header %>

--- a/app/views/users/_page_title.html.erb
+++ b/app/views/users/_page_title.html.erb
@@ -1,1 +1,1 @@
-<% content_for :title, "#{user.last_name.upcase} #{user.first_name} - Fiche usager - #{current_structure.name} - rdv-insertion" %>
+<% content_for :title, "#{user.first_name} #{user.last_name.first.upcase} - Fiche usager - #{current_structure.name} - rdv-insertion" %>


### PR DESCRIPTION
closes #2282 et #2283 

- On ne met pas le nom de l'usager en titre de page (pour qu'il ne soit pas remonté sur Matomo)
- On ajoute l'attribute `data-matomo-mask` pour être sûr de n'envoyer aucune données personnelles lors des recordings