### PR TITLE
feat(sync): Import user associations from rdvsp on creation

### DIFF
--- a/app/clients/rdv_solidarites_client.rb
+++ b/app/clients/rdv_solidarites_client.rb
@@ -37,6 +37,14 @@ class RdvSolidaritesClient
     )
   end
 
+  def get_user_referent_assignations(user_id)
+    Faraday.get(
+      "#{@url}/api/rdvinsertion/users/#{user_id}/referent_assignations",
+      {},
+      request_headers
+    )
+  end
+
   def update_user(user_id, request_body = {})
     Faraday.patch(
       "#{@url}/api/v1/users/#{user_id}",

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,5 +1,5 @@
 class InvitationsController < ApplicationController
-  before_action :set_organisations, :set_user, :verify_user_is_sync_with_rdv_solidarites, only: [:create]
+  before_action :set_organisations, :set_user, :ensure_rdv_solidarites_user_exists, only: [:create]
   before_action :set_invitation, :verify_invitation_validity, only: [:redirect]
   skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect, :redirect_shortcut]
 
@@ -86,8 +86,8 @@ class InvitationsController < ApplicationController
     @user = policy_scope(User).includes(:invitations).find(params[:user_id])
   end
 
-  def verify_user_is_sync_with_rdv_solidarites
-    sync_user_with_rdv_solidarites(@user) if @user.rdv_solidarites_user_id.nil?
+  def ensure_rdv_solidarites_user_exists
+    recreate_rdv_solidarites_user(@user) if @user.rdv_solidarites_user_id.nil?
   end
 
   def set_invitation

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class RdvsController < ApplicationController
-    before_action :set_user, :verify_user_is_sync_with_rdv_solidarites, :set_organisation, only: [:new]
+    before_action :set_user, :ensure_rdv_solidarites_user_exists, :set_organisation, only: [:new]
 
     def new
       redirect_to rdv_solidarites_find_rdv_url, allow_other_host: true
@@ -17,8 +17,8 @@ module Users
       @user = policy_scope(User).preload(:organisations).find(params[:user_id])
     end
 
-    def verify_user_is_sync_with_rdv_solidarites
-      sync_user_with_rdv_solidarites(@user) if @user.rdv_solidarites_user_id.nil?
+    def ensure_rdv_solidarites_user_exists
+      recreate_rdv_solidarites_user(@user) if @user.rdv_solidarites_user_id.nil?
     end
 
     def set_organisation

--- a/app/controllers/users/referent_assignations_controller.rb
+++ b/app/controllers/users/referent_assignations_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class ReferentAssignationsController < ApplicationController
     before_action :set_department, :set_user, :set_agents, only: [:index, :create, :destroy]
-    before_action :verify_user_is_sync_with_rdv_solidarites, :set_agent, only: [:create, :destroy]
+    before_action :ensure_rdv_solidarites_user_exists, :set_agent, only: [:create, :destroy]
     before_action :set_user_referents, only: [:index]
 
     def index; end
@@ -50,8 +50,8 @@ module Users
       @user_referents = policy_scope(@user.referents).distinct
     end
 
-    def verify_user_is_sync_with_rdv_solidarites
-      sync_user_with_rdv_solidarites(@user) if @user.rdv_solidarites_user_id.nil?
+    def ensure_rdv_solidarites_user_exists
+      recreate_rdv_solidarites_user(@user) if @user.rdv_solidarites_user_id.nil?
     end
 
     def set_department

--- a/app/controllers/users_organisations_controller.rb
+++ b/app/controllers/users_organisations_controller.rb
@@ -3,7 +3,7 @@ class UsersOrganisationsController < ApplicationController
                 only: [:index, :create, :destroy]
   before_action :set_user_organisations, only: [:index]
   before_action :set_organisation_to_add, :assign_motif_category, only: [:create]
-  before_action :set_organisation_to_remove, :verify_user_is_sync_with_rdv_solidarites, only: [:destroy]
+  before_action :set_organisation_to_remove, :ensure_rdv_solidarites_user_exists, only: [:destroy]
 
   def index
     @assignable_organisations = @organisations.where.not(id: @user.organisations.ids)
