### PR TITLE
feat(invitations): Do not send periodic invites in some cases

### DIFF
--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -31,13 +31,16 @@ class SendInvitationRemindersJob < ApplicationJob
 
   def valid_invitations_sent_3_days_ago
     @valid_invitations_sent_3_days_ago ||=
-      # we want the invitation to be valid for at least two days to give time to the user to accept the invitation
-      Invitation.where("expires_at > ?", 2.days.from_now)
+      # We want the invitation to be valid for at least two days to give time to the user to accept the invitation.
+      # We don't send reminders for invitations that never expire since we consider those as invitations
+      # to optional rdvs.
+      # We only send reminders for invitations that have been triggered manually and not by the system.
+      Invitation.manual
+                .where("expires_at > ?", 2.days.from_now)
                 .where(
                   format: %w[email sms],
                   created_at: Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.all_day
                 )
-                .not_reminder
   end
 
   def invitation_sent_3_days_ago?(invitation)

--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -32,7 +32,9 @@ class SendPeriodicInvitesJob < ApplicationJob
 
   def should_send_periodic_invite?(last_invitation, category_configuration)
     if category_configuration.day_of_the_month_periodic_invites.present?
-      Time.zone.today.day == category_configuration.day_of_the_month_periodic_invites
+      Time.zone.today.day == category_configuration.day_of_the_month_periodic_invites &&
+        # We don't send an invite the first month if the invitation was sent less than 10 days ago
+        last_invitation.sent_before?(10.days.ago)
     elsif category_configuration.number_of_days_between_periodic_invites.present?
       (Time.zone.today - last_invitation.created_at.to_date).to_i ==
         category_configuration.number_of_days_between_periodic_invites

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -94,6 +94,24 @@ describe SendPeriodicInvitesJob do
             subject
           end
         end
+
+        context "when the last invitation was sent less than 10 days ago" do
+          let!(:invitation) do
+            create(:invitation,
+                   follow_up: follow_up,
+                   created_at: 9.days.ago,
+                   expires_at: nil,
+                   organisations: [organisation])
+          end
+
+          it "does not send periodic invites" do
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
+                                                                              "email")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
+                                                                              "sms")
+            subject
+          end
+        end
       end
 
       context "when no invitations have been sent" do


### PR DESCRIPTION
closes #2444 

## Contexte

On a remarqué qu'il y avait certaines invitations périodiques qui sont lancée alors que l'usager a reçu une invitation pas longtemps avant. 
C'est parce que quand la périodicité est choisie sur un jour dans le mois (`day_of_the_month_periodic_invites`), on ne vérifiait pas que l'usager n'avait pas reçu d'invitations pas longtemps auparavant. 
Il y avait aussi rien d'explicite dans le code qui s'assurait qu'on envoyait pas des reminder sur des invitations périodiques. 

Dans les faits c'est rare parce qu'on envoie pas de reminder sur les invitations qui n'expirent jamais (ce qui devrait être le cas pour toutes les invitations périodiques), mais ce n'est pas le cas tout le temps (+ de détails à ce sujet dans lla dernière partie de la description). 

## Solutions

* J'ajoute une condition pour ne pas envoyer d'invitations périodiques si la dernière invitation a été envoyée il y a moins de 10 jours
* Je filtre explicitement les invitations éligibles à la relance en ne prenant  en compte que celles envoyées manuellement. J'en profite pour rajouter quelques commentaires sur cette partie

## Remarque sur des configurations dans un état invalides

J'ai listé [ici](https://github.com/gip-inclusion/rdv-insertion/issues/2444) des configurations qui ont l'invitation périodique activée alors que les invitations ont une expiration. Elles sont donc dans un état invalide.
Il faudra changer ces configurations et probablement enlever les expirations sur les invitations périodiques envoyées.

En faisant ça on pourra filtrer sur les invitations qui n'expirent jamais dans le `SendPeriodicInvitesJob` pour itérer sur un set moins grand.