### PR TITLE
fix(mm): Mattermost alert for convocation send without org/lieu phone_number fixed

### DIFF
--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -40,11 +40,15 @@ class MattermostClient
     end
 
     def should_send_daily_message?(text)
-      !REDIS.exists?(redis_key(text))
+      !redis.exists?(redis_key(text))
     end
 
     def update_last_sent_timestamp(text)
-      REDIS.set(redis_key(text), Time.current.to_i, ex: EXPIRATION)
+      redis.set(redis_key(text), Time.current.to_i, ex: EXPIRATION)
+    end
+
+    def redis
+      @redis ||= Redis.new
     end
   end
 end

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -1,15 +1,26 @@
 class MattermostClient
   class << self
-    def send_to_notif_channel(text)
+    EXPIRATION = 24.hours.to_i
+
+    def send_to_notif_channel(text, once_a_day: false)
+      return if once_a_day && !should_send_daily_message?(text)
+
       send_message(ENV["MATTERMOST_NOTIFICATIONS_CHANNEL_URL"], text)
+      update_last_sent_timestamp(text) if once_a_day
     end
 
-    def send_to_main_channel(text)
+    def send_to_main_channel(text, once_a_day: false)
+      return if once_a_day && !should_send_daily_message?(text)
+
       send_message(ENV["MATTERMOST_MAIN_CHANNEL_URL"], text)
+      update_last_sent_timestamp(text) if once_a_day
     end
 
-    def send_to_private_channel(text)
+    def send_to_private_channel(text, once_a_day: false)
+      return if once_a_day && !should_send_daily_message?(text)
+
       send_message(ENV["MATTERMOST_PRIVATE_CHANNEL_URL"], text)
+      update_last_sent_timestamp(text) if once_a_day
     end
 
     private
@@ -22,6 +33,18 @@ class MattermostClient
         { text: text }.to_json,
         { "Content-Type" => "application/json" }
       )
+    end
+
+    def redis_key(text)
+      "mattermost_daily_message:#{Digest::MD5.hexdigest(text)}"
+    end
+
+    def should_send_daily_message?(text)
+      !REDIS.exists?(redis_key(text))
+    end
+
+    def update_last_sent_timestamp(text)
+      REDIS.set(redis_key(text), Time.current.to_i, ex: EXPIRATION)
     end
   end
 end

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -3,11 +3,11 @@ module Notifications
     def verify_sender_phone_number!(notification)
       return if notification.rdv.phone_number.present?
 
-      MattermostClient.send_to_private_channel(
-        "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
-        "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
-        " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}.",
-        once_a_day: true
+      MattermostClient.send_unique_message(
+        channel_type: :private,
+        text: "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro" \
+              " de téléphone de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
+              " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
       )
 
       fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -6,7 +6,8 @@ module Notifications
       MattermostClient.send_to_private_channel(
         "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
         "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
-        " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
+        " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}.",
+        once_a_day: true
       )
 
       fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -4,7 +4,7 @@ module Notifications
       return if notification.rdv.phone_number.present?
 
       MattermostClient.send_to_private_channel(
-        "Une convocation a été envoyée par l' #{notification.organisation.name} sans numéro de téléphone " \
+        "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
         "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
         " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
       )

--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -3,12 +3,13 @@ module Notifications
     def verify_sender_phone_number!(notification)
       return if notification.rdv.phone_number.present?
 
-      fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
       MattermostClient.send_to_private_channel(
-        "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro de téléphone " \
+        "Une convocation a été envoyée par l' #{notification.organisation.name} sans numéro de téléphone " \
         "de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
         " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
       )
+
+      fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")
     end
   end
 end

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -160,6 +160,14 @@ describe Notifications::SendEmail, type: :service do
           ["Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné"]
         )
       end
+
+      it "sends a message to mattermost" do
+        expect(MattermostClient).to receive(:send_to_private_channel).with(
+          "Une convocation a été envoyée par l' #{organisation.name} sans numéro de téléphone de l'organisation, " \
+          "du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} et l'usager avec l'ID #{user.id}."
+        )
+        subject
+      end
     end
 
     context "when the email is blank" do

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -163,8 +163,9 @@ describe Notifications::SendEmail, type: :service do
 
       it "sends a message to mattermost" do
         expect(MattermostClient).to receive(:send_to_private_channel).with(
-          "Une convocation a été envoyée par l' #{organisation.name} sans numéro de téléphone de l'organisation, " \
-          "du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} et l'usager avec l'ID #{user.id}."
+          "Une convocation a été envoyée par l'organisation #{organisation.name} sans numéro de téléphone de " \
+          "l'organisation, du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} " \
+          "et l'usager avec l'ID #{user.id}."
         )
         subject
       end

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -162,10 +162,11 @@ describe Notifications::SendEmail, type: :service do
       end
 
       it "sends a message to mattermost" do
-        expect(MattermostClient).to receive(:send_to_private_channel).with(
-          "Une convocation a été envoyée par l'organisation #{organisation.name} sans numéro de téléphone de " \
-          "l'organisation, du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} " \
-          "et l'usager avec l'ID #{user.id}.", once_a_day: true
+        expect(MattermostClient).to receive(:send_unique_message).with(
+          channel_type: :private,
+          text: "Une convocation a été envoyée par l'organisation #{organisation.name} sans numéro de téléphone de " \
+                "l'organisation, du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} " \
+                "et l'usager avec l'ID #{user.id}."
         )
         subject
       end

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -165,7 +165,7 @@ describe Notifications::SendEmail, type: :service do
         expect(MattermostClient).to receive(:send_to_private_channel).with(
           "Une convocation a été envoyée par l'organisation #{organisation.name} sans numéro de téléphone de " \
           "l'organisation, du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} " \
-          "et l'usager avec l'ID #{user.id}."
+          "et l'usager avec l'ID #{user.id}.", once_a_day: true
         )
         subject
       end


### PR DESCRIPTION
On a ces remontées dans sentry
https://sentry.incubateur.net/organizations/betagouv/issues/125507/events/645906f537274c8fa847ad3ed7072183/?project=16&referrer=previous-event&statsPeriod=24h&stream_index=7
Le fail du job et les remontée sont voulus (suite au travail fait ici https://github.com/gip-inclusion/rdv-insertion/pull/2274)

On doit avoir des remontée d'info dans Mattermost pour que le support puisse contacter les organisations en question afin qu'ils renseignent un numéro de téléphone pour que les usagers puisse recevoir correctement les sms mais cette remontée Mattermost ne fonctionnait pas car n'était jamais appelé. C'est fix ici.