@@ -82,8 +82,8 @@ class UsersOrganisationsController < ApplicationController
     @user.assign_motif_category(params[:users_organisation]["motif_category_id_#{@organisation_to_add.id}"])
   end
 
-  def verify_user_is_sync_with_rdv_solidarites
-    sync_user_with_rdv_solidarites(@user) if @user.rdv_solidarites_user_id.nil?
+  def ensure_rdv_solidarites_user_exists
+    recreate_rdv_solidarites_user(@user) if @user.rdv_solidarites_user_id.nil?
   end
 
   def save_user

--- a/app/jobs/import_user_associations_from_rdv_solidarites_job.rb
+++ b/app/jobs/import_user_associations_from_rdv_solidarites_job.rb
@@ -1,0 +1,11 @@
+class ImportUserAssociationsFromRdvSolidaritesJob < ApplicationJob
+  def perform(user_id)
+    user = User.find(user_id)
+    # we take a super admin here but it could be any agent,
+    # we will just need to be able to access the RDV-Solidarites API
+    # to retrieve the associated ressources
+    Agent.super_admins.first.with_rdv_solidarites_session do
+      call_service!(Users::ImportAssociationsFromRdvSolidarites, user:)
+    end
+  end
+end

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -110,7 +110,6 @@ module InboundWebhooks
         rdv_solidarites_rdv.user_ids
       end
 
-      # rubocop:disable Metrics/AbcSize
       def find_or_create_users
         existing_users = User.where(rdv_solidarites_user_id: rdv_solidarites_user_ids).to_a
 
@@ -123,20 +122,13 @@ module InboundWebhooks
             rdv_solidarites_user_id: rdv_solidarites_user.id,
             created_through: "rdv_solidarites_webhook",
             created_from_structure: organisation,
-            organisation_ids: retrieve_user_organisation_ids(rdv_solidarites_user.id),
+            organisations: [organisation],
+            import_associatons_from_rdv_solidarites_on_create: true,
             **rdv_solidarites_user.attributes.slice(*User::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES).compact_blank
           )
         end
 
         @users = existing_users + new_users
-      end
-      # rubocop:enable Metrics/AbcSize
-
-      def retrieve_user_organisation_ids(rdv_solidarites_user_id)
-        rdv_solidarites_organisation_ids = agents.first.with_rdv_solidarites_session do
-          call_service!(RdvSolidaritesApi::RetrieveUser, rdv_solidarites_user_id:).user.organisation_ids
-        end
-        Organisation.where(rdv_solidarites_organisation_id: rdv_solidarites_organisation_ids).ids
       end
 
       def participations_attributes_destroyed

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -123,7 +123,7 @@ module InboundWebhooks
             created_through: "rdv_solidarites_webhook",
             created_from_structure: organisation,
             organisations: [organisation],
-            import_associatons_from_rdv_solidarites_on_create: true,
+            import_associations_from_rdv_solidarites_on_create: true,
             **rdv_solidarites_user.attributes.slice(*User::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES).compact_blank
           )
         end

--- a/app/models/rdv_solidarites/referent_assignation.rb
+++ b/app/models/rdv_solidarites/referent_assignation.rb
@@ -1,0 +1,9 @@
+module RdvSolidarites
+  class ReferentAssignation < Base
+    RECORD_ATTRIBUTES = [:id, :agent, :user].freeze
+
+    def agent
+      RdvSolidarites::Agent.new(@attributes[:agent])
+    end
+  end
+end

--- a/app/services/rdv_solidarites_api/retrieve_user_referent_assignations.rb
+++ b/app/services/rdv_solidarites_api/retrieve_user_referent_assignations.rb
@@ -1,0 +1,21 @@
+module RdvSolidaritesApi
+  class RetrieveUserReferentAssignations < Base
+    def initialize(rdv_solidarites_user_id:)
+      @rdv_solidarites_user_id = rdv_solidarites_user_id
+    end
+
+    def call
+      request!
+      result.referent_assignations =
+        rdv_solidarites_response_body["referent_assignations"].map do |referent_assignation_attributes|
+          RdvSolidarites::ReferentAssignation.new(referent_assignation_attributes)
+        end
+    end
+
+    private
+
+    def rdv_solidarites_response
+      @rdv_solidarites_response ||= rdv_solidarites_client.get_user_referent_assignations(@rdv_solidarites_user_id)
+    end
+  end
+end

