### PR TITLE
feat(tech): add database cleaner gem to prevent flakyness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,8 +125,6 @@ group :development, :test do
   gem "rspec-rails"
   # Strategies for cleaning databases. Can be used to ensure a clean slate for testing.
   gem "database_cleaner"
-  # https://github.com/DatabaseCleaner/database_cleaner-active_record/blob/main/CHANGELOG.md#v210-2023-02-17
-  gem "database_cleaner-active_record", "~> 2.2" # For Rails 7.1 Support
   gem "factory_bot_rails"
   gem "rubocop"
   gem "rubocop-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,10 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails"
+  # Strategies for cleaning databases. Can be used to ensure a clean slate for testing.
+  gem "database_cleaner"
+  # https://github.com/DatabaseCleaner/database_cleaner-active_record/blob/main/CHANGELOG.md#v210-2023-02-17
+  gem "database_cleaner-active_record", "~> 2.2" # For Rails 7.1 Support
   gem "factory_bot_rails"
   gem "rubocop"
   gem "rubocop-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,6 @@ DEPENDENCIES
   capybara (>= 2.15)
   chartkick
   database_cleaner
-  database_cleaner-active_record (~> 2.2)
   dotenv-rails
   factory_bot_rails
   faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,12 @@ GEM
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.4)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
@@ -610,6 +616,8 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chartkick
+  database_cleaner
+  database_cleaner-active_record (~> 2.2)
   dotenv-rails
   factory_bot_rails
   faraday

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -59,8 +59,8 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
     }.deep_symbolize_keys
   end
 
-  let!(:user) { create(:user, organisations: [organisation], id: 3) }
-  let!(:user2) { create(:user, organisations: [organisation], id: 4) }
+  let!(:user) { create(:user, organisations: [organisation]) }
+  let!(:user2) { create(:user, organisations: [organisation]) }
 
   let!(:agent) { create(:agent) }
 
@@ -98,15 +98,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
       [organisation],
       follow_up: follow_up2,
       expires_at: 3.days.from_now
-    )
-  end
-
-  let!(:invitation3) do
-    create(
-      :invitation,
-      organisations: [organisation],
-      follow_up: follow_up,
-      expires_at: 3.days.ago
     )
   end
 
@@ -176,6 +167,15 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
       end
 
       context "it upserts the rdv (for a create)" do
