### PR TITLE
feat(jobs): filter rdvs webhooks sentry errors

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
@@ -42,9 +42,7 @@ module InboundWebhooks
       end
 
       def attach_agent_to_user
-        return if user.reload.referent_ids.include?(agent.id)
-
-        user.referents << agent
+        ReferentAssignation.find_or_create_by!(agent:, user:)
       end
 
       def remove_agent_from_user

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
@@ -53,7 +53,7 @@ module InboundWebhooks
       end
 
       def attach_user_to_org
-        user.organisations << organisation unless user.reload.belongs_to_org?(organisation.id)
+        UsersOrganisation.find_or_create_by!(user:, organisation:)
       end
 
       def remove_user_from_organisation

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,4 +6,5 @@ Sentry.init do |config|
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production
   config.traces_sample_rate = 0.05
+  config.excluded_exceptions += ["WithAdvisoryLock::FailedToAcquireLock"]
 end


### PR DESCRIPTION
Je fais deux choses dans cette PR permettant d'éviter des erreurs dans les jobs traitant les webhooks et ainsi réduire le volume d'erreurs dans Sentry: 

## Fix des `ActiveRecord::NotUnique`

On reçoit très régulièrement sur Sentry des erreurs de ce type pour les jobs 
`InboundWebhooks::RdvSolidarites::ProcessUserProfileJob` et `InboundWebhooks::RdvSolidarites::ProcessReferentAssignationJob`:   https://sentry.incubateur.net/organizations/betagouv/issues/123725/?environment=production&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

En investiguant j'ai remarqué que cela se produisait lorsque le référent ou l'organisation étaient assignés depuis l'interface de rdv-insertion: Comme ces assignations sont faites au sein de transaction sur rdv-i ([ici](https://github.com/gip-inclusion/rdv-insertion/blob/a0b1b7952878fbb2a31eaec82bde59b97a039a97/app/services/users/assign_referent.rb#L9) et [ici](https://github.com/gip-inclusion/rdv-insertion/blob/a0b1b7952878fbb2a31eaec82bde59b97a039a97/app/services/users/save.rb#L17)), il arrive que l'on traite le webhook de rdvsp liés à ces opérations avant même que la transaction finisse côté rdv-i. 

Du coup quand on arrivait à la ligne `user.organisations << organisation` dans le job des user profiles par exemple, cette ligne ne s'exécutait qu'une fois la transaction qui effectuait le même commit soit finie côté rdvi (il y a un lock à cause de la contrainte d'unicité de la ressource). Du coup une fois que la transaction était terminée,  `user.organisations << organisation` était executée et causait donc une erreur d'unicité puisque la ressource existait déjà. 

Je règle le problème en créant la ressource `find_or_create_by!` sur le model de jointure. Ainsi lorsque la ligne sera executée, on essaiera pas de créer la ressource une fois la transaction déclenchée par l'action rdv-i est finie.

C'est ce commit: https://github.com/gip-inclusion/rdv-insertion/commit/3280c51438116517c219ed6d72d8841a3024ea38

## Filtre des `WithAdvisoryLock::FailedToAcquireLock`

Comme convenu je re-filtre ces erreurs sur sentry, on avait enlevé ce filtre dans #2365 le temps de voir que l'on recevait bien ce genre d'erreurs (et que donc le mécanisme de lock marchait correctement). 