### PR TITLE
fix(sync): Choose agent from user org when importing associations

### DIFF
--- a/app/jobs/import_user_associations_from_rdv_solidarites_job.rb
+++ b/app/jobs/import_user_associations_from_rdv_solidarites_job.rb
@@ -1,11 +1,18 @@
 class ImportUserAssociationsFromRdvSolidaritesJob < ApplicationJob
   def perform(user_id)
-    user = User.find(user_id)
-    # we take a super admin here but it could be any agent,
-    # we will just need to be able to access the RDV-Solidarites API
-    # to retrieve the associated ressources
-    Agent.super_admins.first.with_rdv_solidarites_session do
-      call_service!(Users::ImportAssociationsFromRdvSolidarites, user:)
+    @user = User.find(user_id)
+
+    # we just need an agent that has a common organisation with the user here.
+    # It is necessary since in RDV-Solidarites we check the Agent::UserPolicy on the user when
+    # retrieving the user. This policy is based on mutual organisation between the agent and the user.
+    random_agent_from_user_organisations.with_rdv_solidarites_session do
+      call_service!(Users::ImportAssociationsFromRdvSolidarites, user: @user)
     end
+  end
+
+  private
+
+  def random_agent_from_user_organisations
+    Agent.joins(:organisations).merge(@user.organisations.active).with_last_name.take
   end
 end


### PR DESCRIPTION
Répare cette erreur sur sentry: https://sentry.incubateur.net/organizations/betagouv/issues/133840/?project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

Il me semblait que les appels à l'API RDV-SP lancées par le service `Users::ImportAssociationsFromRdvSolidarites` n'appelaient pas de policies côté RDV-SP puisque ce sont des endpoints scopés rdv-insertion. 
Mais [l'endpoint](https://github.com/betagouv/rdv-service-public/blob/cd51b9487ca6c65e8fbfeb9d6bc8b396e813e1dc/app/controllers/api/rdvinsertion/users_controller.rb#L12) récupérant le `user` (et ses organisations) check que l'agent qui appelle a des organisations en commun avec l'usager.

En attendant de peut-être revoir ces policies côté rdv-sp au moment où on fera une séparation + nette entre les endpoints scopés rdv-insertion des autres (notamment en changeant les moyens d'authentifications), je fais en sorte de prendre un agent qui a des orgas en commun avec l'usager pour faire cet appel.