+        let!(:invitation3) do
+          create(
+            :invitation,
+            organisations: [organisation],
+            follow_up: follow_up,
+            expires_at: 3.days.ago
+          )
+        end
+
         it "enqueues a job to upsert the rdv" do
           expect(UpsertRecordJob).to receive(:perform_later)
             .with(
@@ -355,7 +355,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
               id: 2,
               status: "seen",
               created_by: "user",
-              user_id: 4,
+              user_id: user2.id,
               rdv_solidarites_participation_id: 999,
               follow_up_id: follow_up2.id,
               rdv_solidarites_agent_prescripteur_id: nil
@@ -461,7 +461,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 3,
+                  user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
                   convocable: true,
@@ -471,7 +471,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 4,
+                  user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
                   convocable: true,
@@ -498,7 +498,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 3,
+                  user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
                   convocable: false,
@@ -508,7 +508,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 4,
+                  user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
                   convocable: false,
@@ -582,7 +582,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "agent",
-                  user_id: 3,
+                  user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
                   convocable: true,
@@ -592,7 +592,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 4,
+                  user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
                   convocable: false,
@@ -622,7 +622,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                     id: nil,
                     status: "unknown",
                     created_by: "agent",
-                    user_id: 3,
+                    user_id: user.id,
                     rdv_solidarites_participation_id: 998,
                     follow_up_id: follow_up.id,
                     convocable: false,
@@ -632,7 +632,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                     id: nil,
                     status: "unknown",
                     created_by: "user",
-                    user_id: 4,
+                    user_id: user2.id,
                     rdv_solidarites_participation_id: 999,
                     follow_up_id: follow_up2.id,
                     convocable: false,
@@ -702,7 +702,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "agent",
-                  user_id: 3,
+                  user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
                   convocable: true,
@@ -712,7 +712,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   id: nil,
                   status: "unknown",
                   created_by: "user",
-                  user_id: 4,
+                  user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
                   convocable: false,

--- a/spec/jobs/refresh_out_of_date_follow_up_statuses_job_spec.rb
+++ b/spec/jobs/refresh_out_of_date_follow_up_statuses_job_spec.rb
@@ -6,33 +6,34 @@ describe RefreshOutOfDateFollowUpStatusesJob do
   # status out of date
   let!(:participation1) { create(:participation, status: "unknown", follow_up: follow_up1) }
   let!(:rdv1) { create(:rdv, starts_at: 1.day.ago, participations: [participation1]) }
-  let!(:follow_up1) { create(:follow_up, status: "rdv_pending", id: 1) }
+  let!(:follow_up1) { create(:follow_up, status: "rdv_pending") }
 
   # ok
-  let!(:follow_up2) { create(:follow_up, status: "not_invited", id: 2) }
+  let!(:follow_up2) { create(:follow_up, status: "not_invited") }
 
   # status out of date
-  let!(:follow_up3) { create(:follow_up, status: "invitation_pending", id: 3) }
+  let!(:follow_up3) { create(:follow_up, status: "invitation_pending") }
   let!(:invitation) { create(:invitation, created_at: 3.days.ago) }
   let!(:rdv3) { create(:rdv, participations: [participation3]) }
   let!(:participation3) { create(:participation, created_at: 2.days.ago, status: "unknown", follow_up: follow_up3) }
 
   # ok
-  let!(:follow_up4) { create(:follow_up, status: "rdv_seen", id: 4) }
+  let!(:follow_up4) { create(:follow_up, status: "rdv_seen") }
   let!(:rdv4) do
     create(:rdv, starts_at: 1.day.ago, participations: [participation4])
   end
   let!(:participation4) { create(:participation, follow_up: follow_up4, status: "seen") }
 
   # status out of date
-  let!(:follow_up5) { create(:follow_up, status: "rdv_pending", id: 5) }
+  let!(:follow_up5) { create(:follow_up, status: "rdv_pending") }
   let!(:rdv5) { create(:rdv, starts_at: 1.day.ago, participations: [participation5]) }
   let!(:participation5) { create(:participation, status: "seen", follow_up: follow_up5) }
 
   describe "#perform" do
     before do
       # remove follow-ups created in callbacks
-      FollowUp.where.not(id: [1, 2, 3, 4, 5]).find_each(&:destroy!)
+      FollowUp.where.not(id: [follow_up1.id, follow_up2.id, follow_up3.id, follow_up4.id,
+                              follow_up5.id]).find_each(&:destroy!)
       allow(RefreshFollowUpStatusesJob).to receive(:perform_later)
       allow(MattermostClient).to receive(:send_to_notif_channel)
       allow(ENV).to receive(:[]).with("SENTRY_ENVIRONMENT").and_return("production")
@@ -40,14 +41,14 @@ describe RefreshOutOfDateFollowUpStatusesJob do
 
     it "enqueues a refresh job for out of date follow-ups" do
       expect(RefreshFollowUpStatusesJob).to receive(:perform_later)
-        .with([1, 3, 5])
+        .with([follow_up1.id, follow_up3.id, follow_up5.id])
       subject
     end
 
     it "sends a notification on mattermost" do
       expect(MattermostClient).to receive(:send_to_notif_channel)
         .with(
-          "✨ Rafraîchit les statuts pour: [1, 3, 5]"
+          "✨ Rafraîchit les statuts pour: [#{follow_up1.id}, #{follow_up3.id}, #{follow_up5.id}]"
         )
       subject
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,17 +66,30 @@ RSpec.configure do |config|
     ActiveSupport::CurrentAttributes.reset_all
     # ensure that ActiveStorage::Current.url_options is set for all requests
     ActiveStorage::Current.url_options = { host: ENV["HOST"] }
+    DatabaseCleaner.clean_with(:truncation)
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   config.around(:each, :no_transaction) do |example|
     self.use_transactional_tests = false
     example.run
     self.use_transactional_tests = true
+  end
+
+  config.around do |example|
+    DatabaseCleaner.strategy = if example.file_path.include?("/spec/features")
+                                 :truncation
+                               else
+                                 :transaction
+                               end
+
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 
   # You can uncomment this line to turn off ActiveRecord support entirely.


### PR DESCRIPTION
Tout est dans le titre.
Subtilités : 
On doit utiliser cette version spécifique de la gem "database_cleaner-active_record", "~> 2.2" à cause d'une incompatibilité avec rails 7.1. J'ai mis le lien dans le gemfile.
J'ai du revoir des tests qui utilisaient des id spécifiés pour la création des records (à éviter) sinon on avait des erreurs postgres.
