### PR TITLE
fix(ux): better display for less tag filter

### DIFF
--- a/app/javascript/stylesheets/components/_index_filters.scss
+++ b/app/javascript/stylesheets/components/_index_filters.scss
@@ -15,7 +15,7 @@
     align-items: center;
     width: 100%;
     position: absolute;
-    bottom: 0;
+    bottom: -15px;
   }
 }
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="674" alt="Capture d’écran 2024-10-31 à 11 10 32" src="https://github.com/user-attachments/assets/027eebd8-a36d-422d-8ed7-7cfc52028a4f">|<img width="674" alt="Capture d’écran 2024-10-31 à 11 09 30" src="https://github.com/user-attachments/assets/d447a3a6-6adf-490e-8e61-f552e884d3a4">
