### PR TITLE
feat(organisations): add ability to transfer users from a given org to another

### DIFF
--- a/lib/organisations/transfer_users_from_given_motif_category.rb
+++ b/lib/organisations/transfer_users_from_given_motif_category.rb
@@ -1,0 +1,55 @@
+module Organisations
+  class TransferUsersFromGivenMotifCategory
+    attr_reader :source_organisation, :target_organisation, :motif_category
+
+    def initialize(source_organisation_id:, target_organisation_id:, motif_category_id:)
+      @source_organisation = Organisation.find(source_organisation_id)
+      @target_organisation = Organisation.find(target_organisation_id)
+      @motif_category = MotifCategory.find(motif_category_id)
+    end
+
+    def perform
+      transfer_rdvs
+      remove_users_from_source_organisation
+      add_users_to_target_organisation!
+      remove_old_category_configuration!
+    end
+
+    private
+
+    def transfer_rdvs
+      follow_ups = FollowUp.where(user: users_to_transfer, motif_category:)
+
+      Rdv.joins(:participations).where(
+        participations: { follow_up: follow_ups, user: users_to_transfer },
+      ).update_all(organisation_id: target_organisation.id)
+    end
+
+    def remove_users_from_source_organisation
+      UsersOrganisation.where(
+        user: users_to_transfer,
+        organisation: source_organisation,
+      ).delete_all
+    end
+
+    def add_users_to_target_organisation!
+      users_to_transfer.each do |user|
+        UsersOrganisation.create!(user:, organisation: target_organisation) unless UsersOrganisation.exists?(user:, organisation: target_organisation)
+      end
+    end
+
+    def remove_old_category_configuration!
+      CategoryConfiguration.find_by(organisation: source_organisation, motif_category:).destroy!
+    end
+
+    def users_to_transfer
+      @users_to_transfer ||= User
+            .active
+            .distinct
+            .joins(:follow_ups, :organisations)
+            .where(organisations: source_organisation)
+            .where(follow_ups: { motif_category: })
+            .to_a
+    end
+  end
+end

--- a/lib/tasks/organisations/transfer_users_from_given_motif_category.rb
+++ b/lib/tasks/organisations/transfer_users_from_given_motif_category.rb
@@ -1,0 +1,24 @@
+require Rails.root.join("lib/organisations/transfer_users_from_given_motif_category")
+
+namespace :organisations do
+  desc <<-DESC
+    This task allows to transfer users from a given motif category and a given organisation 
+    to the same motif in another organisation.
+
+    SOURCE_ORGANISATION_ID=29 TARGET_ORGANISATION_ID=483 MOTIF_CATEGORY_ID=37   bundle exec rails organisations:transfer_users_from_given_motif_category
+  DESC
+
+  task transfer_users_from_given_motif_category: :environment do
+    source_organisation_id = ENV['SOURCE_ORGANISATION_ID']
+    target_organisation_id = ENV['TARGET_ORGANISATION_ID']
+    motif_category_id = ENV['MOTIF_CATEGORY_ID']
+
+    Organisations::TransferUsersFromGivenMotifCategory.new(
+      source_organisation_id: source_organisation_id,
+      target_organisation_id: target_organisation_id,
+      motif_category_id: motif_category_id
+    ).perform
+  end
+end
+
+

--- a/spec/lib/organisations/transfer_users_from_given_motif_category_spec.rb
+++ b/spec/lib/organisations/transfer_users_from_given_motif_category_spec.rb
@@ -1,0 +1,46 @@
+require Rails.root.join("lib/organisations/transfer_users_from_given_motif_category")
+
+describe Organisations::TransferUsersFromGivenMotifCategory do
+  describe "#perform" do
+    subject { transfer.perform }
+
+    let(:source_organisation) { create(:organisation) }
+    let(:target_organisation) { create(:organisation) }
+    let(:motif_category) { create(:motif_category) }
+    let(:user) { create(:user) }
+    let(:rdv) { create(:rdv, organisation: source_organisation) }
+    let(:follow_up) { create(:follow_up, user:, motif_category:) }
+    let!(:participation) { create(:participation, rdv:, user:, follow_up:) }
+
+    let!(:source_category_configuration) do
+      create(:category_configuration, organisation: source_organisation, motif_category: motif_category)
+    end
+
+    let!(:target_category_configuration) do
+      create(:category_configuration, organisation: target_organisation, motif_category: motif_category)
+    end
+
+    let(:transfer) do
+      described_class.new(
+        source_organisation_id: source_organisation.id,
+        target_organisation_id: target_organisation.id,
+        motif_category_id: motif_category.id
+      )
+    end
+
+    before do
+      create(:users_organisation, organisation: source_organisation, user:)
+    end
+
+    it "transfers users from source to target organisation" do
+      transfer.perform
+
+      expect(UsersOrganisation.where(user:, organisation: source_organisation)).to be_empty
+      expect(UsersOrganisation.where(user:, organisation: target_organisation)).not_to be_empty
+      expect(rdv.reload.organisation).to eq(target_organisation)
+      expect(CategoryConfiguration.find_by(organisation: source_organisation, motif_category:)).to be_nil
+      expect(target_organisation.users).to include(user)
+      expect(source_organisation.users).not_to include(user)
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ajoute une tâche permettant de transférer les usagers d'une catégorie d'une orga vers la même catégorie sur une autre organisation. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2284