### PR TITLE
tech(lint) Avoid unnecessary eslint runs in precommit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
+if [[ $(git status --porcelain | grep app/javascript/) ]]; then # only run the linter if the javascript files have changed
+  yarn lint
+fi


### PR DESCRIPTION
En travaillant sur https://github.com/gip-inclusion/rdv-insertion/pull/2426, je me suis souvent retrouvé à travailler uniquement sur des fichiers ruby/html, et à avoir le hook de précommit pour linter le js qui tourne alors qu'aucun fichier n'a été modifié.
Ça ajoute un peu de friction entre le commit et le push, d'où la proposition de cette pr de ne faire tourner le linter que si les fichiers ont été modifiés.