### PR TITLE
perf(index): remove condition to display orientation filter

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   before_action :set_organisation, :set_department, :set_all_configurations,
                 :set_users_scope, :set_current_category_configuration, :set_current_motif_category,
-                :set_users, :set_follow_ups, :set_structure_orientations, :set_orientation_types, :set_filterable_tags,
+                :set_users, :set_follow_ups, :set_orientation_types, :set_filterable_tags,
                 :set_referents_list, :filter_users, :order_users,
                 for: :index
   before_action :set_user, :set_organisation, :set_department, :set_all_configurations,
@@ -186,12 +186,9 @@ class UsersController < ApplicationController
                     .find_by(id: @user.organisation_ids, department_id: params[:department_id])
   end
 
-  def set_structure_orientations
-    @structure_orientations = Orientation.active.where(user: @users)
-  end
 
   def set_orientation_types
-    @orientation_types = OrientationType.where(id: @structure_orientations.pluck(:orientation_type_id).uniq)
+    @orientation_types = OrientationType.for_department(current_department)
   end
 
   def set_user_referents

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -186,7 +186,6 @@ class UsersController < ApplicationController
                     .find_by(id: @user.organisation_ids, department_id: params[:department_id])
   end
 
-
   def set_orientation_types
     @orientation_types = OrientationType.for_department(current_department)
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -7,6 +7,10 @@ module UsersHelper
     category_configuration.invitation_formats.present?
   end
 
+  def show_orientations_filter?
+    current_structure.orientations.any?
+  end
+
   def no_search_results?(users)
     users.empty? && params[:search_query].present?
   end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -13,6 +13,7 @@ class Department < ApplicationRecord
   has_many :motif_categories, -> { distinct }, through: :category_configurations
   has_many :file_configurations, through: :category_configurations
   has_many :agents, through: :organisations
+  has_many :orientations, through: :organisations
   has_many :rdvs, through: :organisations
   has_many :participations, through: :rdvs
   has_many :follow_ups, through: :users

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -44,7 +44,7 @@
         <i class="fas fa-angle-down"></i>
       </span>
     </div>
-    <%= render "filter_by_orientation_type_button" %>
+    <%= render "filter_by_orientation_type_button" if show_orientations_filter? %>
     <%= render "filter_by_creation_dates_button" if @current_category_configuration.nil? %>
     <%= render "filter_by_invitation_or_convocation_dates_button" if @current_category_configuration.present? || archived_scope?(@users_scope) %>
     <%= render "search_form", url: structure_users_path %>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -44,7 +44,7 @@
         <i class="fas fa-angle-down"></i>
       </span>
     </div>
-    <%= render "filter_by_orientation_type_button" if @structure_orientations.any? %>
+    <%= render "filter_by_orientation_type_button" %>
     <%= render "filter_by_creation_dates_button" if @current_category_configuration.nil? %>
     <%= render "filter_by_invitation_or_convocation_dates_button" if @current_category_configuration.present? || archived_scope?(@users_scope) %>
     <%= render "search_form", url: structure_users_path %>


### PR DESCRIPTION
Cette PR enlève la requête un peu lourde permettant d'afficher ou non le filtre par type d'orientation. 
Désormais le filtre sera toujours visible même si la structure n'utilise pas les orientations. 
On peut faire un compromis entre les deux en faisant par exemple 
```ruby
current_structure.orientations.any?
```
ce qui serait moins lourd mais permettrait au moins de ne pas afficher pour les départements et orgas qui n'utilisent pas du tout les orientations

[Solution proposée ci-dessus mise en place suite à discussion sur Mattermost]