--- a/app/services/users/import_associations_from_rdv_solidarites.rb
+++ b/app/services/users/import_associations_from_rdv_solidarites.rb
@@ -1,0 +1,48 @@
+module Users
+  class ImportAssociationsFromRdvSolidarites < BaseService
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      add_missing_organisations_to_user
+      add_missing_referents_to_user
+    end
+
+    private
+
+    def add_missing_organisations_to_user
+      organisations_linked_to_user_in_rdv_solidarites.each do |organisation|
+        @user.organisations << organisation unless @user.organisations.include?(organisation)
+      end
+    end
+
+    def add_missing_referents_to_user
+      referents_assigned_to_user_in_rdv_solidarites.each do |referent|
+        @user.referents << referent unless @user.referents.include?(referent)
+      end
+    end
+
+    def rdv_solidarites_referent_ids
+      call_service!(
+        RdvSolidaritesApi::RetrieveUserReferentAssignations,
+        rdv_solidarites_user_id: @user.rdv_solidarites_user_id
+      ).referent_assignations.map(&:agent).map(&:id)
+    end
+
+    def referents_assigned_to_user_in_rdv_solidarites
+      Agent.where(rdv_solidarites_agent_id: rdv_solidarites_referent_ids)
+    end
+
+    def rdv_solidarites_organisation_ids
+      call_service!(
+        RdvSolidaritesApi::RetrieveUser,
+        rdv_solidarites_user_id: @user.rdv_solidarites_user_id
+      ).user.organisation_ids
+    end
+
+    def organisations_linked_to_user_in_rdv_solidarites
+      Organisation.where(rdv_solidarites_organisation_id: rdv_solidarites_organisation_ids)
+    end
+  end
+end

--- a/app/services/users/push_to_rdv_solidarites.rb
+++ b/app/services/users/push_to_rdv_solidarites.rb
@@ -51,7 +51,7 @@ module Users
       else
         @rdv_solidarites_user_id = user_id_from_email_taken_error
         # since we are importing an existing user in RDV-S, we need to import its associations
-        @user.import_associatons_from_rdv_solidarites_on_create = true
+        @user.import_associations_from_rdv_solidarites_on_create = true
         update_user_and_associations
       end
     end

--- a/app/services/users/save.rb
+++ b/app/services/users/save.rb
@@ -18,7 +18,7 @@ module Users
           assign_organisation if @organisation.present?
           validate_user!
           save_record!(@user)
-          sync_with_rdv_solidarites
+          push_user_to_rdv_solidarites
         end
       end
     end
@@ -31,18 +31,12 @@ module Users
       @user.organisations = (@user.organisations.to_a + [@organisation]).uniq
     end
 
-    def sync_with_rdv_solidarites
-      call_service!(
-        Users::SyncWithRdvSolidarites,
-        user: @user
-      )
+    def push_user_to_rdv_solidarites
+      call_service!(Users::PushToRdvSolidarites, user: @user)
     end
 
     def validate_user!
-      call_service!(
-        Users::Validate,
-        user: @user
-      )
+      call_service!(Users::Validate, user: @user)
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1065,7 +1065,7 @@ describe UsersController do
 
         before do
           allow(Users::Save).to receive(:call).and_call_original
-          allow_any_instance_of(Users::Save).to receive(:sync_with_rdv_solidarites)
+          allow_any_instance_of(Users::Save).to receive(:push_user_to_rdv_solidarites)
             .and_return true
           organisation.tags << tag
           organisation.tags << existing_tag

--- a/spec/controllers/users_organisations_controller_spec.rb
+++ b/spec/controllers/users_organisations_controller_spec.rb
@@ -96,7 +96,7 @@ describe UsersOrganisationsController do
       let!(:user) { create(:user, id: user_id, organisations: [organisation1], rdv_solidarites_user_id: nil) }
 
       before do
