### PR TITLE
feat(superadmin): add ability to duplicate webhook

### DIFF
--- a/app/controllers/super_admins/webhook_endpoints_controller.rb
+++ b/app/controllers/super_admins/webhook_endpoints_controller.rb
@@ -1,0 +1,24 @@
+module SuperAdmins
+  class WebhookEndpointsController < SuperAdmins::ApplicationController
+    def duplicate
+      webhook_endpoint = WebhookEndpoint.find(params[:id])
+      
+      new_webhook_endpoint = webhook_endpoint.dup
+      organisation = Organisation.find_by(id: webhook_endpoint_params[:target_id])
+      new_webhook_endpoint.organisation = organisation
+
+      if new_webhook_endpoint.save
+        flash[:success] = "Le webhook a bien été dupliqué vers l'organisation : #{organisation}"
+      else
+        flash[:error] = "Impossible de dupliquer le webhook: #{new_webhook_endpoint.errors.full_messages.join(', ')}"
+      end
+      redirect_to super_admins_webhook_endpoints_path
+    end
+
+    private
+
+    def webhook_endpoint_params
+      params.require(:webhook_endpoint).permit(:target_id)
+    end
+  end
+end

--- a/app/controllers/super_admins/webhook_endpoints_controller.rb
+++ b/app/controllers/super_admins/webhook_endpoints_controller.rb
@@ -2,7 +2,7 @@ module SuperAdmins
   class WebhookEndpointsController < SuperAdmins::ApplicationController
     def duplicate
       webhook_endpoint = WebhookEndpoint.find(params[:id])
-      
+
       new_webhook_endpoint = webhook_endpoint.dup
       organisation = Organisation.find_by(id: webhook_endpoint_params[:target_id])
       new_webhook_endpoint.organisation = organisation

--- a/app/dashboards/webhook_endpoint_dashboard.rb
+++ b/app/dashboards/webhook_endpoint_dashboard.rb
@@ -15,7 +15,6 @@ class WebhookEndpointDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :organisation,
     :url,
-    :subscriptions,
-    :created_at
+    :subscriptions
   ].freeze
 end

--- a/app/dashboards/webhook_endpoint_dashboard.rb
+++ b/app/dashboards/webhook_endpoint_dashboard.rb
@@ -1,0 +1,21 @@
+require "administrate/base_dashboard"
+
+class WebhookEndpointDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    url: Field::String,
+    organisation: Field::BelongsTo,
+    subscriptions: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  SHOW_PAGE_ATTRIBUTES = [].freeze
+
+  COLLECTION_ATTRIBUTES = [
+    :organisation,
+    :url,
+    :subscriptions,
+    :created_at
+  ].freeze
+end

--- a/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
+++ b/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
@@ -1,0 +1,28 @@
+<% if existing_action?(collection_presenter.resource_name, :edit) %>
+  <td><%= link_to(
+    t("administrate.actions.edit"),
+    [:edit, namespace, resource],
+    class: "action-edit",
+  ) if accessible_action?(resource, :edit) %></td>
+<% end %>
+
+<td>
+  <%= form_for(:webhook_endpoint, url: duplicate_super_admins_webhook_endpoint_path(resource), method: :post, html: { id: "duplicate_webhook_endpoint_#{resource.id}", }) do |f| %>
+    <%= f.hidden_field :target_id, value: nil %>
+    <%= f.submit "Dupliquer" %>
+  <% end %>
+</td>
+
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+    const form = document.querySelector("#duplicate_webhook_endpoint_<%= resource.id %>")
+
+    form.addEventListener("submit", function(event) {
+      event.preventDefault();
+      const targetId = prompt("Entrez l'id de l'organisation pour laquelle vous souhaitez appliquer ce webhook");
+
+      form.querySelector("input[name='webhook_endpoint[target_id]']").value = targetId
+      form.submit()
+    });
+  });
+</script>

--- a/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
+++ b/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
@@ -19,7 +19,7 @@
 
     form.addEventListener("submit", function(event) {
       event.preventDefault();
-      const targetId = prompt("Entrez l'id de l'organisation pour laquelle vous souhaitez appliquer ce webhook");
+      const targetId = prompt("Entrez l'id RDV-I de l'organisation pour laquelle vous souhaitez appliquer ce webhook");
 
       form.querySelector("input[name='webhook_endpoint[target_id]']").value = targetId
       form.submit()

--- a/config/locales/models/webhook_endpoint.fr.yml
+++ b/config/locales/models/webhook_endpoint.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  activerecord:
+    models:
+      webhook_endpoint: Webhooks
+    attributes:
+      webhook_endpoint:
+        subscriptions: Ressources écoutées

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
     resources :motif_categories, only: [:index, :show, :new, :create, :edit, :update]
     resources :templates, only: [:index, :show]
     resources :orientation_types, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+    resources :webhook_endpoints, only: [:index] do
+      post :duplicate, on: :member
+    end
 
     root to: "agents#index"
   end


### PR DESCRIPTION
Cette PR ajoute une interface permettant de visualiser la liste des webhooks et de dupliquer un webhook existant en l'ajoutant à une organisation donnée :
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/3e4d7e81-946b-413e-a21f-bf63d21efe60">

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2412