### PR TITLE
fix(policy): Fix scope in policies

### DIFF
--- a/app/policies/archive_policy.rb
+++ b/app/policies/archive_policy.rb
@@ -6,8 +6,4 @@ class ArchivePolicy < ApplicationPolicy
   def show? = create?
 
   def destroy? = create?
-
-  def resolve
-    Archive.where(organisation_id: pundit_user.organisations.pluck(:id))
-  end
 end

--- a/app/policies/category_configuration_policy.rb
+++ b/app/policies/category_configuration_policy.rb
@@ -1,7 +1,7 @@
 class CategoryConfigurationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      CategoryConfiguration.where(organisation: pundit_user.organisations)
+      scope.where(organisation_id: pundit_user.organisation_ids)
     end
   end
 end

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -20,7 +20,7 @@ class DepartmentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      Department.where(id: pundit_user.organisations.pluck(:department_id))
+      scope.where(id: pundit_user.organisations.pluck(:department_id))
     end
   end
 end

--- a/app/policies/messages_configuration_policy.rb
+++ b/app/policies/messages_configuration_policy.rb
@@ -1,7 +1,7 @@
 class MessagesConfigurationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      MessagesConfiguration.where(organisation_id: pundit_user.admin_organisations_ids)
+      scope.where(organisation_id: pundit_user.admin_organisations_ids)
     end
   end
 end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -42,7 +42,7 @@ class OrganisationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      pundit_user.organisations
+      scope.where(id: pundit_user.organisation_ids)
     end
   end
 end

--- a/spec/features/agent_can_change_navigation_level_spec.rb
+++ b/spec/features/agent_can_change_navigation_level_spec.rb
@@ -2,8 +2,11 @@ describe "Agents can sort users on index page", :js do
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }
   let!(:organisation2) { create(:organisation, department: department) }
-  let!(:agent) { create(:agent, organisations: [organisation2]) }
-  let!(:admin_agent_role) { create(:agent_role, organisation: organisation, agent: agent, access_level: "admin") }
+  let!(:other_department) { create(:department) }
+  let!(:other_department_organisation) { create(:organisation, department: other_department) }
+  let!(:agent) do
+    create(:agent, admin_role_in_organisations: [organisation, organisation2, other_department_organisation])
+  end
   let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation") }
   let!(:motif_category2) { create(:motif_category, short_name: "rsa_accompagnement", name: "RSA accompagnement") }
   let!(:category_configuration) do
@@ -31,6 +34,8 @@ describe "Agents can sort users on index page", :js do
           )
           expect(page).to have_link(organisation.name, href: organisation_users_path(organisation))
           expect(page).to have_link(organisation2.name, href: organisation_users_path(organisation2))
+          expect(page).to have_no_link(other_department_organisation.name,
+                                       href: organisation_users_path(other_department_organisation))
         end
       end
     end


### PR DESCRIPTION
## Contexte 

On a un bug qui est apparu suite à la refacto de la méthode `current_agent_department_organisations` dans #2404 .

En effet, `policy_scope(current_department.organisations)` retourne toutes les organisations de l'agent et pas celle du département seulement 😬 .

Ça a pour conséquence que toutes les organisations de tous les départements sont retournées dans la liste: 

![image](https://github.com/user-attachments/assets/4419b607-7c2e-4ac3-a3ed-ab53c96c8ceb)


Heureusement il n'y a que nous (les super admins) qui sommes sur plusieurs territoires donc le bug n'a à priori pas eu d'impact.

## Solution

Je répare la manière dont est construit le scope erroné dans l'`OrganisationPolicy` ainsi que dans les autres policies en faisant appel à la variable `scope` pour prendre en compte la requête passée en argument de la méthode `policy_scope`.