### PR TITLE
feat(user): add transfer referent task

### DIFF
--- a/lib/tasks/users/transfer_referent.rake
+++ b/lib/tasks/users/transfer_referent.rake
@@ -1,0 +1,15 @@
+require Rails.root.join("lib/users/transfer_referent")
+
+namespace :users do
+  desc <<-DESC
+    This task allows to transfer users from one referent to another
+    
+    SOURCE_REFERENT_ID=1 TARGET_REFERENT_ID=2  bundle exec rails users:transfer_referent
+  DESC
+  task transfer_referent: :environment do
+    source_referent_id = ENV['SOURCE_REFERENT_ID'].to_i
+    target_referent_id = ENV['TARGET_REFERENT_ID'].to_i
+
+    Users::TransferReferent.new(source_referent_id:, target_referent_id:).call
+  end
+end

--- a/lib/tasks/users/transfer_referent.rake
+++ b/lib/tasks/users/transfer_referent.rake
@@ -10,6 +10,13 @@ namespace :users do
     source_referent_id = ENV['SOURCE_REFERENT_ID'].to_i
     target_referent_id = ENV['TARGET_REFERENT_ID'].to_i
 
-    Users::TransferReferent.new(source_referent_id:, target_referent_id:).call
+    service = Users::TransferReferent.new(source_referent_id:, target_referent_id:)
+    service.call
+
+    if service.errors.any?
+      puts "Les usagers suivants n'ont pas pu être transférés : #{service.errors { |e| e[:user].id }.join(', ')}"
+    else
+      puts "Tous les usagers ont été transférés avec succès"
+    end
   end
 end

--- a/lib/users/transfer_referent.rb
+++ b/lib/users/transfer_referent.rb
@@ -27,7 +27,7 @@ module Users
       if assignation_service.success?
         remove_source_referent(referent_assignation)
       else
-        @errors << { error: assignation_service.error, user: referent_assignation.user }
+        @errors << { error: { message: assignation_service.error, source: Users::AssignReferent.to_s }, user: referent_assignation.user }
       end
     end
 
@@ -35,7 +35,7 @@ module Users
       remove_service = Users::RemoveReferent.call(user: referent_assignation.user, agent: source_referent)
 
       if !remove_service.success?
-        @errors << { error: remove_service.error, user: referent_assignation.user }
+        @errors << { error: { message: remove_service.error, source: Users::RemoveReferent.to_s  }, user: referent_assignation.user }
       end
     end
   end

--- a/lib/users/transfer_referent.rb
+++ b/lib/users/transfer_referent.rb
@@ -10,16 +10,8 @@ module Users
 
     def call
       ReferentAssignation.where(agent: source_referent).find_each do |referent_assignation|
-        ActiveRecord::Base.transaction do
-          set_current_agent(referent_assignation)
-          assign_target_and_remove_source_referent(referent_assignation)
-        end
-      end
-
-      if errors.any?
-        puts "Les usagers suivants n'ont pas pu être transférés : #{errors.map { |e| e[:user].id }.join(', ')}"
-      else
-        puts "Tous les usagers ont été transférés avec succès"
+        set_current_agent(referent_assignation)
+        assign_target_and_remove_source_referent(referent_assignation)
       end
     end
 
@@ -44,7 +36,6 @@ module Users
 
       if !remove_service.success?
         @errors << { error: remove_service.error, user: referent_assignation.user }
-        raise ActiveRecord::Rollback
       end
     end
   end

--- a/lib/users/transfer_referent.rb
+++ b/lib/users/transfer_referent.rb
@@ -1,0 +1,51 @@
+module Users
+  class TransferReferent
+    attr_reader :source_referent, :target_referent, :errors
+
+    def initialize(source_referent_id:, target_referent_id:)
+      @source_referent = Agent.find(source_referent_id)
+      @target_referent = Agent.find(target_referent_id)
+      @errors = []
+    end
+
+    def call
+      ReferentAssignation.includes(user: :organisations).where(agent: source_referent).each do |referent_assignation|
+        ActiveRecord::Base.transaction do
+          set_current_agent(referent_assignation)
+          assign_target_and_remove_source_referent(referent_assignation)
+        end
+      end
+
+      if errors.any?
+        puts "Les usagers suivants n'ont pas pu être transférés : #{errors.map { |e| e[:user].id }.join(', ')}"
+      else
+        puts "Tous les usagers ont été transférés avec succès"
+      end
+    end
+
+    private
+
+    def set_current_agent(referent_assignation)
+      Current.agent = referent_assignation.agent
+    end
+
+    def assign_target_and_remove_source_referent(referent_assignation)
+      assignation_service = Users::AssignReferent.call(user: referent_assignation.user, agent: target_referent)
+
+      if assignation_service.success?
+        remove_source_referent(referent_assignation)
+      else
+        @errors << { error: assignation_service.error, user: referent_assignation.user }
+      end
+    end
+
+    def remove_source_referent(referent_assignation)
+      remove_service = Users::RemoveReferent.call(user: referent_assignation.user, agent: source_referent)
+
+      if !remove_service.success?
+        @errors << { error: remove_service.error, user: referent_assignation.user }
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+end

