### PR TITLE
fix(jobs): Order rdv jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,6 +7,9 @@ class ApplicationJob < ActiveJob::Base
     set(wait: wait_time).perform_later(*)
   end
 
+  # InboundWebhooks::RdvSolidarites::ProcessRdvJob => lock:inbound_webhooks:rdv_solidarites:process_rdv_job
+  def self.base_lock_key = "lock:#{name.split('::').map(&:underscore).join(':')}"
+
   private
 
   class FailedServiceError < StandardError; end

--- a/app/jobs/concerns/locked_and_ordered_jobs.rb
+++ b/app/jobs/concerns/locked_and_ordered_jobs.rb
@@ -3,7 +3,7 @@ module LockedAndOrderedJobs
   # This will wrap the hook inside the perform_with_lock method
   prepend LockedJobs
 
-  CACHED_TIMESTAMP_EXPIRATION_TIME = 30.minutes
+  CACHED_TIMESTAMP_EXPIRATION_TIME = 1.day
 
   included do
     around_perform :perform_in_order

--- a/app/jobs/concerns/locked_and_ordered_jobs.rb
+++ b/app/jobs/concerns/locked_and_ordered_jobs.rb
@@ -3,7 +3,7 @@ module LockedAndOrderedJobs
   # This will wrap the hook inside the perform_with_lock method
   prepend LockedJobs
 
-  CACHED_TIMESTAMP_EXPIRATION_TIME = 1.day
+  CACHED_TIMESTAMP_EXPIRATION_TIME_IN_SECONDS = 1.day.to_i
 
   included do
     around_perform :perform_in_order
@@ -21,7 +21,7 @@ module LockedAndOrderedJobs
 
       yield
 
-      redis.set(cache_key, job_timestamp.to_s, ex: CACHED_TIMESTAMP_EXPIRATION_TIME)
+      redis.set(cache_key, job_timestamp.to_s, ex: CACHED_TIMESTAMP_EXPIRATION_TIME_IN_SECONDS)
     end
   end
 

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessAgentRoleJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "#{name}:#{data.dig(:agent, :id)}:#{data.dig(:organisation, :id)}"
+        "Lock::#{name}:#{data.dig(:agent, :id)}:#{data.dig(:organisation, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessAgentRoleJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "Lock::#{name}:#{data.dig(:agent, :id)}:#{data.dig(:organisation, :id)}"
+        "#{base_lock_key}:#{data.dig(:agent, :id)}:#{data.dig(:organisation, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -3,11 +3,9 @@ class WebhookProcessingJobError < StandardError; end
 module InboundWebhooks
   module RdvSolidarites
     # rubocop:disable Metrics/ClassLength
-    class ProcessRdvJob < ApplicationJob
-      include LockedJobs
-
+    class ProcessRdvJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "#{name}:#{data[:id]}"
+        "Lock::#{name}:#{data[:id]}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -5,7 +5,7 @@ module InboundWebhooks
     # rubocop:disable Metrics/ClassLength
     class ProcessRdvJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "Lock::#{name}:#{data[:id]}"
+        "#{base_lock_key}:#{data[:id]}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessReferentAssignationJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "Lock::#{name}:#{data.dig(:agent, :id)}:#{data.dig(:user, :id)}"
+        "#{base_lock_key}:#{data.dig(:agent, :id)}:#{data.dig(:user, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_referent_assignation_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessReferentAssignationJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "#{name}:#{data.dig(:agent, :id)}:#{data.dig(:user, :id)}"
+        "Lock::#{name}:#{data.dig(:agent, :id)}:#{data.dig(:user, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessUserProfileJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "Lock::#{name}:#{data.dig(:user, :id)}:#{data.dig(:organisation, :id)}"
+        "#{base_lock_key}:#{data.dig(:user, :id)}:#{data.dig(:organisation, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessUserProfileJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "#{name}:#{data.dig(:user, :id)}:#{data.dig(:organisation, :id)}"
+        "Lock::#{name}:#{data.dig(:user, :id)}:#{data.dig(:organisation, :id)}"
       end
 
       def perform(data, meta)

--- a/app/jobs/invite_user_job.rb
+++ b/app/jobs/invite_user_job.rb
@@ -4,7 +4,7 @@ class InviteUserJob < ApplicationJob
   sidekiq_options retry: 10
 
   def self.lock_key(user_id, _organisation_id, _invitation_attributes, _motif_category_attributes)
-    "#{name}:#{user_id}"
+    "#{base_lock_key}:#{user_id}"
   end
 
   def perform(user_id, organisation_id, invitation_attributes, motif_category_attributes)

--- a/app/jobs/notify_participation_to_user_job.rb
+++ b/app/jobs/notify_participation_to_user_job.rb
@@ -4,7 +4,7 @@ class NotifyParticipationToUserJob < ApplicationJob
   include LockedJobs
 
   def self.lock_key(participation_id, format, event)
-    "#{name}:#{participation_id}:#{format}:#{event}"
+    "#{base_lock_key}:#{participation_id}:#{format}:#{event}"
   end
 
   def perform(participation_id, format, event)


### PR DESCRIPTION
Certains webhooks de rdvs prennent du temps à être processés lorsque ce sont des webhooks de rdvs collectifs notamment.
Comme les jobs sont "lockés" pour un même rdv, si on reçoit beaucoup de webhooks pour le même rdvs on va avoir beaucoup dde jobs qui vont raise une erreur `WithAdvisoryLock::FailedToAcquireLock` et s'empiler dans le retry set.

J'applique donc le mécanisme d'ordering des jobs pour ne pas exécuter le job si on a déjà traité un webhook postérieur.

J'en profite pour préfixer ces clés redis par "lock" pour éviter la confusion parce que je me suis rendu compte qu'il y avait beaucoup de clé redis qui commencent par le nom du job (probablement par sidekiq / active job)