### PR TITLE
fix(redirect): prevent navigation redirection

### DIFF
--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -6,7 +6,8 @@ module CurrentStructure
                   :current_structure, :current_structure_name, :current_structure_id,
                   :current_department, :current_department_name, :current_department_id,
                   :current_organisation, :current_organisation_id,
-                  :current_agent_department_organisations
+                  :current_agent_department_organisations,
+                  :current_structure_type_in_params
 
     delegate :name, to: :current_structure, prefix: true
     delegate :name, to: :current_department, prefix: true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,8 @@ module ApplicationHelper
   end
 
   def show_organisation_navigation_button?
+    return false if current_page?(controller: :organisations, action: :index)
+
     current_agent_department_organisations && current_agent_department_organisations.length > 1
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def show_organisation_navigation_button?
-    return false if current_page?(organisations_path)
+    return false if current_structure_type_in_params.blank?
 
     current_agent_department_organisations && current_agent_department_organisations.length > 1
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def show_organisation_navigation_button?
-    return false if current_page?(controller: :organisations, action: :index)
+    return false if current_page?(organisations_path)
 
     current_agent_department_organisations && current_agent_department_organisations.length > 1
   end


### PR DESCRIPTION
Cette PR permet de ne pas afficher le bandeau de navigation par orga lorsque l'on a pas choisi d'organisation

Devrait au passage fixer https://github.com/gip-inclusion/rdv-insertion/issues/2391