### PR TITLE
feat(invitations): Change non invited page display

### DIFF
--- a/app/blueprints/address_geocoding_blueprint.rb
+++ b/app/blueprints/address_geocoding_blueprint.rb
@@ -1,0 +1,3 @@
+class AddressGeocodingBlueprint < ApplicationBlueprint
+  fields :post_code, :city
+end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -27,6 +27,7 @@ class UserBlueprint < ApplicationBlueprint
     association :organisations, blueprint: OrganisationBlueprint
     association :referents, blueprint: AgentBlueprint
     association :archives, blueprint: ArchiveBlueprint
+    association :address_geocoding, blueprint: AddressGeocodingBlueprint
 
     policy_scoped_association :invitations, blueprint: InvitationBlueprint
     policy_scoped_association :follow_ups, blueprint: FollowUpBlueprint

--- a/app/controllers/users/searches_controller.rb
+++ b/app/controllers/users/searches_controller.rb
@@ -14,9 +14,9 @@ module Users
         .active
         .where(id: search_in_all_users.ids + search_in_department_organisations.ids)
         .preload(
-          :referents, :archives,
+          :referents, :archives, :address_geocoding,
           invitations: [follow_up: :motif_category],
-          follow_ups: [:participations],
+          follow_ups: [participations: :rdv],
           tags: [:tag_organisations],
           organisations: [:motif_categories, :department, :category_configurations]
         ).distinct

--- a/app/javascript/react/components/user/EditableCell.jsx
+++ b/app/javascript/react/components/user/EditableCell.jsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react-lite";
 import Tippy from "@tippyjs/react";
 import EditableTags from "./EditableTags";
 
-function EditableCell({ user, cell, type, values }) {
+function EditableCell({ user, cell, type, values, labelClassName = "", labelStyle = {} }) {
   const [isEditing, setIsEditing] = useState(false);
   const [isEditingTags, setIsEditingTags] = useState(false);
 
@@ -58,7 +58,7 @@ function EditableCell({ user, cell, type, values }) {
         ))}
       </select>
     );
