### PR TITLE
fix(users): Validation de l'usager sur le phone_number_formatted

### DIFF
--- a/app/services/users/validate.rb
+++ b/app/services/users/validate.rb
@@ -9,7 +9,7 @@ module Users
       validate_uid_uniqueness_inside_department if @user.affiliation_number? && @user.role?
       validate_department_internal_id_uniqueness if @user.department_internal_id?
       validate_email_and_first_name_uniquess if @user.email?
-      validate_phone_number_and_first_name_uniqueness if @user.phone_number?
+      validate_phone_number_and_first_name_uniqueness if @user.phone_number_formatted.present?
     end
 
     private


### PR DESCRIPTION
closes #2402 

## Explication 

Lorsqu'on essayait de créer un usager avec un faux numéro de téléphone, `@user.phone_number` était présent alors que `@user.phone_number_formatted` était `nil`.
Du coup dans le service `Users::Validate`, la méthode `validate_phone_number_and_first_name_uniqueness` était appelé dans ce cas, or elle fait une recherche dans la bdd via le `phone_number_formatted`. Du coup on cherchait des usagers qui avait le même prénom que l'usager qu'on était en train de créer et dont le numéro de téléphone est `nil`. On en trouvait donc beaucoup, ce qui faisait échouer le serivce `Users::Validate`.

## Solution

On appelle `validate_phone_number_and_first_name_uniqueness` que si le numéro de téléphone formatté (celui qui sera sauvé en db) est présent.