### PR TITLE
feat(superadmin): improve superadmin header

### DIFF
--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -7,6 +7,7 @@
 module SuperAdmins
   class ApplicationController < Administrate::ApplicationController
     include AuthenticatedControllerConcern
+    include SuperAdmins::Impersonate
     include SuperAdmins::RedirectAndRenderConcern
     # Needed to generate ActiveStorage urls locally, it sets the host and protocol
     include ActiveStorage::SetCurrent unless Rails.env.production?
@@ -15,6 +16,11 @@ module SuperAdmins
 
     def authenticate_super_admin!
       return if current_agent.super_admin?
+
+      if agent_impersonated?
+        unimpersonate_agent
+        return
+      end
 
       redirect_to root_path, alert: "Vous n'avez pas accès à cette page"
     end

--- a/app/helpers/sign_out_helper.rb
+++ b/app/helpers/sign_out_helper.rb
@@ -1,21 +1,11 @@
 module SignOutHelper
   def sign_out_link
-    if agent_impersonated?
-      { url: super_admins_agent_impersonation_path(agent_id: current_agent.id), options: { method: :delete } }
-    elsif logged_with_inclusion_connect?
+    if logged_with_inclusion_connect?
       { url: inclusion_connect_sign_out_path, options: { data: { turbo: false } } }
     elsif logged_with_agent_connect?
       { url: agent_connect_logout_path, options: { data: { turbo: false } } }
     else
       { url: sign_out_path, options: { method: :delete } }
-    end
-  end
-
-  def sign_out_button_text
-    if agent_impersonated?
-      "Revenir à ma session"
-    else
-      "Se déconnecter"
     end
   end
 end

--- a/app/javascript/controllers/super_admin_header_controller.js
+++ b/app/javascript/controllers/super_admin_header_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    if (localStorage.getItem("super-admin-header-closed") === "true")
+      this.hide()
+    else
+      this.show();    
+  }
+
+  toggle() {
+    if (this.element.classList.contains("hidden"))
+      this.show()
+    else
+      this.hide();
+  }
+
+  show() {
+    this.element.classList.remove("hidden");
+    localStorage.setItem("super-admin-header-closed", "false");
+  }
+
+  hide() {
+    this.element.classList.add("hidden");
+    localStorage.setItem("super-admin-header-closed", "true");
+  }
+}

--- a/app/javascript/stylesheets/components/_navbar.scss
+++ b/app/javascript/stylesheets/components/_navbar.scss
@@ -15,18 +15,57 @@ header {
   margin-left: 15px;
 }
 
