### PR TITLE
fix(tag): fix unicity constraint for `TagOrganisation` and add modal error message

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -10,6 +10,8 @@ class TagsController < ApplicationController
     @organisation.tags << tag
 
     redirect_to organisation_category_configurations_path(@organisation)
+  rescue ActiveRecord::ActiveRecordError => e
+    turbo_stream_display_error_modal(e.record.errors.full_messages)
   end
 
   def destroy

--- a/app/models/tag_organisation.rb
+++ b/app/models/tag_organisation.rb
@@ -1,4 +1,6 @@
 class TagOrganisation < ApplicationRecord
   belongs_to :tag
   belongs_to :organisation
+
+  validates :tag_id, uniqueness: { scope: :organisation_id }
 end

--- a/spec/features/agent_can_edit_organisation_tags_spec.rb
+++ b/spec/features/agent_can_edit_organisation_tags_spec.rb
@@ -20,5 +20,26 @@ describe "Agents can edit organisation tags", :js do
       expect(tag).to have_content(tag_value)
       expect(organisation.reload.tags.first.value).to eq(tag_value)
     end
+
+    it "allows to delete the organisation tags" do
+      organisation.tags << Tag.create(value: tag_value)
+
+      visit organisation_category_configurations_path(organisation)
+      find("#tag_#{organisation.tags.first.id} a").click
+      find_by_id("confirm-button").click
+      expect(page).to have_no_selector("#tag_#{organisation.tags.first.id}")
+
+      expect(organisation.reload.tags).to be_empty
+    end
+
+    it "displays an error message when tag already exist in this organisation" do
+      organisation.tags << Tag.create(value: tag_value)
+
+      visit organisation_category_configurations_path(organisation)
+      page.fill_in "tag_value", with: tag_value
+      click_button("Créer le tag")
+
+      expect(page).to have_content("Tag est déjà utilisé")
+    end
   end
 end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2306

Rien de franchement compliqué ici.
Cela dit j'ai pris un peu de temps pour me décider sur quel message d'erreur afficher et comprendre comment fonctionne les erreurs et dans quel cas on affiche quel type d'erreur. (modal standard, modal custom, liste dans le formulaire, message flash)
Initialement je suis parti sur la liste des erreurs directement dans le formulaire en utilisant un `turbo_stream_replace_error_list_with` modifié mais je trouve que ca marche mieux avec la modale.
J'en ai profité pour ajouter un test pour aller avec (et un test sur la suppression de tag qui n'existait pas)
Le message d'erreur est basique :

<img width="655" alt="Capture d’écran 2024-09-27 à 14 28 32" src="https://github.com/user-attachments/assets/ce01e7f0-c523-4323-bd48-69f47ffb7584">
