### PR TITLE
ux(filters): add collapse button for filters in index

### DIFF
--- a/app/javascript/controllers/index_filters_controller.js
+++ b/app/javascript/controllers/index_filters_controller.js
@@ -2,8 +2,15 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
-    if (this.element.clientHeight > 200 && !window.location.href.includes("expanded-filters=true")) {
-      this.element.classList.add("is-clipped");
+    const isExpandedInUrl = window.location.href.includes("expanded-filters=true");
+    const exceedsMaxHeight = this.element.clientHeight > 200;
+
+    if (exceedsMaxHeight) {
+      if (isExpandedInUrl) {
+        this.element.classList.add("is-expanded");
+      } else {
+        this.element.classList.add("is-collapsed");
+      }
     }
 
     this.element.querySelectorAll("input[type=checkbox]").forEach((checkbox) => {
@@ -14,13 +21,22 @@ export default class extends Controller {
         this.setInitialValue(checkbox);
         this.attachListeners(checkbox);
       }
-    })
+    });
   }
 
   expand() {
-    this.element.classList.remove("is-clipped");
+    this.element.classList.remove("is-collapsed");
+    this.element.classList.add("is-expanded");
     const url = new URL(window.location.href);
     url.searchParams.set("expanded-filters", "true");
+    window.history.replaceState({}, "", url);
+  }
+
+  collapse() {
+    this.element.classList.remove("is-expanded");
+    this.element.classList.add("is-collapsed");
+    const url = new URL(window.location.href);
+    url.searchParams.delete("expanded-filters");
     window.history.replaceState({}, "", url);
   }
 
@@ -43,7 +59,7 @@ export default class extends Controller {
   attachListeners(checkbox) {
     checkbox.addEventListener("change", () => {
       const url = new URL(window.location.href);
-  
+
       if (checkbox.checked) {
         url.searchParams.set(checkbox.name, true);
       } else {

--- a/app/javascript/stylesheets/components/_index_filters.scss
+++ b/app/javascript/stylesheets/components/_index_filters.scss
@@ -2,11 +2,28 @@
   display: none;
 }
 
-.is-clipped {
+.collapse-button-container {
+  display: none;
+}
+
+.is-expanded {
+  position: relative;
+
+  .collapse-button-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+.is-collapsed {
   overflow: hidden;
   max-height: 200px;
   position: relative;
-  
+
   .expand-button-container {
     display: flex;
     justify-content: center;

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -81,6 +81,11 @@
           <i class="fas fa-arrow-down"></i> Voir plus de filtres
         </button>
       </div>
+      <div class="collapse-button-container">
+        <button data-action="index-filters#collapse">
+          <i class="fas fa-arrow-up"></i> Voir moins de filtres
+        </button>
+      </div>
       <% if display_back_to_list_button? %>
         <div>
           <%= link_to structure_users_path(motif_category_id: @current_motif_category&.id, users_scope: @users_scope), class: "btn btn-blue-out" do %>


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2373

On ajoute le bouton "Voir moins de filtres" quand la liste des tags est déroulée

## Captures d'écran

Avant | Après
:- | -:
<img width="1058" alt="Capture d’écran 2024-10-22 à 15 39 14" src="https://github.com/user-attachments/assets/69a8c524-fd4a-4ab8-973c-448736be4db3">|<img width="1058" alt="Capture d’écran 2024-10-22 à 15 37 34" src="https://github.com/user-attachments/assets/8148398e-1589-43f1-83f2-6e294ed142a1">


"Voir plus de filtres" ne change pas.

<img width="1058" alt="Capture d’écran 2024-10-22 à 15 37 21" src="https://github.com/user-attachments/assets/adb30003-6b88-4411-bb66-b38a3b124e90">
