### PR TITLE
fix(orientation): only display relevant orgs in orientation structure select

### DIFF
--- a/app/controllers/users/orientations_controller.rb
+++ b/app/controllers/users/orientations_controller.rb
@@ -50,7 +50,10 @@ module Users
     end
 
     def set_organisations
-      @organisations = current_department.organisations.includes(:agents)
+      @organisations = current_department
+                       .organisations
+                       .where(organisation_type: Organisation::ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
+                       .includes(:agents)
     end
 
     def set_agents


### PR DESCRIPTION
Cette PR permet de n'afficher que les organisation issues du type "delegataire_rsa conseil_departemental france_travail" dans la liste des structures référentes

fix https://github.com/gip-inclusion/rdv-insertion/issues/2367