-    label = values.find((el) => el.value === user[cell])?.key || " - ";
+    label = <span>{values.find((el) => el.value === user[cell])?.key || " - "}</span>;
   } else if (type === "tags") {
     const userTags = user[cell].map(tag => tag.toLowerCase())
     const existingTags = values.filter((tag) => userTags.includes(tag.toLowerCase()));
@@ -77,6 +77,11 @@ function EditableCell({ user, cell, type, values }) {
       </div>
     );
   } else {
+    label = (
+      <div className={labelClassName} style={labelStyle} >
+        {user[cell] || " - "}
+      </div >
+    );
     input = (
       <input
         type="text"
@@ -101,8 +106,13 @@ function EditableCell({ user, cell, type, values }) {
         user.triggers[`${cell}Update`] ? "En cours..." : "Double-cliquez pour modifier",
       ].join("")}
     >
-      <div onDoubleClick={handleDoubleClick} onBlur={handleBlur} style={{ cursor: "pointer" }}>
-        {isEditing ? input : <span>{label}</span>}
+      <div
+        onDoubleClick={handleDoubleClick}
+        onBlur={handleBlur}
+        className="d-flex justify-content-center align-items-center"
+        style={{ cursor: "pointer" }}
+      >
+        {isEditing ? input : label}
         {isEditingTags ? (
           <EditableTags
             user={user}

--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -71,6 +71,8 @@ export default class User {
     this.linkedOrganisationSearchTerms = formattedAttributes.linkedOrganisationSearchTerms;
     this.referentEmail = formattedAttributes.referentEmail || currentAgent?.email;
     this.tags = attributes.tags || [];
+    this.addressGeocoding = attributes.addressGeocoding
+
 
     this.currentAgent = currentAgent;
     this.department = department;

--- a/app/javascript/react/models/Users.jsx
+++ b/app/javascript/react/models/Users.jsx
@@ -42,14 +42,14 @@ class Users {
           </>
         ),
         content: ({ user }) => (
-            <input
-              type="checkbox"
-              className="form-check-input"
-              checked={Boolean(user.selected)}
-              onChange={(event) => {
-                user.selected = event.target.checked;
-              }}
-            />
+          <input
+            type="checkbox"
+            className="form-check-input"
+            checked={Boolean(user.selected)}
+            onChange={(event) => {
+              user.selected = event.target.checked;
+            }}
+          />
         )
       },
       {
@@ -81,15 +81,22 @@ class Users {
         content: ({ user }) => <EditableCell type="text" user={user} cell="lastName" />
       },
       {
+        name: "Ville",
+        sortable: true,
+        key: "city",
+        visible: this.sourcePage === "batchActions",
+        content: ({ user }) => user.addressGeocoding?.city ?? " - "
+      },
+      {
         name: "Numéro CAF",
-        visible: this.sourcePage === "upload" && this.fileColumnNames?.affiliation_number_column,
+        visible: (this.sourcePage === "upload" && this.fileColumnNames?.affiliation_number_column) || this.sourcePage === "batchActions",
         content: ({ user }) => <EditableCell type="text" user={user} cell="affiliationNumber" />
       },
       {
         name: "Rôle",
         sortable: true,
         key: "role",
-        visible: (this.sourcePage === "upload" && this.fileColumnNames?.role_column) || this.sourcePage === "batchActions",
+        visible: this.sourcePage === "upload" && this.fileColumnNames?.role_column,
         content: ({ user }) => (
           <EditableCell
             user={user}
@@ -122,7 +129,14 @@ class Users {
         key: "email",
         isInContactFile: true,
         visible: (this.sourcePage === "upload" && this.fileColumnNames?.email_column) || this.sourcePage === "batchActions",
-        content: ({ user }) => <EditableCell user={user} cell="email" />
+        content: ({ user }) => (
+          <EditableCell
+            user={user}
+            cell="email"
+            labelClassName={this.sourcePage === "batchActions" ? "text-truncate" : ""}
+            labelStyle={this.sourcePage === "batchActions" ? { maxWidth: "100px" } : {}}
+          />
+        )
       },
       {
         name: "Téléphone",

--- a/app/javascript/react/pages/users/BatchActions.jsx
+++ b/app/javascript/react/pages/users/BatchActions.jsx
@@ -53,7 +53,8 @@ const UsersBatchActions = observer(
             birthName: userFromApp.birth_name,
             departmentInternalId: userFromApp.department_internal_id,
             rightsOpeningDate: formatDateInput(userFromApp.rights_opening_date),
-            referentEmail: userFromApp.referent_email
+            referentEmail: userFromApp.referent_email,
+            addressGeocoding: userFromApp.address_geocoding
           },
           department,
           organisation,
@@ -72,13 +73,13 @@ const UsersBatchActions = observer(
         <div className="container mt-5 mb-3">
           <div className="row card-white justify-content-center">
             <div className="col-4 text-center d-flex align-items-center justify-content-start">
-                <button
-                  type="submit"
-                  className="btn btn-secondary btn-blue-out"
-                  onClick={redirectToUsersList}
-                >
-                  Retour au suivi
-                </button>
+              <button
+                type="submit"
+                className="btn btn-secondary btn-blue-out"
+                onClick={redirectToUsersList}
+              >
+                Retour au suivi
+              </button>
             </div>
             <div className="col-4 text-center">
               <h2 className="text-center new-users-title">Envoyer des invitations aux usagers non-invités</h2>
@@ -86,9 +87,14 @@ const UsersBatchActions = observer(
             <div className="col-4" />
           </div>
           <div className="row my-3" style={{ height: 50 }}>
-            <div className="d-flex justify-content-end align-items-center">
-              <BatchActionsButtons users={users} />
-              <DisplayReferentsColumnButton users={users} />
+            <div className="d-flex justify-content-between align-items-center">
+              <div>
+                {`${users.list.length} usagers non-invités`}
+              </div>
+              <div className="d-flex justify-content-end">
+                <BatchActionsButtons users={users} />
+                <DisplayReferentsColumnButton users={users} />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
closes #2292 

J'ajoute quelques améliorations à la page d'invitation des non invités:

* On n'affiche toujours la colonne numéro CAF
* On n'affiche plus la colonne Rôle
* On rajoute la colonne commune
* On truncate les adresses mails des usagers
* On afficher un compteur sur le nombre d'usager présents sur la page

Preview 📸 :  
<img width="1664" alt="image" src="https://github.com/user-attachments/assets/cb4a82dd-c4c3-43f2-9580-8cee4cc87702">
