### PR TITLE
perf(orientations): add missing index

### DIFF
--- a/db/migrate/20241120140423_add_indexes_on_orientations.rb
+++ b/db/migrate/20241120140423_add_indexes_on_orientations.rb
@@ -1,0 +1,5 @@
+class AddIndexesOnOrientations < ActiveRecord::Migration[7.1]
+  def change
+    add_index :orientations, [:starts_at, :ends_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_31_161416) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_20_140423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -346,6 +346,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_31_161416) do
     t.index ["agent_id"], name: "index_orientations_on_agent_id"
     t.index ["organisation_id"], name: "index_orientations_on_organisation_id"
     t.index ["orientation_type_id"], name: "index_orientations_on_orientation_type_id"
+    t.index ["starts_at", "ends_at"], name: "index_orientations_on_starts_at_and_ends_at"
     t.index ["user_id"], name: "index_orientations_on_user_id"
   end
 


### PR DESCRIPTION
Cette PR ajoute un index sur les champs starts_at et ends_at de la table orientations. 
Comme on peut [le voir dans skylight](https://www.skylight.io/app/applications/lsTKL2LytCi4/recent/6h/endpoints/UsersController%23index?responseType=html) 
<img width="1389" alt="image" src="https://github.com/user-attachments/assets/94adf047-2084-4a03-8dd8-75bb34a7dd1e">

Les percentiles les plus lents de cette requête HTTP sont causés par le `SELECT` sur la table orientations. 
Mis à part quelques filtrages sur les users la complexité de cette requête est causé par l'absence d'index sur les champs `starts_at` et `ends_at` sur lequels on applique les opérateurs `<=` et `>=` 

J'ai ajouté un index basique avec le type par défaut Btree étant donné que ce type d'index s'applique parfaitement à ces types d'opérateurs (cf : https://www.postgresql.org/docs/14/indexes-types.html)

> B-trees can handle equality and range queries on data that can be sorted into some ordering. In particular, the PostgreSQL > query planner will consider using a B-tree index whenever an indexed column is involved in a comparison using one of > these operators: `<   <=   =   >=   >`

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2427