### PR TITLE
tech(perf): improve memory usage with jemalloc

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/Scalingo/jemalloc-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/ruby-buildpack

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: jemalloc.sh bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb
 postdeploy: bundle exec rake db:migrate
 worker: bundle exec sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec puma -C config/puma.rb
+web: jemalloc.sh bundle exec puma -C config/puma.rb
 postdeploy: bundle exec rake db:migrate
 worker: bundle exec sidekiq


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2304

Pour activer jemalloc dans scalingo il faut ajouter la variable d'environnement `JEMALLOC_ENABLED` à `true`.
C'est ce que j'ai fait sur staging, il faudra le faire sur les autres environnements quand on déploiera.

On pourrait aussi le faire au niveau du/des container dans le procfile : 
ex : `web: jemalloc.sh bundle exec puma -C config/puma.rb`

La doc scalingo se trouve [ici](https://doc.scalingo.com/platform/deployment/buildpacks/jemalloc).

Pour s'assurer que jemalloc fonctionne bien et avoir accès à plein de stats on peut lancer la commande suivante en bash sur les vm scalingo : 
```MALLOC_CONF=stats_print:true ruby -e \"exit\"```

<img width="857" alt="Capture d’écran 2024-10-09 à 15 07 52" src="https://github.com/user-attachments/assets/d89bacd4-a083-4471-b2df-1610cc0b4e7a">

Ci dessous, pour comparaison ultérieure les graphs mémoire de nos conteneurs scalingo entre Lundi 15h et Mercredi 15h.
Démo

<img width="1647" alt="Capture d’écran 2024-10-09 à 15 21 26" src="https://github.com/user-attachments/assets/42809993-af5d-41dd-a223-e6f8de084e07">

Prod

<img width="1647" alt="Capture d’écran 2024-10-09 à 15 21 55" src="https://github.com/user-attachments/assets/252df762-db2f-4059-aa9f-96e201573240">