### PR TITLE
feat(motif_category): add motif_category_type

### DIFF
--- a/app/dashboards/motif_category_dashboard.rb
+++ b/app/dashboards/motif_category_dashboard.rb
@@ -10,7 +10,6 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     category_configurations: Field::HasMany,
-    leads_to_orientation: Field::Boolean,
     motifs: Field::HasMany,
     name: Field::String,
     motif_category_type: Field::Select.with_options(
@@ -46,7 +45,6 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
     template
     motif_category_type
     motifs
-    leads_to_orientation
     optional_rdv_subscription
     created_at
     updated_at
@@ -60,14 +58,12 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
     short_name
     template
     motif_category_type
-    leads_to_orientation
     optional_rdv_subscription
   ].freeze
 
   FORM_ATTRIBUTES_EDIT = %i[
     template
     motif_category_type
-    leads_to_orientation
     optional_rdv_subscription
   ].freeze
 

--- a/app/dashboards/motif_category_dashboard.rb
+++ b/app/dashboards/motif_category_dashboard.rb
@@ -13,6 +13,10 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
     leads_to_orientation: Field::Boolean,
     motifs: Field::HasMany,
     name: Field::String,
+    motif_category_type: Field::Select.with_options(
+      searchable: false,
+      collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }
+    ),
     optional_rdv_subscription: Field::Boolean,
     follow_ups: Field::HasMany,
     rdv_solidarites_motif_category_id: Field::Number,
@@ -30,6 +34,7 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     name
+    motif_category_type
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -39,6 +44,7 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
     name
     short_name
     template
+    motif_category_type
     motifs
     leads_to_orientation
     optional_rdv_subscription
@@ -53,12 +59,14 @@ class MotifCategoryDashboard < Administrate::BaseDashboard
     name
     short_name
     template
+    motif_category_type
     leads_to_orientation
     optional_rdv_subscription
   ].freeze
 
   FORM_ATTRIBUTES_EDIT = %i[
     template
+    motif_category_type
     leads_to_orientation
     optional_rdv_subscription
   ].freeze

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -34,7 +34,7 @@ class FollowUp < ApplicationRecord
                           }
   scope :with_all_invitations_expired, -> { joins(:invitations).where.not(invitations: Invitation.valid) }
   scope :with_sent_invitations, -> { where.associated(:invitations) }
-  scope :orientation, -> { joins(:motif_category).where(motif_category: { leads_to_orientation: true }) }
+  scope :orientation, -> { joins(:motif_category).where(motif_category: { motif_category_type: "rsa_orientation" }) }
 
   def action_required_status?
     status.in?(STATUSES_WITH_ACTION_REQUIRED)
@@ -57,7 +57,7 @@ class FollowUp < ApplicationRecord
   end
 
   def orientation?
-    motif_category.leads_to_orientation?
+    motif_category.rsa_orientation?
   end
 
   def human_status

--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -10,11 +10,15 @@ class MotifCategory < ApplicationRecord
 
   validates :short_name, presence: true, uniqueness: true
   validates :name, presence: true
+  validates :motif_category_type, presence: true
   validates :rdv_solidarites_motif_category_id, uniqueness: true, allow_nil: true
   validate :selected_template_allows_mandatory_rdv_subscription
 
   delegate :model, to: :template, prefix: true
   delegate :atelier?, to: :template
