### PR TITLE
fix(locking): Fix flaky test + Remove sentry excluded exception

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,8 +6,4 @@ Sentry.init do |config|
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production
   config.traces_sample_rate = 0.05
-
-  # if a job cannot execute because of a lock it fails and will be retried later,
-  # see https://github.com/gip-inclusion/rdv-insertion/pull/2340
-  config.excluded_exceptions += ["WithAdvisoryLock::FailedToAcquireLock"]
 end


### PR DESCRIPTION
Cette PR fait suite à #2340 et je modifie deux choses par rapport au commit initial: 


* Je change la spec du concern `locked_jobs` qui était flaky parce que le lock pouvait persister entre les 2 tests que comprend le fichier `locked_jobs_spec.rb`. Je fais en sorte d'englober chaque thread dans un bloc que l'on passe à  `ActiveRecord::Base.connection_pool.with_connection` pour être sûr que le thread release sa connection (et donc le lock) après son exécution. Ce changement se trouve ici: https://github.com/gip-inclusion/rdv-insertion/pull/2365/commits/7aca12a68b925f0cdec7872ed84b5adb0e7032ff


* Suite à ce commentaire https://github.com/gip-inclusion/rdv-insertion/pull/2340#discussion_r1782262124 je remets l'exception sur sentry le temps de voir si on a bien des jobs qui raise en tentant d'acquérir le lock. Ce changement se trouve ici: https://github.com/gip-inclusion/rdv-insertion/pull/2365/commits/97ee7c8066251dae3d91b02189109e21c4f3c2ea