### PR TITLE
script(referent): fix potentially blocking errors

### DIFF
--- a/lib/tasks/users/transfer_referent.rake
+++ b/lib/tasks/users/transfer_referent.rake
@@ -14,7 +14,7 @@ namespace :users do
     service.call
 
     if service.errors.any?
-      puts "Les usagers suivants n'ont pas pu être transférés : #{service.errors { |e| e[:user].id }.join(', ')}"
+      puts "Les usagers suivants n'ont pas pu être transférés : #{service.errors.map { |e| e[:user].id }.join(', ')}"
     else
       puts "Tous les usagers ont été transférés avec succès"
     end

--- a/lib/users/transfer_referent.rb
+++ b/lib/users/transfer_referent.rb
@@ -10,8 +10,12 @@ module Users
 
     def call
       ReferentAssignation.where(agent: source_referent).find_each do |referent_assignation|
-        set_current_agent(referent_assignation)
-        assign_target_and_remove_source_referent(referent_assignation)
+        begin
+          set_current_agent(referent_assignation)
+          assign_target_and_remove_source_referent(referent_assignation)
+        rescue => e
+          @errors << { error: { message: e.message, source: e.class.to_s }, user: referent_assignation.user }
+        end
       end
     end
 


### PR DESCRIPTION
Cette PR rajoute un rescue sur des erreurs possiblement imprévues. Typiquement j'ai reçu une 500 pour un des usagers ce qui a bloqué l'execution du script. 

De cette façon il tournera jusqu'au bout et affichera les ids problématiques afin de pouvoir les débugger à la main