### PR TITLE
fix(icons): apply correct kaminari icons

### DIFF
--- a/config/locales/views/kaminari-fr.yml
+++ b/config/locales/views/kaminari-fr.yml
@@ -1,10 +1,10 @@
 fr:
   views:
     pagination:
-      first: "<i class='ri-skip-left-fill'></i>"
-      last: "<i class='ri-skip-right-fill'></i>"
-      previous: "<i class='ri-arrow-left-wide-line'></i><span class='ms-3'>Page précédente</span>"
-      next: "<span class='me-3'>Page suivante</span><i class='ri-arrow-right-wide-line'></i>"
+      first: "<i class='ri-skip-left-line'></i>"
+      last: "<i class='ri-skip-right-line'></i>"
+      previous: "<i class='ri-arrow-left-s-line'></i><span class='ms-3'>Page précédente</span>"
+      next: "<span class='me-3'>Page suivante</span><i class='ri-arrow-right-s-line'></i>"
       truncate: "&hellip;"
   helpers:
     page_entries_info:


### PR DESCRIPTION
Suite au retour de Samantha sur les icones de la pagination, cette PR applique les icônes du DSFR (cf https://github.com/gip-inclusion/rdv-insertion/issues/2414#issuecomment-2514682329)

<img width="756" alt="Screenshot 2024-12-04 at 09 55 46" src="https://github.com/user-attachments/assets/074be794-d147-45b5-a338-2fabb2b9ea77">