+
+  enum motif_category_type: { autre: "autre", siae: "siae", rsa_orientation: "rsa_orientation",
+                              rsa_accompagnement: "rsa_accompagnement" }
 
   scope :optional_rdv_subscription, lambda { |optional_rdv_subscription = true|
     where(optional_rdv_subscription: optional_rdv_subscription)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -208,6 +208,7 @@ tables:
       - short_name
       - name
       - template_id
+      - motif_category_type
       - rdv_solidarites_motif_category_id
       - created_at
       - updated_at

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -213,7 +213,6 @@ tables:
       - created_at
       - updated_at
       - optional_rdv_subscription
-      - leads_to_orientation
 
   - table_name: motifs
     anonymized_column_names:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -5,7 +5,6 @@ fr:
     field_hints:
       motif_category:
         short_name: "en minuscule, sans accents, sans espace. Par exemple, \"RDV Orientation\" devient \"rdv_orientation\""
-        leads_to_orientation: "Sert pour les stats ; si cochée, les RDV de cette catégorie sont considérés comme des RDV d'orientation"
         optional_rdv_subscription: "Si cochée, pas de rappels envoyés pour les invitations et les invitations ne sont pas invalidées"
       department:
         pronoun: "en minuscule - par exemple, \"la\" pour \"la Drôme\""

--- a/config/locales/models/motif_category.fr.yml
+++ b/config/locales/models/motif_category.fr.yml
@@ -5,3 +5,4 @@ fr:
     attributes:
       motif_category:
         optional_rdv_subscription: Prise de rdv facultative
+        motif_category_type: Type de catégorie

--- a/db/migrate/20241001131337_add_motif_category_type_to_motif_category.rb
+++ b/db/migrate/20241001131337_add_motif_category_type_to_motif_category.rb
@@ -1,0 +1,5 @@
+class AddMotifCategoryTypeToMotifCategory < ActiveRecord::Migration[7.1]
+  def change
+    add_column :motif_categories, :motif_category_type, :string, default: "Autre", null: false
+  end
+end

--- a/db/migrate/20241001133756_remove_leads_to_orienation_from_motif_category.rb
+++ b/db/migrate/20241001133756_remove_leads_to_orienation_from_motif_category.rb
@@ -1,0 +1,11 @@
+class RemoveLeadsToOrienationFromMotifCategory < ActiveRecord::Migration[7.1]
+  def up
+    MotifCategory.where(leads_to_orientation: true).update_all(motif_category_type: "rsa_orientation")
+    remove_column :motif_categories, :leads_to_orientation, :boolean, default: false
+  end
+
+  def down
+    add_column :motif_categories, :leads_to_orientation, :boolean, default: false
+    MotifCategory.where(motif_category_type: "rsa_orientation").update_all(leads_to_orientation: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_01_131337) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_01_133756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -270,7 +270,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_01_131337) do
     t.datetime "updated_at", null: false
     t.bigint "template_id"
     t.boolean "optional_rdv_subscription", default: false
-    t.boolean "leads_to_orientation", default: false
     t.string "motif_category_type", default: "Autre", null: false
     t.index ["rdv_solidarites_motif_category_id"], name: "index_motif_categories_on_rdv_solidarites_motif_category_id", unique: true
     t.index ["short_name"], name: "index_motif_categories_on_short_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_10_154029) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_01_131337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -271,6 +271,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_10_154029) do
     t.bigint "template_id"
     t.boolean "optional_rdv_subscription", default: false
     t.boolean "leads_to_orientation", default: false
