### PR TITLE
fix(notif): prevent sending notifs to empty orgs

### DIFF
--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -1,8 +1,8 @@
 class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
     Department.find_each do |departement|
-      departement.organisations.each do |organisation|
-        NotifyUnavailableCreneauJob.perform_later(organisation.id)
+      departement.organisations.joins(:agents).distinct.find_each do |organisation|
+        NotifyUnavailableCreneauJob.perform_later(organisation.id) if organisation.agents.any?
       end
     end
   end

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -2,7 +2,7 @@ class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
     Department.find_each do |departement|
       departement.organisations.joins(:agents).distinct.find_each do |organisation|
-        NotifyUnavailableCreneauJob.perform_later(organisation.id) if organisation.agents.any?
+        NotifyUnavailableCreneauJob.perform_later(organisation.id)
       end
     end
   end

--- a/spec/jobs/send_creneau_availability_alert_job_spec.rb
+++ b/spec/jobs/send_creneau_availability_alert_job_spec.rb
@@ -9,7 +9,7 @@ describe SendCreneauAvailabilityAlertJob do
       before do
         departments_count.times do
           department = create(:department)
-          organisations_per_department.times do |i|
+          organisations_per_department.times do |_i|
             organisation = create(:organisation, department: department)
             agent = create(:agent)
             organisation.agents << agent

--- a/spec/jobs/send_creneau_availability_alert_job_spec.rb
+++ b/spec/jobs/send_creneau_availability_alert_job_spec.rb
@@ -2,22 +2,37 @@ describe SendCreneauAvailabilityAlertJob do
   subject { described_class.new.perform }
 
   describe "#perform" do
-    let(:departments_count) { 3 }
-    let(:organisations_per_department) { 2 }
+    context "when there are agents" do
+      let(:departments_count) { 3 }
+      let(:organisations_per_department) { 2 }
 
-    before do
-      departments_count.times do
-        department = create(:department)
-        organisations_per_department.times do
-          create(:organisation, department: department)
+      before do
+        departments_count.times do
+          department = create(:department)
+          organisations_per_department.times do |i|
+            organisation = create(:organisation, department: department)
+            agent = create(:agent)
+            organisation.agents << agent
+          end
         end
+      end
+
+      it "perform NotifyUnavailableCreneauJob for all organisations" do
+        expect(NotifyUnavailableCreneauJob).to receive(:perform_later).exactly(6).times
+
+        subject
       end
     end
 
-    it "perform NotifyUnavailableCreneauJob for all organisations" do
-      expect(NotifyUnavailableCreneauJob).to receive(:perform_later).exactly(6).times
+    context "when there are no agents" do
+      let(:department) { create(:department) }
+      let(:organisation) { create(:organisation, department: department) }
 
-      subject
+      it "does not perform NotifyUnavailableCreneauJob" do
+        expect(NotifyUnavailableCreneauJob).not_to receive(:perform_later)
+
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
cette PR fait en sorte de ne pas envoyer la notif de créneaux indispo a des orgs n'ayant pas d'agents, pour éviter ceci dans sidekiq : 
<img width="725" alt="image" src="https://github.com/user-attachments/assets/9b8285ee-b660-4e0f-82af-aa8b4c6463ce">
