### PR TITLE
bug(ux): fix archiving tooltip not displaying archiving_reason with spaces

### DIFF
--- a/app/helpers/organisations_badges_helper.rb
+++ b/app/helpers/organisations_badges_helper.rb
@@ -9,12 +9,16 @@ module OrganisationsBadgesHelper
   def tooltip_for_organisation_badge(archive)
     return if archive.nil?
 
-    html_escape(
-      "data-controller=tooltip " \
-      "data-action=mouseover->tooltip#organisationArchiveInformations " \
-      "data-archive-creation-date=#{format_date(archive.created_at)} " \
-      "data-archive-reason=#{archive.archiving_reason} " \
-      "data-show-archiving-reason=#{policy(archive).show?}"
-    )
+    attributes = {
+      data: {
+        controller: "tooltip",
+        action: "mouseover->tooltip#organisationArchiveInformations",
+        "archive-creation-date": format_date(archive.created_at),
+        "archive-reason": archive.archiving_reason,
+        "show-archiving-reason": policy(archive).show?
+      }
+    }
+
+    html_escape(tag.attributes(attributes))
   end
 end

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
     tippy(this.element, {
       content(reference) {
         const { archiveCreationDate, archiveReason, showArchivingReason } = reference.dataset;
-        const displayedArchivingReason = showArchivingReason === "true" ? `Motif: ${archiveReason || "Aucun motif renseigné"}` : ""
+        const displayedArchivingReason = showArchivingReason === "true" ? `Motif : ${archiveReason || "Aucun motif renseigné"}` : ""
 
         return (
           `Archivé le ${archiveCreationDate}<br/>${displayedArchivingReason}`


### PR DESCRIPTION
Close : https://github.com/gip-inclusion/rdv-insertion/issues/2269

Avant | Après
:- | -:
<img width="361" alt="Capture d’écran 2024-09-10 à 15 12 11" src="https://github.com/user-attachments/assets/1be42739-84e4-4eca-b666-c5dfa103888e">|<img width="361" alt="Capture d’écran 2024-09-10 à 15 17 57" src="https://github.com/user-attachments/assets/a9bf9299-4d7d-4782-9dd0-fcd7c60bbc99">

Pour info, j'ai préféré ne pas limiter arbitrairement le nombre de caractères concernant la raison de l'archivage.
Le tooltip gère automatiquement le retour à la ligne si le texte est trop long. @samanthaauffret 
Ex : 
<img width="361" alt="Capture d’écran 2024-09-10 à 15 26 29" src="https://github.com/user-attachments/assets/23d5ede5-2452-4c6c-b698-55e0d8ffd86b">