+
 .sub-header {
-  height: 40px;
+  height: 50px;
   display: flex;
   align-items: center;
   justify-content: left;
-  border-top: 1px solid $dark-grey;
+  background-color: #C0DAF4;
   position: relative;
   z-index: 2;
-  p, a {
-    font-size: 12px;
-    color: black;
+
+  &.hidden {
+    height: 0px;
+    .sub-header-content {
+      display: none !important;
+    }
+    #toggle-navbar {
+      top: 0px;
+    }
   }
+
+  #toggle-navbar {
+    right: 50px;
+    top: 45px;
+    width: 45px;
+    height: 30px;
+    justify-content: center;
+    display: flex;
+    background-color: #C0DAF4;
+    align-items: center;
+    border-radius: 0px 0px 10px 10px;
+  }
+
+  p, a, button {
+    color: #083B66;
+  }
+  a {
+    border-bottom: 2px solid;
+    padding-bottom: 1px;
+  }
+
+  &.dark-blue-style {
+    background-color: #1876D0;
+
+    p, a, button {
+      color: white;
+    }
+    #toggle-navbar {
+      background-color: #1876D0;
+    }
+  }
+
 }
 
 .nav {

--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -1,4 +1,42 @@
 <header>
+  <% if current_agent.super_admin? || agent_impersonated? %>
+    <div class="sub-header d-flex <%= agent_impersonated? ? "dark-blue-style" : "" %>" data-controller="super-admin-header">
+      <div class="container d-flex position-relative sub-header-content">
+        <div class="container d-flex justify-content-start px-3">
+          <% if agent_impersonated? %>
+            <p class="mb-0">Vous êtes connecté.e en tant que <%= current_agent.to_s %></p>
+          <% else %>
+            <p class="mb-0">Bonjour <%= current_agent.first_name %>, voulez-vous accéder au SuperAdmin ?</p>
+          <% end %>
+        </div>
+        <div class="container d-flex justify-content-end px-4">
+          <% if agent_impersonated? %>
+            <p class="mb-0">
+              <%= link_to super_admins_root_path, class: "me-5" do %>
+                <i class="fas fa-shield-alt me-1"></i>
+                Revenir au Super admin
+              <% end %>
+
+              <%= link_to super_admins_agent_impersonation_path(agent_id: current_agent.id), method: :delete do %>
+                <i class="fas fa-user me-1"></i>
+                Revenir à ma session
+              <% end %>
+            </p>
+          <% else %>
+            <p class="mb-0">
+              <%= link_to super_admins_root_path do %>
+                <i class="fas fa-shield-alt me-1"></i>
+                Accéder au Super admin
+              <% end %>
+            </p>
+          <% end %>
+        </div>
+      </div>
+      <button type="button" id="toggle-navbar" class="position-absolute" data-action="click->super-admin-header#toggle">
+        <i class="fas fa-shield-alt"></i>
+      </button>
+    </div>
+  <% end %>
   <nav class="container navbar px-3 navbar-expand-lg">
     <div class="d-flex justify-content-start">
       <%= link_to root_path do %>
@@ -8,16 +46,7 @@
     </div>
     <div class="nav col justify-content-end align-items-center">
       <% if current_agent %>
-        <% if current_agent.super_admin? %>
-          <%= link_to super_admins_root_path do %>
-            <button class="btn btn-header border-light-grey w-100">
-              <span class="d-none d-sm-inline">Super admin</span>
-              <span class="d-inline d-sm-none"><i class="fas fa-sign-out-alt"></i></span>
-            </button>
-          <% end %>
-        <% else %>
-          <%= render "common/header_help_menu" %>
-        <% end %>
+        <%= render "common/header_help_menu" %>
         <% if show_organisation_navigation_button? %>
           <%= render "common/header_organisation_navigation_button" %>
         <% end %>
@@ -27,11 +56,4 @@
       <% end %>
     </div>
   </nav>
-  <% if current_agent && agent_impersonated? %>
-    <div class="sub-header d-flex">
-      <div class="container d-flex justify-content-center">
-        <p class="mb-0"><i class="fas fa-info-circle"></i> Vous êtes connecté.e en tant que <%= current_agent.to_s %></p>
-      </div>
-    </div>
-  <% end %>
 </header>

--- a/app/views/common/_sign_out_button.html.erb
+++ b/app/views/common/_sign_out_button.html.erb
@@ -1,6 +1,6 @@
 <%= link_to sign_out_link[:url], sign_out_link[:options] do %>
   <button class="btn btn-header border-light-grey w-100">
-    <span class="d-none d-sm-inline"><%= sign_out_button_text %></span>
+    <span class="d-none d-sm-inline">Se déconnecter</span>
     <span class="d-inline d-sm-none"><i class="fas fa-sign-out-alt"></i></span>
   </button>
 <% end %>


### PR DESCRIPTION
Cette PR ajout un bandeau de super admin, remet le header classique tel qu'il est pour les non super admins et modifie le comportement lors d'un retour au super admin depuis une session impersonated. 

<img width="1647" alt="Screenshot 2024-10-22 at 12 26 35" src="https://github.com/user-attachments/assets/a53417eb-e398-4a0f-aa8d-df2da3f4439d">
<img width="1618" alt="Screenshot 2024-10-22 at 12 26 24" src="https://github.com/user-attachments/assets/9ee4e465-6742-49a8-8884-eaebd75f6562">


Fix https://github.com/gip-inclusion/rdv-insertion/issues/2256
Fix https://github.com/gip-inclusion/rdv-insertion/issues/2255