--- a/lib/users/transfer_referent.rb
+++ b/lib/users/transfer_referent.rb
@@ -9,7 +9,7 @@ module Users
     end
 
     def call
-      ReferentAssignation.includes(user: :organisations).where(agent: source_referent).each do |referent_assignation|
+      ReferentAssignation.where(agent: source_referent).find_each do |referent_assignation|
         ActiveRecord::Base.transaction do
           set_current_agent(referent_assignation)
           assign_target_and_remove_source_referent(referent_assignation)

--- a/spec/lib/users/transfer_referent_spec.rb
+++ b/spec/lib/users/transfer_referent_spec.rb
@@ -1,0 +1,49 @@
+require Rails.root.join("lib/users/transfer_referent")
+
+describe Users::TransferReferent do
+  subject { described_class.new(source_referent_id: source_referent.id, target_referent_id: target_referent.id).call }
+
+  let(:user) { create(:user) }
+  let(:source_referent) { create(:agent) }
+  let(:target_referent) { create(:agent) }
+
+  before do
+    source_referent.users << user
+    stub_rdv_solidarites_assign_referent(
+      user.rdv_solidarites_user_id,
+      target_referent.rdv_solidarites_agent_id
+    )
+    stub_rdv_solidarites_assign_referent(
+      user.rdv_solidarites_user_id,
+      source_referent.rdv_solidarites_agent_id
+    )
+    allow($stdout).to receive(:puts)
+  end
+
+  it "calls appropriate services and assigns referent" do
+    expect(Users::AssignReferent).to receive(:call).with(user:, agent: target_referent).once.and_call_original
+    expect(Users::RemoveReferent).to receive(:call).with(user:, agent: source_referent).once.and_call_original
+    expect($stdout).to receive(:puts).with(/succès/).once
+
+    subject
+
+    expect(user.reload.referents).to eq([target_referent])
+  end
+
+  context "when assign referent fails" do
+    before do
+      allow(Users::AssignReferent).to(
+        receive(:call).with(user:, agent: target_referent).once.and_return(
+          OpenStruct.new(success?: false)
+        )
+      )
+    end
+
+    it "does not call remove referent" do
+      expect(Users::RemoveReferent).not_to receive(:call)
+      expect($stdout).to receive(:puts).with(/#{user.id}/).once
+
+      subject
+    end
+  end
+end

--- a/spec/lib/users/transfer_referent_spec.rb
+++ b/spec/lib/users/transfer_referent_spec.rb
@@ -17,13 +17,11 @@ describe Users::TransferReferent do
       user.rdv_solidarites_user_id,
       source_referent.rdv_solidarites_agent_id
     )
-    allow($stdout).to receive(:puts)
   end
 
   it "calls appropriate services and assigns referent" do
     expect(Users::AssignReferent).to receive(:call).with(user:, agent: target_referent).once.and_call_original
     expect(Users::RemoveReferent).to receive(:call).with(user:, agent: source_referent).once.and_call_original
-    expect($stdout).to receive(:puts).with(/succès/).once
 
     subject
 
@@ -41,7 +39,6 @@ describe Users::TransferReferent do
 
     it "does not call remove referent" do
       expect(Users::RemoveReferent).not_to receive(:call)
-      expect($stdout).to receive(:puts).with(/#{user.id}/).once
 
       subject
     end


### PR DESCRIPTION
Dans cette PR j'ajoute une tâche permettant de transférer sereinement des usagers d'un référent à un autre. 

J'ai fait le choix de faire ça de notre côté en appelant l'API de RDV-s pour s'éviter la gymnastique mentale de devoir penser à passer les IDs en RDVs, pour garder la main sur cette tâche et la faire évoluer comme on le souhaite. 

Cette task sera à utiliser dans le scope de cette issue : 
https://github.com/gip-inclusion/rdv-insertion/issues/2346