### PR TITLE
fix(preview): Fix mailer preview generation

### DIFF
--- a/lib/mailer_previews/invitation_preview.rb
+++ b/lib/mailer_previews/invitation_preview.rb
@@ -13,16 +13,16 @@ class InvitationPreview < ActionMailer::Preview
   # from current_category_configuration.***_override attributes. These methods are implemented in the Templatable concern
   invitation.define_singleton_method(:current_category_configuration) { nil }
 
-  MotifCategory.find_each do |motif_category|
-    follow_up = FollowUp.new(motif_category: motif_category, user: user)
-    invitation.follow_up = follow_up
+  MotifCategory.where.not(template_id: nil).find_each do |motif_category|
 
     define_method motif_category.short_name do
+      invitation.define_singleton_method(:motif_category) { motif_category }
       InvitationMailer.with(invitation: invitation, user: invitation.user)
                       .send("#{motif_category.template_model}_invitation")
     end
 
     define_method "#{motif_category.short_name}_rappel" do
+      invitation.define_singleton_method(:motif_category) { motif_category }
       InvitationMailer.with(invitation: invitation, user: invitation.user)
                       .send("#{motif_category.template_model}_invitation_reminder")
     end

--- a/lib/mailer_previews/invitation_preview.rb
+++ b/lib/mailer_previews/invitation_preview.rb
@@ -16,12 +16,16 @@ class InvitationPreview < ActionMailer::Preview
   MotifCategory.where.not(template_id: nil).find_each do |motif_category|
 
     define_method motif_category.short_name do
+      # we need to set the motif_category on the invitation instance to be able to use it in the mailer preview
+      # we have to do this here otherwise it will reference the last motif_category set in the loop
       invitation.define_singleton_method(:motif_category) { motif_category }
       InvitationMailer.with(invitation: invitation, user: invitation.user)
                       .send("#{motif_category.template_model}_invitation")
     end
 
     define_method "#{motif_category.short_name}_rappel" do
+      # we need to set the motif_category on the invitation instance to be able to use it in the mailer preview
+      # we have to do this here otherwise it will reference the last motif_category set in the loop
       invitation.define_singleton_method(:motif_category) { motif_category }
       InvitationMailer.with(invitation: invitation, user: invitation.user)
                       .send("#{motif_category.template_model}_invitation_reminder")

--- a/lib/mailer_previews/notification_preview.rb
+++ b/lib/mailer_previews/notification_preview.rb
@@ -12,28 +12,33 @@ class NotificationPreview < ActionMailer::Preview
   # from current_category_configuration.***_override attributes. These methods are implemented in the Templatable concern
   notification.define_singleton_method(:current_category_configuration) { nil }
 
-  MotifCategory.find_each do |motif_category|
+  MotifCategory.where.not(template_id: nil).find_each do |motif_category|
     define_method "#{motif_category.short_name}_presential_participation_created" do
+      notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("presential_participation_created")
     end
 
     define_method "#{motif_category.short_name}_presential_participation_updated" do
+      notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("presential_participation_updated")
     end
 
     define_method "#{motif_category.short_name}_by_phone_participation_created" do
+      notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("by_phone_participation_created")
     end
 
     define_method "#{motif_category.short_name}_by_phone_participation_updated" do
+      notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("by_phone_participation_updated")
     end
 
     define_method "#{motif_category.short_name}_participation_cancelled" do
+      notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("participation_cancelled")
     end

--- a/lib/mailer_previews/notification_preview.rb
+++ b/lib/mailer_previews/notification_preview.rb
@@ -14,6 +14,8 @@ class NotificationPreview < ActionMailer::Preview
 
   MotifCategory.where.not(template_id: nil).find_each do |motif_category|
     define_method "#{motif_category.short_name}_presential_participation_created" do
+      # we need to set the motif_category on the notification instance to be able to use it in the mailer preview
+      # we have to do this here otherwise it will reference the last motif_category set in the loop
       notification.define_singleton_method(:motif_category) { motif_category }
       NotificationMailer.with(notification: notification)
                         .send("presential_participation_created")


### PR DESCRIPTION
Dans le code permettant de générer dynamiquement des méthodes permettant de visualiser des previews, les messages pointaient tous vers le même template.

C'était parce que les block appelés par `define_method` ne sont appelés qu'une fois qu'on appelle la méthode en question et pas au moment d'itérer sur les `motif_categories`.
Ainsi ils faisaient tous référence à la même catégorie de motif, la dernière de la boucle.

Je fix ça en passant la catégorie de motif par valeur au sein du block passé à `define_method` et non plus par référence à l'extérieur du block. 