### PR TITLE
feat(migrations): Add safer migrations mechanism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,9 @@ gem "bootsnap", ">= 1.4.2", require: false
 # APM
 gem "skylight"
 
+# Sets migrations timeouts
+gem "activerecord-safer_migrations"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       activemodel (= 7.1.3.4)
       activesupport (= 7.1.3.4)
       timeout (>= 0.4.0)
+    activerecord-safer_migrations (4.0.0)
+      activerecord (>= 7.0)
     activestorage (7.1.3.4)
       actionpack (= 7.1.3.4)
       activejob (= 7.1.3.4)
@@ -585,6 +587,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-safer_migrations
   addressable
   administrate!
   administrate-field-active_storage

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,6 +1,6 @@
 class OrganisationsController < ApplicationController
   PERMITTED_PARAMS = [
-    :name, :phone_number, :email, :slug, :logo_filename, :rdv_solidarites_organisation_id,
+    :name, :phone_number, :email, :slug, :rdv_solidarites_organisation_id,
     :department_id, :safir_code
   ].freeze
 

--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -27,7 +27,6 @@ class OrganisationDashboard < Administrate::BaseDashboard
     last_webhook_update_received_at: Field::DateTime,
     lieux: Field::HasMany,
     logo: Field::ActiveStorage.with_options(show_preview_variant: false),
-    logo_filename: Field::String,
     messages_configuration: Field::HasOne,
     motif_categories: Field::HasMany,
     motifs: Field::HasMany,

--- a/config/initializers/safe_migration.rb
+++ b/config/initializers/safe_migration.rb
@@ -1,0 +1,2 @@
+ActiveRecord::SaferMigrations.default_lock_timeout = 5000
+ActiveRecord::SaferMigrations.default_statement_timeout = 10_000


### PR DESCRIPTION
L'application a été down quelques minutes ce matin suite au déploiement de commit https://github.com/gip-inclusion/rdv-insertion/commit/904d7117454c31bdb1046b0e8c8e478782b6a3e3. 
Pour une raison que l'on ignore, la migration pourtant simple était bloquée pendant plusieurs minutes. @Michaelvilleneuve a évoqué la piste de la sur-utilisation de notre RAM Postgres.
Dans tous les cas cela a eu pour conséquence de locker notre table `organisations` pendant plusieurs minutes. Et comme cette table est utilisée dans presque toutes les pages, ça a fait que les requêtes se sont  empilées et toute dans l'attente de la release de la table, ce qui a fait que plus aucune connection à la base était disponible.

Pour prévenir que cela se reproduise de nouveau, j'ai ajouté un `lock_timeout` via la gem "activerecord-safer_migrations".

Ainsi, si la migration ne lockera pas la table pas plus de 5 secondes par défaut et évitera que ce problème se reproduise.

Ça n'empêchera quelques requêtes de ne pas aboutir si on gel une table 5 secondes, mais vu le traffic relativement "faible" sur l'appli et le caractères idempotent de la plupart des actions cela me parait acceptable et moins coûteux que d'avoir un process plus lourd.

N.B: j'en profite pour enlever les dernières occurences de `logo_filename` qui n'avait pas été dans le commit précédent dans ce commit https://github.com/gip-inclusion/rdv-insertion/commit/de659286a9c2f1f07358271eddc2727730ec731a