### PR TITLE
feat(impersonate): add impersonation warning

### DIFF
--- a/app/helpers/impersonation_helper.rb
+++ b/app/helpers/impersonation_helper.rb
@@ -1,0 +1,12 @@
+module ImpersonationHelper
+  def with_rdvs_impersonation_warning(url)
+    return {} unless agent_impersonated?
+
+    {
+      data: {
+        turbo_confirm: true,
+        turbo_confirm_template: raw(render("common/rdvs_impersonation_warning", url:)) # rubocop:disable Rails/OutputSafety
+      }
+    }
+  end
+end

--- a/app/helpers/impersonation_helper.rb
+++ b/app/helpers/impersonation_helper.rb
@@ -1,5 +1,5 @@
 module ImpersonationHelper
-  def with_rdvs_impersonation_warning(url)
+  def with_rdv_solidarites_impersonation_warning(url)
     return {} unless agent_impersonated?
 
     {

--- a/app/javascript/components/confirm-modal.js
+++ b/app/javascript/components/confirm-modal.js
@@ -8,6 +8,10 @@ class ConfirmModal {
   }
 
   checkForExternalConfirmLinks() {
+    // Turbo automatically handles confirmation of internal links (those handled by Rails)
+    // but by default there's no way to handle confirmation of external links.
+    // This code automatically detects external links with a data-turbo-confirm attribute
+    // and shows the confirmation modal when they are clicked.
     document.querySelectorAll("[data-turbo-confirm]").forEach((element) => {
       if (element.target !== "_blank") return;
 

--- a/app/javascript/components/confirm-modal.js
+++ b/app/javascript/components/confirm-modal.js
@@ -4,6 +4,20 @@ class ConfirmModal {
   constructor() {
     this.modalPartial = document.querySelector("#confirm-modal");
     window.Turbo.setConfirmMethod(this.confirm.bind(this));
+    this.checkForExternalConfirmLinks();
+  }
+
+  checkForExternalConfirmLinks() {
+    document.querySelectorAll("[data-turbo-confirm]").forEach((element) => {
+      if (element.target !== "_blank") return;
+
+      element.addEventListener("click", (event) => {
+        event.preventDefault();
+        this.confirm(element.getAttribute("data-turbo-confirm"), element).then(() => {
+          this.modal.hide();
+        });
+      });
+    });
   }
 
   confirm(message, triggerElement) {

--- a/app/views/category_configurations/index.html.erb
+++ b/app/views/category_configurations/index.html.erb
@@ -6,7 +6,7 @@
       <%= link_to(@back_to_users_list_url || structure_users_path) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
-      <%= link_to @organisation.rdv_solidarites_url, target: "_blank" do %>
+      <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(@organisation.rdv_solidarites_url) do %>
         <button class="btn btn-blue">Voir sur RDV-Solidarités<i class="fas fa-external-link-alt icon-sm"></i></button>
       <% end %>
     </div>

--- a/app/views/category_configurations/index.html.erb
+++ b/app/views/category_configurations/index.html.erb
@@ -6,7 +6,7 @@
       <%= link_to(@back_to_users_list_url || structure_users_path) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
-      <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(@organisation.rdv_solidarites_url) do %>
+      <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning(@organisation.rdv_solidarites_url) do %>
         <button class="btn btn-blue">Voir sur RDV-Solidarités<i class="fas fa-external-link-alt icon-sm"></i></button>
       <% end %>
     </div>

--- a/app/views/common/_rdvs_impersonation_warning.html.erb
+++ b/app/views/common/_rdvs_impersonation_warning.html.erb
@@ -1,0 +1,19 @@
+<div class="modal-header">
+  <h5 class="modal-title">
+    Vous êtes sur le point d'ouvrir RDV-Solidarités
+  </h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+  <div id="custom-body" class="w-100 mb-3">
+    Vous allez être redirigé sur RDV-Solidarités avec votre compte RDV-S. Pour continuer à naviguer "en tant que", rendez-vous dans le Superadmin RDV-S.
+  </div>
+  <div class="d-flex justify-content-end align-items-center px-3">
+    <a href="<%= ENV["RDV_SOLIDARITES_URL"] %>/super_admins" target="_blank" class="btn btn-blue-out border-0 me-2">
+      Aller sur le super admin RDV-S
+    </a>
+    <a href="<%= url %>" target="_blank" id="confirm-button" class="btn btn-blue me-2">
+      Ouvrir RDV-Solidarités
+    </a>
+  </div>
+</div>

--- a/app/views/convocations/new.html.erb
+++ b/app/views/convocations/new.html.erb
@@ -14,10 +14,10 @@
   <%= render "common/remote_modal", title: "Choix du type de rdv" do %>
     <h6 class="text-center mb-5">S'agit-il d'un rdv individuel ou d'un rdv collectif ?</h6>
     <div class="d-flex justify-content-between">
-      <%= link_to @convocation_links_by_type[:individuel], target: "_blank" do %>
+      <%= link_to @convocation_links_by_type[:individuel], target: "_blank", **with_rdv_solidarites_impersonation_warning(@convocation_links_by_type[:individuel]) do %>
         <button class="btn btn-blue-out" type="button">Rdv individuel <i class="fas fa-external-link-alt icon-sm"></i></button>
       <% end %>
-      <%= link_to @convocation_links_by_type[:collectif], target: "_blank" do %>
+      <%= link_to @convocation_links_by_type[:collectif], target: "_blank", **with_rdv_solidarites_impersonation_warning(@convocation_links_by_type[:individuel]) do %>
         <button class="btn btn-blue-out" type="button">Rdv collectif <i class="fas fa-external-link-alt icon-sm"></i></button>
       <% end %>
     </div>

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -68,7 +68,7 @@
                     </td>
                     <td class="px-4 py-3">
                       <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
-                        <%= link_to participation.rdv_solidarites_url, target: "_blank" do %>
+                        <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(participation.rdv_solidarites_url) do %>
                           <button class="btn btn-blue">
                             Voir sur RDV-S<i class="fas fa-external-link-alt icon-sm"></i>
                           </button>

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -68,7 +68,7 @@
                     </td>
                     <td class="px-4 py-3">
                       <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
-                        <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(participation.rdv_solidarites_url) do %>
+                        <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning(participation.rdv_solidarites_url) do %>
                           <button class="btn btn-blue">
                             Voir sur RDV-S<i class="fas fa-external-link-alt icon-sm"></i>
                           </button>

--- a/app/views/users/_find_rdv_button.html.erb
+++ b/app/views/users/_find_rdv_button.html.erb
@@ -3,7 +3,7 @@
     <button class="btn btn-blue dropdown-toggle accessible" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">Trouver un RDV</button>
     <div data-dropdown-menu-target="dropdown" class="dropdown-menu">
       <% mutual_department_organisations(@user, current_agent, @department).each do |organisation| %>
-        <%= link_to new_user_rdv_path(@user, organisation_id: organisation.id), target: "_blank", class: "dropdown-item py-3 d-flex justify-content-between" do %>
+        <%= link_to new_user_rdv_path(@user, organisation_id: organisation.id), target: "_blank", class: "dropdown-item py-3 d-flex justify-content-between", **with_rdv_solidarites_impersonation_warning(new_user_rdv_path(@user, organisation_id: organisation.id)) do %>
           Sur l'organisation <%= organisation.name %>
           <i class="fas ms-5 me-1 fa-external-link-alt text-dark-blue"></i>
         <% end %>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -101,7 +101,7 @@
     </h4>
     <% unless department_level? %>
       <div class="mt-2">
-        <%= link_to @organisation.rdv_solidarites_url, target: "_blank" do %>
+        <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(@organisation.rdv_solidarites_url) do %>
           <button class="btn btn-blue">Voir sur RDV-Solidarités<i class="fas fa-external-link-alt icon-sm"></i></button>
         <% end %>
       </div>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -101,7 +101,7 @@
     </h4>
     <% unless department_level? %>
       <div class="mt-2">
-        <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdvs_impersonation_warning(@organisation.rdv_solidarites_url) do %>
+        <%= link_to @organisation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning(@organisation.rdv_solidarites_url) do %>
           <button class="btn btn-blue">Voir sur RDV-Solidarités<i class="fas fa-external-link-alt icon-sm"></i></button>
         <% end %>
       </div>


### PR DESCRIPTION
Cette PR ajoute une modale de confirmation lors d'un clic sur un lien rdvs et que l'on est connecté "en tant que". 
Je tire parti de la logique associée aux modales de confirmation existantes en ajoutant la possibilité de demander une confirmation sur un lien externe à l'application. 

Pour info j'ai décidé de ne pas mettre l'illustration dans la modale car elle demandait du code spécifique, je trouve pas que ce soit une bonne utilisation de notre temps que d'en consacrer au design de cette modale 100% spécifique aux super admin, donc à nous en interne

<img width="622" alt="image" src="https://github.com/user-attachments/assets/e9d904e8-f731-4905-a86d-b43233b78d1e">


Fix https://github.com/gip-inclusion/rdv-insertion/issues/2254