### PR TITLE
bug(upload): assign_referent route changed but not in js file

### DIFF
--- a/app/javascript/react/actions/assignReferent.js
+++ b/app/javascript/react/actions/assignReferent.js
@@ -2,17 +2,9 @@ import appFetch from "../../lib/appFetch";
 
 const assignReferent = async (
   userId,
-  referentEmail,
-  departmentId,
-  organisationId,
-  isDepartmentLevel
+  referentEmail
 ) => {
-  let url;
-  if (isDepartmentLevel) {
-    url = `/departments/${departmentId}/referent_assignations`;
-  } else {
-    url = `/organisations/${organisationId}/referent_assignations`;
-  }
+  const url = `/users/${userId}/referent_assignations`;
   return appFetch(url, "POST", {
     referent_assignation: { user_id: userId, agent_email: referentEmail },
   });


### PR DESCRIPTION
Bug remonté par Eva toute à l'heure.
La fonctionnalité d'ajout de référent depuis la page upload est cassée.
Cela est sans doute lié à cette PR de changement des routes : https://github.com/betagouv/rdv-insertion/issues/2247
Je fix ce problème ici.