### PR TITLE
fix(tests): Ensure assets are precompiled when launching tests

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -3,7 +3,7 @@ const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const RemoveEmptyScriptsPlugin = require("webpack-remove-empty-scripts");
 // The RAILS_ENV variable is set as "development" in Procfile.dev
-const mode = process.env.RAILS_ENV === "development" ? "development" : "production";
+const mode = (process.env.RAILS_ENV === "development" || process.env.RAILS_ENV === "test") ? "development" : "production";
 
 module.exports = {
   mode,

--- a/spec/support/assets_build.rb
+++ b/spec/support/assets_build.rb
@@ -1,0 +1,25 @@
+# This hook checks that changes made to the js and css code are reflected in the compiled assets.
+# If they are not we launch the build command.
+RSpec.configure do |config|
+  config.before(:suite) do
+    # Skip asset building in CI environment
+    if ENV["CI"]
+      puts "CI environment detected; skipping asset build."
+    # We only run this if feature specs are being run
+    elsif config.files_to_run.any? { |file| file.include?("/spec/features/") }
+
+      source_files = Dir[Rails.root.join("app/javascript/**/*.{js,jsx,css,scss,sass}")]
+
+      built_assets = Dir[Rails.root.join("app/assets/builds/*.{js,css}")]
+
+      source_last_modified = source_files.map { |f| File.mtime(f) }.max
+
+      assets_last_modified = built_assets.map { |f| File.mtime(f) }.max
+
+      if assets_last_modified.nil? || source_last_modified > assets_last_modified
+        puts "Assets are not up-to-date; Building assets..."
+        system("RAILS_ENV=test yarn build")
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2172 .

En faisant des tests de mon côté, j'ai l'impression qu'après avoir enlevé tous les assets précompilés sur ma machine via la commande `rails assets:clobber` (merci @adipasquale 🙇‍♂️ !), les changements dans le code des assets sont maintenant 
reflétés dans les tests d'intégration.

Maintenant lorsque : 
 
* j'effectue un changement sur du code amené à être précompilé (dans le dossier `app/javascript/`)
* et que mon app tourne en local (et que donc le changement est pris en compte via la compilation de webpack)

= > Le test reflète bien le changement effectué.

En plus de ça, j'ajoute dans cette PR un script qui vérifie qu'un build a toujours eu lieu après un changement au niveau du code des assets. Si ce n'est pas le cas et que l'on a lancé au moins un test de feature, on lance un build se lance avant de lancer les tests.

On pourra vérifier ensemble @Holist et essayer de reproduire.