-        allow(Users::SyncWithRdvSolidarites).to receive(:call)
+        allow(Users::PushToRdvSolidarites).to receive(:call)
           .with(user: user)
           .and_return(OpenStruct.new(success?: false, errors: ["Something went wrong"]))
       end

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -107,7 +107,7 @@ describe "Super admin can manage users" do
 
   context "from user admin edit page" do
     before do
-      stub_sync_with_rdv_solidarites_user(rdv_solidarites_user_id)
+      stub_rdv_solidarites_update_user_and_associations(rdv_solidarites_user_id)
       # Somehow the tests fail on CI if we do not put this line, the before_save :set_status callback is not
       # triggered on the follow-ups when we create them (in Users::Save) and so there is an error when redirected
       # to show page after update

--- a/spec/features/agent_can_create_user_through_form_spec.rb
+++ b/spec/features/agent_can_create_user_through_form_spec.rb
@@ -29,7 +29,7 @@ describe "Agents can create user through form", :js do
     before do
       setup_agent_session(agent)
       stub_rdv_solidarites_create_user(rdv_solidarites_user_id)
-      stub_sync_with_rdv_solidarites_user(rdv_solidarites_user_id)
+      stub_rdv_solidarites_update_user_and_associations(rdv_solidarites_user_id)
       # Somehow the tests fail on CI if we do not put this line, the before_save :set_status callback is not
       # triggered on the follow-ups when we create them (in Users::Save) and so there is an error when redirected
       # to show page after creation

--- a/spec/features/agent_can_update_contacts_info_spec.rb
+++ b/spec/features/agent_can_update_contacts_info_spec.rb
@@ -9,7 +9,7 @@ describe "Agents can update contact info with caf file", :js do
   before do
     setup_agent_session(agent)
     stub_rdv_solidarites_create_user(rdv_solidarites_user_id)
-    stub_sync_with_rdv_solidarites_user(rdv_solidarites_user_id)
+    stub_rdv_solidarites_update_user_and_associations(rdv_solidarites_user_id)
     stub_brevo
     stub_geo_api_request("127 RUE DE GRENELLE 75007 PARIS")
   end

--- a/spec/features/agent_can_update_user_through_form_spec.rb
+++ b/spec/features/agent_can_update_user_through_form_spec.rb
@@ -36,7 +36,7 @@ describe "Agents can update user through form", :js do
   describe "#update" do
     before do
       setup_agent_session(agent)
-      stub_sync_with_rdv_solidarites_user(rdv_solidarites_user_id)
+      stub_rdv_solidarites_update_user_and_associations(rdv_solidarites_user_id)
       # Somehow the tests fail on CI if we do not put this line, the before_save :set_status callback is not
       # triggered on the follow-ups when we create them (in Users::Save) and so there is an error when redirected
       # to show page after update

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -237,32 +237,19 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
           let!(:new_follow_up) do
             build(:follow_up, motif_category: motif_category, user: new_user)
           end
-          let!(:other_rdv_solidarites_organisation_id) { 22_424 }
-          let!(:other_user_organisation) do
-            create(:organisation, rdv_solidarites_organisation_id: other_rdv_solidarites_organisation_id)
-          end
 
           before do
             allow(User).to receive(:create!).and_return(new_user)
             allow(FollowUp).to receive(:find_or_create_by!)
               .with(user: new_user, motif_category: motif_category)
               .and_return(new_follow_up)
