### PR TITLE
feat(organisations): Mark organisation as archived

### DIFF
--- a/app/controllers/users/orientations_controller.rb
+++ b/app/controllers/users/orientations_controller.rb
@@ -52,6 +52,7 @@ module Users
     def set_organisations
       @organisations = current_department
                        .organisations
+                       .active
                        .where(organisation_type: Organisation::ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
                        .includes(:agents)
     end

--- a/app/controllers/users_organisations_controller.rb
+++ b/app/controllers/users_organisations_controller.rb
@@ -58,7 +58,7 @@ class UsersOrganisationsController < ApplicationController
   end
 
   def set_organisations
-    @organisations = @department.organisations.includes(:motif_categories)
+    @organisations = @department.organisations.active.includes(:motif_categories)
   end
 
   def set_user_organisations

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -9,7 +9,7 @@ module InboundWebhooks
         @data = data.deep_symbolize_keys
         @meta = meta.deep_symbolize_keys
 
-        return if organisation.blank? || @data[:access_level] == "intervenant"
+        return if organisation.blank? || organisation.archived? || @data[:access_level] == "intervenant"
 
         # This is necessary when the agent role has been created through rdv-i without the rdv-s record
         # when importing an organisation

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -1,7 +1,7 @@
 class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
     Department.find_each do |departement|
-      departement.organisations.joins(:agents).distinct.find_each do |organisation|
+      departement.organisations.active.distinct.find_each do |organisation|
         NotifyUnavailableCreneauJob.perform_later(organisation.id)
       end
     end

--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -7,10 +7,18 @@ class AgentRole < ApplicationRecord
   validates :rdv_solidarites_agent_role_id, uniqueness: true, allow_nil: true
   validates :agent, uniqueness: { scope: :organisation, message: "est déjà relié à l'organisation" }
 
+  validate :organisation_is_not_archived, on: :create
+
   enum access_level: { basic: "basic", admin: "admin" }
 
   scope :authorized_to_export_csv, -> { where(authorized_to_export_csv: true) }
   scope :with_last_name, -> { joins(:agent).where.not(agents: { last_name: nil }) }
 
   before_save -> { self.authorized_to_export_csv = admin? }, if: :access_level_changed?
+
+  private
+
+  def organisation_is_not_archived
+    errors.add(:organisation, "est archivée") if organisation.archived?
+  end
 end

--- a/app/models/concerns/organisation/archivable.rb
+++ b/app/models/concerns/organisation/archivable.rb
@@ -1,0 +1,21 @@
+module Organisation::Archivable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :active, -> { where(archived_at: nil) }
+    scope :archived, -> { where.not(archived_at: nil) }
+    validate :cannot_be_archived_if_agents_present, on: :update
+  end
+
+  def archived? = archived_at.present?
+
+  def archive!
+    update!(archived_at: Time.zone.now)
+  end
+
+  private
+
+  def cannot_be_archived_if_agents_present
+    errors.add(:archived_at, "Ne peut pas être archivée si des agents sont présents") if archived_at? && agents.any?
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,8 +2,9 @@ class Organisation < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:name, :phone_number, :email].freeze
   SEARCH_ATTRIBUTES = [:name, :slug].freeze
 
-  include Searchable
   include HasLogo
+  include Searchable
+  include Organisation::Archivable
 
   before_create { build_messages_configuration }
 

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -434,6 +434,7 @@ tables:
       - updated_at
       - department_id
       - last_webhook_update_received_at
+      - archived_at
 
   - table_name: users_organisations
     non_anonymized_column_names:

--- a/db/migrate/20241031161416_add_deleted_at_to_organisations.rb
+++ b/db/migrate/20241031161416_add_deleted_at_to_organisations.rb
@@ -1,0 +1,10 @@
+class AddDeletedAtToOrganisations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :organisations, :archived_at, :datetime
+    add_index :organisations, :archived_at
+
+    up_only do
+      Organisation.where.missing(:agents).update_all(archived_at: Time.zone.now)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_07_132950) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_31_161416) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -319,6 +319,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_132950) do
     t.string "slug"
     t.string "safir_code"
     t.string "organisation_type"
+    t.datetime "archived_at"
+    t.index ["archived_at"], name: "index_organisations_on_archived_at"
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
   end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -28,9 +28,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
                    email: "josiane.balasko@gmail.com",
                    inclusion_connect_open_id_sub: "1234")
   end
-  let!(:agent_role) do
-    create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
-  end
+
   let!(:meta) do
     {
       "model" => "AgentRole",
@@ -50,12 +48,22 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
       subject
     end
 
-    it "assigns the rdv solidarites agent role id" do
-      subject
-      expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
+    context "when the agent role is created" do
+      let!(:agent_role) do
+        create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
+      end
+
+      it "assigns the rdv solidarites agent role id" do
+        subject
+        expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
+      end
     end
 
     context "for destroyed event" do
+      let!(:agent_role) do
+        create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
+      end
+
       let!(:meta) do
         {
           "model" => "AgentRole",

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -179,5 +179,14 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
         subject
       end
     end
+
+    context "when the organisation is archived" do
+      let!(:organisation) { create(:organisation, archived_at: Time.current) }
+
+      it "does not process the upsert" do
+        expect(UpsertRecordJob).not_to receive(:perform_later)
+        subject
+      end
+    end
   end
 end

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -101,4 +101,13 @@ describe AgentRole do
       end
     end
   end
+
+  describe "organisation cannot be archived" do
+    let(:organisation) { create(:organisation, archived_at: Time.current) }
+    let(:agent_role) { build(:agent_role, organisation: organisation) }
+
+    it "adds an error" do
+      expect(agent_role).not_to be_valid
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -68,4 +68,15 @@ describe Organisation do
       end
     end
   end
+
+  describe "archivable" do
+    let(:organisation) { create(:organisation, agents: [create(:agent)]) }
+
+    it "cannot be archived if agents are present" do
+      organisation.update(archived_at: Time.current)
+      expect(organisation).not_to be_valid
+      expect(organisation.errors.full_messages.to_sentence)
+        .to include("Ne peut pas être archivée si des agents sont présents")
+    end
+  end
 end


### PR DESCRIPTION
closes #2393 

Je mets en place ici une logique d'archivage des orgas pour les orgas qui ne sont plus utilisées.
Pour se faire j'ajoute une colonne `archived_at` aux `organisations` et que je set d'emblée pour toutes les organisations qui n'ont pas d'agents.

Je mets également en place une règle de validation simple: **Une organisation ne peut être archivée que si elle a été vidée de ses agents**
En effet sinon cela nous amènerait à gérer dans l'appli les orgas archivées auxquelles les agents appartient, ce qui compliquerait grandement les choses: il faudrait ne pas les afficher pour l'agent, les filtrer au moment de l'invitation etc. 
Or une organisation archivée n'a pas vocation à être utilisée par un agent.

=> Du coup la plupart des cas sont déjà réglés par la logique d'appartenance de l'agent aux organisations. 

Il y a seulement deux endroits où on récupère toutes les organisations du département (et pas juste scopées à l'agent) où l'on veut filtrer par organisations actives: 
* Au moment d'assigner une orga à l'usager
* Au moment d'assigner une structure référente à l'orientation

On s'assure également de ne pas pouvoir ajouter d'agents aux organisations archivées, en filtrant les webhooks de création d'agent roles pour ces organisations et en ajoutant en plus une règle de validation au model `AgentRole`. 
