### PR TITLE
rgpd(archives): remover users from organisations after 2 years of archiving

### DIFF
--- a/app/jobs/remove_organisation_user_for_expired_archive_job.rb
+++ b/app/jobs/remove_organisation_user_for_expired_archive_job.rb
@@ -1,0 +1,29 @@
+class RemoveOrganisationUserForExpiredArchiveJob < ApplicationJob
+  def perform(archive_id)
+    @archive = Archive.find(archive_id)
+    @organisation = @archive.organisation
+    @user = @archive.user
+
+    return no_agent_found unless @organisation.agents.any?
+
+    remove_user_from_organisation
+  end
+
+  private
+
+  def no_agent_found
+    Sentry.capture_message(
+      "No agent found for organisation #{@organisation.id} when trying to remove user #{@user.id}"
+    )
+  end
+
+  def remove_user_from_organisation
+    @organisation.agents.first.with_rdv_solidarites_session do
+      call_service!(
+        Users::RemoveFromOrganisation,
+        user: @user,
+        organisation: @organisation
+      )
+    end
+  end
+end

--- a/app/jobs/remove_organisation_users_for_expired_archives_job.rb
+++ b/app/jobs/remove_organisation_users_for_expired_archives_job.rb
@@ -1,0 +1,20 @@
+class RemoveOrganisationUsersForExpiredArchivesJob < ApplicationJob
+  def perform
+    expired_archives.find_each do |archive|
+      RemoveOrganisationUserForExpiredArchiveJob.perform_later(archive.id)
+    end
+    notify_on_mattermost
+  end
+
+  private
+
+  def expired_archives
+    Archive.where("created_at < ?", 2.years.ago)
+  end
+
+  def notify_on_mattermost
+    MattermostClient.send_to_notif_channel(
+      "🧹 #{expired_archives.count} usagers archivés il y a plus de 2 ans ont été retirés de leurs organisations"
+    )
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,6 +28,9 @@ upsert_monthly_stats_job:
 refresh_out_of_date_follow_up_statuses_job:
   cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "RefreshOutOfDateFollowUpStatusesJob"
+remove_organisation_users_for_expired_archives_job:
+  cron: "0 23 * * *" # we remove expired archived users from organisations once a day, at 23:00
+  class: "RemoveOrganisationUsersForExpiredArchivesJob"
 destroy_old_ressources_job:
   cron: "0 0 * * *" # we destroy inactive users and useless ressources once a day, at 00:00
   class: "DestroyOldRessourcesJob"

--- a/spec/jobs/remove_organisation_user_for_expired_archive_job_spec.rb
+++ b/spec/jobs/remove_organisation_user_for_expired_archive_job_spec.rb
@@ -1,0 +1,38 @@
+describe RemoveOrganisationUserForExpiredArchiveJob do
+  subject do
+    described_class.new.perform(archive.id)
+  end
+
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation1, organisation2]) }
+  let!(:organisation1) { create(:organisation) }
+  let!(:organisation2) { create(:organisation) }
+  let!(:archived_user) { create(:user, organisations: [organisation1, organisation2]) }
+  let!(:archive) { create(:archive, user: archived_user, organisation: organisation1, created_at: 25.months.ago) }
+
+  describe "#perform" do
+    before do
+      allow(RdvSolidaritesApi::DeleteUserProfile).to receive(:call)
+        .with(
+          rdv_solidarites_user_id: archived_user.rdv_solidarites_user_id,
+          rdv_solidarites_organisation_id: organisation1.rdv_solidarites_organisation_id
+        ).and_return(OpenStruct.new(success?: true))
+    end
+
+    it "remove the user from organisation1 after 2 years of archiving" do
+      subject
+      expect(archived_user.reload.organisations).to eq([organisation2])
+    end
+
+    context "when no agent found" do
+      before do
+        organisation1.agents.destroy_all
+      end
+
+      it "logs a message" do
+        expect(Sentry).to receive(:capture_message)
+          .with("No agent found for organisation #{organisation1.id} when trying to remove user #{archived_user.id}")
+        subject
+      end
+    end
+  end
+end

--- a/spec/jobs/remove_organisation_users_for_expired_archives_job_spec.rb
+++ b/spec/jobs/remove_organisation_users_for_expired_archives_job_spec.rb
@@ -1,0 +1,30 @@
+describe RemoveOrganisationUsersForExpiredArchivesJob do
+  subject do
+    described_class.new.perform
+  end
+
+  let!(:agent) { create(:agent, admin_role_in_organisations: organisations) }
+  let!(:organisation1) { create(:organisation) }
+  let!(:organisation2) { create(:organisation) }
+  let!(:organisation3) { create(:organisation) }
+  let!(:organisation4) { create(:organisation) }
+  let!(:organisations) { [organisation1, organisation2, organisation3, organisation4] }
+  let!(:archived_user) { create(:user, organisations: organisations) }
+  let!(:old_archive1) { create(:archive, user: archived_user, organisation: organisation1, created_at: 25.months.ago) }
+  let!(:old_archive2) { create(:archive, user: archived_user, organisation: organisation2, created_at: 26.months.ago) }
+  let!(:archive3) { create(:archive, user: archived_user, organisation: organisation3, created_at: 1.month.ago) }
+  let!(:archive4) { create(:archive, user: archived_user, organisation: organisation4) }
+
+  describe "#perform" do
+    it "enqueues remove organisation job for each expired archive" do
+      expect(RemoveOrganisationUserForExpiredArchiveJob).to receive(:perform_later)
+        .with(old_archive1.id)
+      expect(RemoveOrganisationUserForExpiredArchiveJob).to receive(:perform_later)
+        .with(old_archive2.id)
+      expect(MattermostClient).to receive(:send_to_notif_channel).with(
+        "🧹 2 usagers archivés il y a plus de 2 ans ont été retirés de leurs organisations"
+      )
+      subject
+    end
+  end
+end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2290

On log une erreur si l'organisation de l'archive ne contient pas d'agent (nécessaire pour la connexion à rdvsp).
En lien avec cette PR il y a cette issue qu'on pourra traiter (dans une autre pr) : https://github.com/gip-inclusion/rdv-insertion/issues/2422