-
-            allow(RdvSolidaritesApi::RetrieveUser).to receive(:call)
-              .with(rdv_solidarites_user_id: user_id1)
-              .and_return(
-                OpenStruct.new(
-                  success?: true,
-                  user: OpenStruct.new(organisation_ids: [rdv_solidarites_organisation_id,
-                                                          other_rdv_solidarites_organisation_id])
-                )
-              )
           end
 
           it "creates the user" do
             expect(User).to receive(:create!).with(
               rdv_solidarites_user_id: user_id1,
-              organisation_ids: [organisation.id, other_user_organisation.id],
+              organisations: [organisation],
+              import_associations_from_rdv_solidarites_on_create: true,
               first_name: "James",
               last_name: "Cameron",
               address: "50 rue Victor Hugo 93500 Pantin",

--- a/spec/lib/users/transfer_organisation_spec.rb
+++ b/spec/lib/users/transfer_organisation_spec.rb
@@ -22,7 +22,7 @@ describe Users::TransferOrganisation do
   before do
     source_organisation.users << user
     source_organisation.agents << agent
-    allow(Users::SyncWithRdvSolidarites).to receive(:call)
+    allow(Users::PushToRdvSolidarites).to receive(:call)
       .with(user: user).and_return(OpenStruct.new(success?: true))
     allow(RdvSolidaritesApi::DeleteUserProfile).to receive(:call)
       .with(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -395,6 +395,38 @@ describe User do
     end
   end
 
+  describe "#import_associations_from_rdv_solidarites" do
+    let!(:user) { build(:user, import_associations_from_rdv_solidarites_on_create: true) }
+
+    before do
+      allow(ImportUserAssociationsFromRdvSolidaritesJob).to receive(:perform_later)
+    end
+
+    it "enqueues a job to import associations from rdv_solidarites on creation" do
+      expect(ImportUserAssociationsFromRdvSolidaritesJob).to receive(:perform_later)
+      user.save
+    end
+
+    context "when the option import_associations_from_rdv_solidarites_on_create is not set" do
+      let!(:user) { build(:user) }
+
+      it "does not enqueue a job to import associations from rdv_solidarites" do
+        expect(ImportUserAssociationsFromRdvSolidaritesJob).not_to receive(:perform_later)
+        user.save
+      end
+    end
+
+    context "when the user is being updated" do
+      let!(:user) { create(:user) }
+
+      it "does not enqueue a job to import associations from rdv_solidarites" do
+        user.import_associations_from_rdv_solidarites_on_create = true
+        expect(ImportUserAssociationsFromRdvSolidaritesJob).not_to receive(:perform_later)
+        user.save
+      end
+    end
+  end
+
   describe "#as_json" do
     subject { user.as_json }
 

--- a/spec/services/rdv_solidarites_api/retrieve_user_referent_assignations_spec.rb
+++ b/spec/services/rdv_solidarites_api/retrieve_user_referent_assignations_spec.rb
@@ -1,0 +1,55 @@
+describe RdvSolidaritesApi::RetrieveUserReferentAssignations, type: :service do
+  subject do
+    described_class.call(rdv_solidarites_user_id:)
+  end
+
+  let(:rdv_solidarites_user_id) { 42 }
+
+  let(:rdv_solidarites_client) { instance_double(RdvSolidaritesClient) }
+
+  let(:referent_assignations) do
+    [{
+      "id" => 1,
+      "agent" => {
+        "id" => 2,
+        "email" => "linus@linux.com"
+      },
+      "user" => {
+        "id" => 3,
+        "email" => "james@linux.com"
+      }
+    }]
+  end
+
+  before do
+    allow(Current).to receive(:rdv_solidarites_client).and_return(rdv_solidarites_client)
+    allow(rdv_solidarites_client).to receive(:get_user_referent_assignations)
+      .with(rdv_solidarites_user_id)
+      .and_return(OpenStruct.new(success?: true, body: { "referent_assignations" => referent_assignations }.to_json))
+  end
+
+  describe "#call" do
+    it "retrieves the user referent assignation" do
+      expect(rdv_solidarites_client).to receive(:get_user_referent_assignations).with(rdv_solidarites_user_id)
+      subject
+    end
+
+    it "returns the user referent assignations" do
+      expect(subject.referent_assignations.map(&:agent).map(&:id)).to contain_exactly(2)
+    end
+
+    context "when it fails" do
+      before do
+        allow(rdv_solidarites_client).to receive(:get_user_referent_assignations).and_return(
+          OpenStruct.new(success?: false, body: { error_messages: ["some error"] }.to_json)
+        )
+      end
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error" do
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
+      end
+    end
+  end
+end

--- a/spec/services/users/import_associations_from_rdv_solidarites_spec.rb
+++ b/spec/services/users/import_associations_from_rdv_solidarites_spec.rb
@@ -1,0 +1,64 @@
+describe Users::ImportAssociationsFromRdvSolidarites, type: :service do
+  subject do
+    described_class.call(user:)
+  end
+
+  let(:user) { create(:user, organisations: [organisation], referents: []) }
+  let(:organisation) { create(:organisation) }
+  let(:other_organisation) { create(:organisation) }
+  let(:referent) { create(:agent) }
+
+  before do
+    allow(RdvSolidaritesApi::RetrieveUserReferentAssignations).to receive(:call).and_return(
+      OpenStruct.new(
+        success?: true,
+        referent_assignations: [OpenStruct.new(agent: OpenStruct.new(id: referent.rdv_solidarites_agent_id))]
+      )
+    )
+    allow(RdvSolidaritesApi::RetrieveUser).to receive(:call).and_return(
+      OpenStruct.new(
+        success?: true,
+        user: OpenStruct.new(
+          organisation_ids: [
+            organisation.rdv_solidarites_organisation_id,
+            other_organisation.rdv_solidarites_organisation_id
+          ]
+        )
+      )
+    )
+  end
+
+  describe "#call" do
+    it "is a success" do
+      is_a_success
+    end
+
+    it "imports the associations" do
+      subject
+      expect(user.reload.referents).to eq([referent])
+      expect(user.reload.organisations).to eq([organisation, other_organisation])
+    end
+
+    context "when the call to retrieve the user referent assignations fails" do
+      before do
+        allow(RdvSolidaritesApi::RetrieveUserReferentAssignations).to receive(:call).and_return(
+          OpenStruct.new(success?: false)
+        )
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+    end
+
+    context "when the call to retrieve the user fails" do
+      before do
+        allow(RdvSolidaritesApi::RetrieveUser).to receive(:call).and_return(OpenStruct.new(success?: false))
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+    end
+  end
+end

--- a/spec/services/users/push_to_rdv_solidarites_spec.rb
+++ b/spec/services/users/push_to_rdv_solidarites_spec.rb
@@ -1,4 +1,4 @@
-describe Users::SyncWithRdvSolidarites, type: :service do
+describe Users::PushToRdvSolidarites, type: :service do
   subject do
     described_class.call(user:)
   end
@@ -228,7 +228,7 @@ describe Users::SyncWithRdvSolidarites, type: :service do
               )
           end
 
-          context "when there is no user linked to this user" do
+          context "when there is no other rdv-i user linked to this rdv-s user" do
             it "assigns the user to the department organisations by creating user profiles on rdvs" do
               expect(RdvSolidaritesApi::CreateUserProfiles).to receive(:call)
                 .with(
@@ -263,6 +263,11 @@ describe Users::SyncWithRdvSolidarites, type: :service do
             it "assign the rdv solidarites user id" do
               subject
               expect(user.rdv_solidarites_user_id).to eq(42)
+            end
+
+            it "marks the user to import associations from rdv-s" do
+              subject
+              expect(user.import_associatons_from_rdv_solidarites_on_create).to be(true)
             end
           end
         end

--- a/spec/services/users/push_to_rdv_solidarites_spec.rb
+++ b/spec/services/users/push_to_rdv_solidarites_spec.rb
@@ -267,7 +267,7 @@ describe Users::PushToRdvSolidarites, type: :service do
 
             it "marks the user to import associations from rdv-s" do
               subject
-              expect(user.import_associatons_from_rdv_solidarites_on_create).to be(true)
+              expect(user.import_associations_from_rdv_solidarites_on_create).to be(true)
             end
           end
         end

--- a/spec/services/users/save_spec.rb
+++ b/spec/services/users/save_spec.rb
@@ -18,7 +18,7 @@ describe Users::Save, type: :service do
       allow(user).to receive(:save).and_return(true)
       allow(Users::Validate).to receive(:call)
         .with(user: user).and_return(OpenStruct.new(success?: true))
-      allow(Users::SyncWithRdvSolidarites).to receive(:call)
+      allow(Users::PushToRdvSolidarites).to receive(:call)
         .and_return(OpenStruct.new(success?: true))
     end
 
@@ -35,7 +35,7 @@ describe Users::Save, type: :service do
     end
 
     it "syncs the user with Rdv Solidarites" do
-      expect(Users::SyncWithRdvSolidarites).to receive(:call)
+      expect(Users::PushToRdvSolidarites).to receive(:call)
         .with(user: user)
       subject
     end
@@ -71,7 +71,7 @@ describe Users::Save, type: :service do
 
     context "when the rdv solidarites user sync fails" do
       before do
-        allow(Users::SyncWithRdvSolidarites).to receive(:call)
+        allow(Users::PushToRdvSolidarites).to receive(:call)
           .and_return(OpenStruct.new(errors: ["some error"], success?: false))
       end
 

--- a/spec/support/stub_helper.rb
+++ b/spec/support/stub_helper.rb
@@ -77,7 +77,7 @@ module StubHelper
     stub_geo_api_request("127 RUE DE GRENELLE 75007 PARIS")
   end
 
-  def stub_sync_with_rdv_solidarites_user(rdv_solidarites_user_id)
+  def stub_rdv_solidarites_update_user_and_associations(rdv_solidarites_user_id)
     stub_rdv_solidarites_assign_organisations(rdv_solidarites_user_id)
     stub_rdv_solidarites_assign_many_referents(rdv_solidarites_user_id)
     stub_rdv_solidarites_update_user(rdv_solidarites_user_id)


### PR DESCRIPTION
closes #2396 

## Contexte 

On avait en sorte dans #2369 de récupérer les organisations des usagers qui ont été créés sur RDV-SP puis importé sur rdv-i parce qu'ils avaient un rdv sur une orga gérée sur rdv-i sur une catégorie gérée sur leur orga.

On s'est rendu compte qu'il y avait un autre cas où on importait des usagers déjé créés sur RDV-SP, c'est lorsque le mail est déjà pris dans RDV-SP (et que la personne n'est pas déjà sur rdv-i). Du coup il fallait importer les organisations de ces usagers lorsqu'on les crée sur rdv-i.

En plus des organisations, il se peut que ces usagers aient déjà des référents assignés sur RDV-SP avant leur importation sur RDV-I. Il faut importer les référents de l'usager également.

## Implémentation

Je discute de l'implémentation choisie ici en analysant commit par commit. 

### Renomage du service `SyncWithRdvSolidarites` https://github.com/gip-inclusion/rdv-insertion/commit/fa90fa1c7ae63aaa801386eedd85ed69a4ce076f

Je renomme le service `Users::SyncWithRdvSolidarites` en `Users::PushToRdvSolidarites` pour mieux refléter le fait que ce service ne synchronise pas vraiment l'usager car il ne va que dans un sens: de rdv-i vers rdv-sp. Ainsi on pourra mieux distinguer la logique poussant des informations de rdv-i vers rdv-s de celle récupérant des infos de rdv-s vers rdv-i. 
Je renomme au passage les méthodes qui font appel à ce service.

### Récupération des référents des usagers https://github.com/gip-inclusion/rdv-insertion/commit/2aeaba0259f01087bccd10bf3be65a6d2934842e

Suite à [la PR sur RDV-SP](https://github.com/betagouv/rdv-service-public/pull/4806) permettant de récupérer les référents des usagers, je mets en place la logique côté rdv-i pour récupérer ces référents.

### Import des associations des usagers à la création https://github.com/gip-inclusion/rdv-insertion/commit/27dab2511e471c659c4cc3b28598c827400fb3d3

C'est le gros de cette PR. Lorsque l'on crée un usager en l'important depuis RDV-SP, on enqueue un job qui va se charge d'importer toutes les associations de cet usager sur RDV-I.

Du coup je revert la logique de #2369 pour que la récupération des organisations de l'usager se fasse au même endroit et pas lorsque l'on récupère le webhook.


