### PR TITLE
feat(archives): add archive reason

### DIFF
--- a/app/javascript/react/components/user/InvitationCells.jsx
+++ b/app/javascript/react/components/user/InvitationCells.jsx
@@ -10,7 +10,18 @@ export default function InvitationCells({ user }) {
     /* ----------------------------- Disabled invitations cases -------------------------- */
     user.isArchived() ? (
       <td colSpan={user.list.invitationsColSpan}>
-        Dossier archivé
+        Dossier archivé 
+        {user.isArchivedInCurrentOrganisation() && (
+          <Tippy
+            content={
+              <>
+                Usager archivé pour le motif suivant : {user.archiveInCurrentOrganisation().archiving_reason}
+              </>
+            }
+          >
+            <i className="ms-2 fas fa-info-circle" />
+          </Tippy>
+        )}
       </td>
     ) : user.createdAt && user.list.isDepartmentLevel && !user.linkedToCurrentCategory() ? (
       <td colSpan={user.list.invitationsColSpan}>


### PR DESCRIPTION
Cette PR rend visible via un tooltip le motif d'archivage pour les archives créées au niveau de l'organisation dans laquelle on est en train d'importer des usagers. 

<img width="606" alt="image" src="https://github.com/user-attachments/assets/450b3049-3dbb-4cae-a31e-818503a1bcb3">

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2315