+    t.string "motif_category_type", default: "Autre", null: false
     t.index ["rdv_solidarites_motif_category_id"], name: "index_motif_categories_on_rdv_solidarites_motif_category_id", unique: true
     t.index ["short_name"], name: "index_motif_categories_on_short_name", unique: true
     t.index ["template_id"], name: "index_motif_categories_on_template_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,9 @@ yonne = Department.create!(
 # --------------------------------------------------------------------------------------------------------------------
 puts "Creating motif categories..."
 orientation_category = MotifCategory.create!(
-  short_name: "rsa_orientation", name: "RSA orientation",
+  name: "RSA orientation",
+  short_name: "rsa_orientation",
+  motif_category_type: "rsa_orientation",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'orientation",
@@ -55,7 +57,9 @@ orientation_category = MotifCategory.create!(
   )
 )
 accompagnement_category = MotifCategory.create!(
-  short_name: "rsa_accompagnement", name: "RSA accompagnement",
+  name: "RSA accompagnement",
+  short_name: "rsa_accompagnement",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'accompagnement",
@@ -70,6 +74,7 @@ accompagnement_category = MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA accompagnement socio-pro",
   short_name: "rsa_accompagnement_sociopro",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'accompagnement",
@@ -84,6 +89,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA accompagnement social",
   short_name: "rsa_accompagnement_social",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'accompagnement",
@@ -98,6 +104,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA signature CER",
   short_name: "rsa_cer_signature",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous de signature de CER",
@@ -111,6 +118,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA suivi",
   short_name: "rsa_follow_up",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous de suivi",
@@ -124,6 +132,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA offre insertion pro",
   short_name: "rsa_insertion_offer",
+  motif_category_type: "rsa_accompagnement",
   optional_rdv_subscription: true,
   template: Template.find_or_create_by!(
     model: "atelier",
@@ -137,6 +146,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA orientation sur plateforme téléphonique",
   short_name: "rsa_orientation_on_phone_platform",
+  motif_category_type: "rsa_orientation",
   template: Template.find_or_create_by!(
     model: "phone_platform",
     rdv_title: "rendez-vous d'orientation téléphonique",
@@ -149,6 +159,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA Atelier collectif obligatoire",
   short_name: "rsa_atelier_collectif_mandatory",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "atelier collectif",
@@ -162,6 +173,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA Atelier rencontres professionnelles",
   short_name: "rsa_atelier_rencontres_pro",
+  motif_category_type: "rsa_accompagnement",
   optional_rdv_subscription: true,
   template: Template.find_or_create_by!(
     model: "atelier",
@@ -174,6 +186,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA Atelier compétences",
   short_name: "rsa_atelier_competences",
+  motif_category_type: "rsa_accompagnement",
   optional_rdv_subscription: true,
   template: Template.find_or_create_by!(
     model: "atelier",
@@ -186,6 +199,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA Main Tendue",
   short_name: "rsa_main_tendue",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "entretien de main tendue",
@@ -199,6 +213,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA SPIE",
   short_name: "rsa_spie",
+  motif_category_type: "spie",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'accompagnement",
@@ -213,6 +228,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA Information d'intégration",
   short_name: "rsa_integration_information",
+  motif_category_type: "autre",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'information",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -213,7 +213,7 @@ MotifCategory.create!(
 MotifCategory.create!(
   name: "RSA SPIE",
   short_name: "rsa_spie",
-  motif_category_type: "spie",
+  motif_category_type: "rsa_accompagnement",
   template: Template.find_or_create_by!(
     model: "standard",
     rdv_title: "rendez-vous d'accompagnement",

--- a/spec/factories/motif_category.rb
+++ b/spec/factories/motif_category.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :motif_category do
     template
+    motif_category_type { "autre" }
     sequence(:short_name) { |n| "rsa_orientation_#{n}" }
     name { "RSA orientation" }
     optional_rdv_subscription { false }

--- a/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
@@ -63,8 +63,8 @@ describe "Super admin can manage motif categories" do
       expect(page).to have_css("dt", id: "motifs", text: "MOTIFS")
       expect(page).to have_css("tr", class: "js-table-row", count: 1)
       within("tr.js-table-row") { expect(page).to have_css("td.cell-data", text: motif.name) }
-      expect(page).to have_css("dt", id: "leads_to_orientation", text: "LEADS TO ORIENTATION")
-      expect(page).to have_css("dd", class: "attribute-data", text: motif_category.leads_to_orientation)
+      expect(page).to have_css("dt", id: "motif_category_type", text: "TYPE DE CATÉGORIE")
+      expect(page).to have_css("dd", class: "attribute-data", text: motif_category.motif_category_type)
       expect(page).to have_css("dt", id: "optional_rdv_subscription", text: "PRISE DE RDV FACULTATIVE")
       expect(page).to have_css("dd", class: "attribute-data", text: motif_category.optional_rdv_subscription)
     end
@@ -98,7 +98,7 @@ describe "Super admin can manage motif categories" do
       expect(page).to have_field("motif_category[short_name]")
       expect(page).to have_css("label[for=\"motif_category_template_id-selectized\"]", text: "Template")
       expect(page).to have_field("motif_category_template_id-selectized")
-      expect(page).to have_css("label[for=\"motif_category_leads_to_orientation\"]", text: "Leads to orientation")
+      expect(page).to have_field("motif_category_motif_category_type-selectized")
       expect(page).to have_css(
         "label[for=\"motif_category_optional_rdv_subscription\"]", text: "Prise de rdv facultative"
       )

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -203,14 +203,14 @@ describe Stat do
           create(
             :follow_up,
             user: first_user,
-            motif_category: create(:motif_category, leads_to_orientation: true)
+            motif_category: create(:motif_category, motif_category_type: "rsa_orientation")
           )
         end
         let!(:first_user_second_orientation_follow_up) do
           create(
             :follow_up,
             user: first_user,
-            motif_category: create(:motif_category, leads_to_orientation: true)
+            motif_category: create(:motif_category, motif_category_type: "rsa_orientation")
           )
         end
 
@@ -218,7 +218,7 @@ describe Stat do
           create(
             :follow_up,
             user: second_user,
-            motif_category: create(:motif_category, leads_to_orientation: true)
+            motif_category: create(:motif_category, motif_category_type: "rsa_orientation")
           )
         end
 
@@ -226,7 +226,7 @@ describe Stat do
           create(
             :follow_up,
             user: third_user,
-            motif_category: create(:motif_category, leads_to_orientation: false)
+            motif_category: create(:motif_category, motif_category_type: "rsa_accompagnement")
           )
         end
 

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -4,7 +4,8 @@ describe Exporters::GenerateUsersCsv, type: :service do
   let!(:now) { Time.zone.parse("22/06/2022") }
   let!(:timestamp) { now.to_i }
   let!(:motif_category) do
-    create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation", leads_to_orientation: true)
+    create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation",
+                            motif_category_type: "rsa_orientation")
   end
   let!(:department) { create(:department, name: "Drôme", number: "26") }
   let!(:organisation) { create(:organisation, name: "Drome RSA", department: department) }
@@ -284,7 +285,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
 
         context "if it is not the orientation date" do
           let!(:motif_category) do
-            create(:motif_category, leads_to_orientation: false)
+            create(:motif_category, motif_category_type: "rsa_accompagnement")
           end
 
           it "does not take it into account" do

--- a/spec/support/motif_categories_helper.rb
+++ b/spec/support/motif_categories_helper.rb
@@ -4,8 +4,9 @@ module MotifCategoriesHelper
     let!(:category_rsa_orientation) do
       create(
         :motif_category,
-        name: "RSA orientation", short_name: "rsa_orientation",
-        leads_to_orientation: true,
+        name: "RSA orientation",
+        short_name: "rsa_orientation",
+        motif_category_type: "rsa_orientation",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -22,8 +23,9 @@ module MotifCategoriesHelper
     let!(:category_rsa_orientation_coaching) do
       create(
         :motif_category,
-        name: "RSA orientation - coaching emploi", short_name: "rsa_orientation_coaching",
-        leads_to_orientation: true,
+        name: "RSA orientation - coaching emploi",
+        short_name: "rsa_orientation_coaching",
+        motif_category_type: "rsa_orientation",
         template: create(
           :template,
           model: "standard",
@@ -39,8 +41,9 @@ module MotifCategoriesHelper
     let!(:category_rsa_orientation_freelance) do
       create(
         :motif_category,
-        name: "RSA orientation - travailleurs indépendants", short_name: "rsa_orientation_freelance",
-        leads_to_orientation: true,
+        name: "RSA orientation - travailleurs indépendants",
+        short_name: "rsa_orientation_freelance",
+        motif_category_type: "rsa_orientation",
         template: create(
           :template,
           model: "standard",
@@ -58,6 +61,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA accompagnement",
         short_name: "rsa_accompagnement",
+        motif_category_type: "rsa_accompagnement",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -77,6 +81,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA accompagnement socio-pro",
         short_name: "rsa_accompagnement_sociopro",
+        motif_category_type: "rsa_accompagnement",
         template: create(
           :template,
           model: "standard",
@@ -95,6 +100,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA accompagnement social",
         short_name: "rsa_accompagnement_social",
+        motif_category_type: "rsa_accompagnement",
         template: create(
           :template,
           model: "standard",
@@ -113,6 +119,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA signature CER",
         short_name: "rsa_cer_signature",
+        motif_category_type: "rsa_accompagnement",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -131,6 +138,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA suivi",
         short_name: "rsa_follow_up",
+        motif_category_type: "rsa_accompagnement",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -149,7 +157,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA offre insertion pro",
         short_name: "rsa_insertion_offer",
-        leads_to_orientation: true,
+        motif_category_type: "rsa_orientation",
         optional_rdv_subscription: true,
         template: create(
           :template,
@@ -167,7 +175,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA orientation sur plateforme téléphonique",
         short_name: "rsa_orientation_on_phone_platform",
-        leads_to_orientation: true,
+        motif_category_type: "rsa_orientation",
         template: create(
           :template,
           model: "phone_platform",
@@ -185,6 +193,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA Atelier collectif obligatoire",
         short_name: "rsa_atelier_collectif_mandatory",
+        motif_category_type: "rsa_accompagnement",
         template: create(
           :template,
           model: "standard",
@@ -202,6 +211,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA Atelier rencontres professionnelles",
         short_name: "rsa_atelier_rencontres_pro",
+        motif_category_type: "rsa_accompagnement",
         optional_rdv_subscription: true,
         template: create(
           :template,
@@ -219,6 +229,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA Atelier compétences",
         short_name: "rsa_atelier_competences",
+        motif_category_type: "rsa_accompagnement",
         optional_rdv_subscription: true,
         template: create(
           :template,
@@ -235,6 +246,7 @@ module MotifCategoriesHelper
       create(
         :motif_category,
         name: "RSA Main Tendue",
+        motif_category_type: "rsa_accompagnement",
         short_name: "rsa_main_tendue",
         template: create(
           :template,
@@ -253,7 +265,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA SPIE",
         short_name: "rsa_spie",
-        leads_to_orientation: true,
+        motif_category_type: "rsa_orientation",
         template: create(
           :template,
           model: "standard",
@@ -272,7 +284,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA Information d'intégration",
         short_name: "rsa_integration_information",
-        leads_to_orientation: true,
+        motif_category_type: "rsa_orientation",
         template: create(
           :template,
           model: "standard",
@@ -290,6 +302,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "Psychologue",
         short_name: "psychologue",
+        motif_category_type: "autre",
         template: create(
           :template,
           model: "short",
@@ -304,7 +317,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA orientation France Travail",
         short_name: "rsa_orientation_france_travail",
-        leads_to_orientation: true,
+        motif_category_type: "rsa_orientation",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -327,6 +340,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "Atelier Enfants / Ados",
         short_name: "atelier_enfants_ados",
+        motif_category_type: "autre",
         template: create(
           :template,
           model: "atelier_enfants_ados",
@@ -341,6 +355,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "Entretien SIAE",
         short_name: "siae_interview",
+        motif_category_type: "siae",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -359,6 +374,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "Info coll. SIAE",
         short_name: "siae_collective_information",
+        motif_category_type: "siae",
         optional_rdv_subscription: false,
         template: create(
           :template,
@@ -377,6 +393,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "Suivi SIAE",
         short_name: "siae_follow_up",
+        motif_category_type: "siae",
         optional_rdv_subscription: false,
         template: create(
           :template,


### PR DESCRIPTION
Close https://github.com/gip-inclusion/rdv-insertion/issues/2291

## Produit
Dans le super admin vous pouvez spécifier le type de catégorie de motif quand vous en créez une.
J'affiche également la colonne dans l'index pour pouvoir les trier si besoin.
L'option leads_to_orientation a été remplacé par la valeur `rsa_orientation` pour le nouvel attribut.

Avant | Après
:- | -:
<img width="1622" alt="Capture d’écran 2024-10-01 à 16 36 07" src="https://github.com/user-attachments/assets/3ce88569-647d-419a-a0b2-a7962cc30122"> | <img width="1622" alt="Capture d’écran 2024-10-01 à 16 24 07" src="https://github.com/user-attachments/assets/2f608b0b-57f1-457a-baa9-68a043bd70b2">

Avant | Après
:- | -:
<img width="1622" alt="Capture d’écran 2024-10-01 à 16 35 55" src="https://github.com/user-attachments/assets/0d4ab531-37b6-4d1d-8168-8dee4d2bba77">| <img width="1622" alt="Capture d’écran 2024-10-01 à 16 24 37" src="https://github.com/user-attachments/assets/63ea41ee-352d-46ca-a1dc-19922bce8e15">

## Technique
On ajoute un champ pour les `MotficCategory` pour pouvoir spécifier le type de motif. (`motif_category_type`)
Je n'ai pas utilisé le nom de colonne `type` car le mot type fait parti des mots réservés.
J'ai remplacé le fonctionnement existant de l'attribut `leads_to_orientation` par le nouveau champ et la valeur `rsa_orientation` dans le scope existant.

Je compte modifier manuellement les type de catégories de motifs en prod et en démo quand cette PR sera merge en me basant sur la liste de l'issue fournie par Amaury.