### PR TITLE
feat(orientation): add organisation email notification modal on orientation create

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -18,4 +18,4 @@ FRANCE_TRAVAIL_AUTH_URL=https://somefakeauthurl.fr
 FRANCE_TRAVAIL_RDV_API_URL=https://francetravailfakerdvurl.fr
 
 AGENT_SIGNATURE_KEY=bc995863-5c80-43a3-a31d-0da216e814a4
-HOST=http://example.com
+HOST=http://www.rdv-insertion-test.fake

--- a/.env.test
+++ b/.env.test
@@ -18,3 +18,4 @@ FRANCE_TRAVAIL_AUTH_URL=https://somefakeauthurl.fr
 FRANCE_TRAVAIL_RDV_API_URL=https://francetravailfakerdvurl.fr
 
 AGENT_SIGNATURE_KEY=bc995863-5c80-43a3-a31d-0da216e814a4
+HOST=http://example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema parallel:spec['spec/(?!features)']
         env:
-          HOST: http://example.com
+          HOST: http://www.rdv-insertion-test.fake
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           POSTGRES_USER: rdv_insertion_test
@@ -154,7 +154,7 @@ jobs:
 
           RAILS_ENV=test bundle exec rspec $(cat node_spec_files.txt)
         env:
-          HOST: http://example.com
+          HOST: http://www.rdv-insertion-test.fake
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           POSTGRES_USER: rdv_insertion_test

--- a/app/controllers/users/orientations_controller.rb
+++ b/app/controllers/users/orientations_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class OrientationsController < ApplicationController
-    before_action :set_user, :set_organisations, :set_agents, only: [:new, :edit, :create, :update]
+    before_action :set_user, :set_organisations, :set_agents, :set_orientations, only: [:new, :edit, :create, :update]
     before_action :set_orientation, only: [:edit, :update, :destroy]
     before_action :set_agent_ids_by_organisation_id, :set_orientation_types, only: [:new, :edit]
 
@@ -65,6 +65,12 @@ module Users
       authorize @orientation
     end
 
+    def set_orientations
+      @orientations = policy_scope(@user.orientations)
+                      .where(organisation: { department_id: current_department_id })
+                      .includes(:agent, :organisation, :orientation_type).order(starts_at: :asc)
+    end
+
     def set_orientation_types
       @orientation_types = OrientationType.for_department(@current_department)
     end
@@ -74,8 +80,9 @@ module Users
     end
 
     def save_orientation_and_redirect
+      @should_notify_organisation = new_organisation?
       if save_orientation.success?
-        turbo_stream_redirect structure_user_parcours_path(user_id: @user.id)
+        render :create
       elsif save_orientation.shrinkeable_orientation.present?
         turbo_stream_confirm_update_anterior_ends_at_modal
       else
@@ -100,6 +107,10 @@ module Users
           user: @user
         }
       )
+    end
+
+    def new_organisation?
+      @user.organisations.exclude?(@orientation.organisation)
     end
   end
 end

--- a/app/controllers/users/orientations_controller.rb
+++ b/app/controllers/users/orientations_controller.rb
@@ -1,6 +1,7 @@
 module Users
   class OrientationsController < ApplicationController
-    before_action :set_user, :set_organisations, :set_agents, :set_orientations, only: [:new, :edit, :create, :update]
+    before_action :set_user, :set_organisations, :set_agents, only: [:new, :edit, :create, :update]
+    before_action :set_orientations, only: [:create]
     before_action :set_orientation, only: [:edit, :update, :destroy]
     before_action :set_agent_ids_by_organisation_id, :set_orientation_types, only: [:new, :edit]
 

--- a/app/views/users/orientations/create.turbo_stream.erb
+++ b/app/views/users/orientations/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <% if @should_notify_organisation %>
   <% if @orientation.organisation.email? %>
     <%= turbo_stream.replace "remote_modal" do %>
-      <%= render partial: "organisations/user_added_notifications/form",
+      <%= render partial: "users/orientations/user_added_notifications/form",
         locals: { emails: [@orientation.organisation.email],
                   user: @user,
                   organisation: @orientation.organisation } %>

--- a/app/views/users/orientations/create.turbo_stream.erb
+++ b/app/views/users/orientations/create.turbo_stream.erb
@@ -1,0 +1,19 @@
+<% if @should_notify_organisation %>
+  <% if @orientation.organisation.email? %>
+    <%= turbo_stream.replace "remote_modal" do %>
+      <%= render partial: "organisations/user_added_notifications/form",
+        locals: { emails: [@orientation.organisation.email],
+                  user: @user,
+                  organisation: @orientation.organisation } %>
+    <% end %>
+  <% else %>
+    <%= turbo_stream.replace "remote_modal" do %>
+      <%= render partial: "organisations/user_added_notifications/no_email",
+        locals: { organisation: @orientation.organisation } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.replace "orientations_list" do %>
+  <%= render partial: "orientations/orientations_list", locals: { orientations: @orientations } %>
+<% end %>

--- a/app/views/users/orientations/user_added_notifications/_form.html.erb
+++ b/app/views/users/orientations/user_added_notifications/_form.html.erb
@@ -1,0 +1,34 @@
+<%= render "common/remote_modal", title: "Informer l’organisation par email" do %>
+  <%= form_for(:email, url: organisations_user_added_notifications_path, method: :post) do |f| %>
+      <div class="p-3 pt-0">
+        <p>Prévenir l’organisation que l’usager a été ajouté à leur liste </p>
+        <div class="mb-3">
+          <h5 class="text-dark-blue h4-as-labels">Destinataire</h5>
+            <%= f.select :to,
+                        emails,
+                        { include_blank: false },
+                        class: "form-control"
+            %>
+        </div>
+        <div class="mb-3">
+          <h5 class="text-dark-blue h4-as-labels">Objet</h5>
+            <%= f.text_field :subject, class: "form-control", value: "[RDV-Insertion] Un usager a été ajouté à votre organisation" %>
+        </div>
+        <div class="mb-3">
+          <h5 class="text-dark-blue h4-as-labels">Message</h5>
+            <%= f.text_area :content, class: "form-control", cols: 15, rows: 6, value: "L'usager #{user} a été ajouté à votre organisation #{organisation.name}.\nVous pouvez consulter son historique d'accompagnement ainsi que les éventuels documents de parcours téléchargés (diagnostic, contrat) sur le lien suivant :\n #{organisation_user_parcours_url(user_id: user.id, organisation_id: organisation.id, host: ENV['HOST'])}" %>
+        </div>
+
+        <div class="d-flex justify-content-end align-items-center pt-2">
+          <button type="button" class="btn btn-blue-out border-0 me-2" data-bs-dismiss="modal">
+            Ignorer cette étape
+          </button>
+          <button type="submit" class="btn btn-blue">
+            <i class="ri-send-plane-line me-2"></i>
+            Envoyer
+          </button>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -115,7 +115,7 @@ describe "Agents can add user orientation", :js do
           "L'usager #{user} a été ajouté à votre organisation Asso 26.\nVous pouvez consulter son historique" \
           " d'accompagnement ainsi que les éventuels documents de parcours téléchargés (diagnostic, contrat) sur le" \
           " lien suivant :\n " \
-          "http://localhost:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}/users/#{user.id}/parcours",
+          "#{ENV['HOST']}:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}/users/#{user.id}/parcours",
         user_attachements: [],
         reply_to: agent.email
       ).and_return(OpenStruct.new(deliver_now: nil))

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -115,8 +115,8 @@ describe "Agents can add user orientation", :js do
           "L'usager #{user} a été ajouté à votre organisation Asso 26.\nVous pouvez consulter son historique" \
           " d'accompagnement ainsi que les éventuels documents de parcours téléchargés (diagnostic, contrat) sur le" \
           " lien suivant :\n " \
-          "#{ENV['HOST']}:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}" \
-          "/users/#{user.id}/parcours",
+          "http://www.rdv-insertion-test.fake:#{Capybara.current_session.server.port}" \
+          "/organisations/#{other_organisation.id}/users/#{user.id}/parcours",
         user_attachements: [],
         reply_to: agent.email
       ).and_return(OpenStruct.new(deliver_now: nil))

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -115,7 +115,8 @@ describe "Agents can add user orientation", :js do
           "L'usager #{user} a été ajouté à votre organisation Asso 26.\nVous pouvez consulter son historique" \
           " d'accompagnement ainsi que les éventuels documents de parcours téléchargés (diagnostic, contrat) sur le" \
           " lien suivant :\n " \
-          "#{ENV['HOST']}:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}/users/#{user.id}/parcours",
+          "#{ENV['HOST']}:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}" \
+          "/users/#{user.id}/parcours",
         user_attachements: [],
         reply_to: agent.email
       ).and_return(OpenStruct.new(deliver_now: nil))

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -91,6 +91,77 @@ describe "Agents can add user orientation", :js do
     expect(page).to have_content("non renseigné")
   end
 
+  it "open organisation email notification modal when adding an orientation to another organisation" do
+    visit organisation_user_path(organisation_id: organisation.id, id: user.id)
+
+    click_link("Parcours")
+    click_button("Ajouter une orientation")
+
+    page.select orientation_type_social.name, from: "orientation[orientation_type_id]"
+    page.execute_script("document.querySelector('#orientation_starts_at').value = '2023-07-03'")
+    page.select "Asso 26", from: "orientation_organisation_id"
+    click_button "Enregistrer"
+
+    expect(page).to have_content("Informer l’organisation par email")
+    expect(page).to have_content("Prévenir l’organisation que l’usager a été ajouté à leur liste")
+    click_button "Envoyer"
+
+    expect(OrganisationMailer).to receive(:user_added)
+      .once
+      .with(
+        to: other_organisation.email,
+        subject: "[RDV-Insertion] Un usager a été ajouté à votre organisation",
+        content:
+          "L'usager #{user} a été ajouté à votre organisation Asso 26.\nVous pouvez consulter son historique" \
+          " d'accompagnement ainsi que les éventuels documents de parcours téléchargés (diagnostic, contrat) sur le" \
+          " lien suivant :\n " \
+          "http://localhost:#{Capybara.current_session.server.port}/organisations/#{other_organisation.id}/users/#{user.id}/parcours",
+        user_attachements: [],
+        reply_to: agent.email
+      ).and_return(OpenStruct.new(deliver_now: nil))
+
+    expect(page).to have_content("Du 03/07/2023 à aujourd'hui")
+    expect(page).to have_content("Asso 26")
+  end
+
+  it "open organisation no email warning modal when adding an orientation to another organisation with no email" do
+    other_organisation.update(email: nil)
+    visit organisation_user_path(organisation_id: organisation.id, id: user.id)
+
+    click_link("Parcours")
+    click_button("Ajouter une orientation")
+
+    page.select orientation_type_social.name, from: "orientation[orientation_type_id]"
+    page.execute_script("document.querySelector('#orientation_starts_at').value = '2023-07-03'")
+    page.select "Asso 26", from: "orientation_organisation_id"
+    click_button "Enregistrer"
+
+    expect(page).to have_no_content("Informer l’organisation par email")
+    expect(page).to have_content("L'organisation Asso 26 n'a pas d'adresse email renseignée.")
+    click_button "J'ai compris"
+
+    expect(page).to have_content("Du 03/07/2023 à aujourd'hui")
+    expect(page).to have_content("Asso 26")
+  end
+
+  it "does not open email notification modal when user is already in the organisation" do
+    user.organisations << other_organisation
+    visit organisation_user_path(organisation_id: organisation.id, id: user.id)
+
+    click_link("Parcours")
+    click_button("Ajouter une orientation")
+
+    page.select orientation_type_social.name, from: "orientation[orientation_type_id]"
+    page.execute_script("document.querySelector('#orientation_starts_at').value = '2023-07-03'")
+    page.select "Asso 26", from: "orientation_organisation_id"
+    click_button "Enregistrer"
+
+    expect(page).to have_content("Du 03/07/2023 à aujourd'hui")
+    expect(page).to have_content("Asso 26")
+    expect(page).to have_no_content("Informer l’organisation par email")
+    expect(page).to have_no_content("L'organisation Asso 26 n'a pas d'adresse email renseignée.")
+  end
+
   describe "department scoped orientations" do
     let!(:other_department) { create(:department, number: "13") }
     let!(:other_department_agent) { create(:agent) }


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2450

On met en place une pop-in d’envoi d’email depuis l’onglet “parcours” lorsqu'on ajoute un parcours dans une autre organisation. Cette modale s'affiche si l'usager ne fait pas déjà parti de l'organisation concernée par le parcours.
Plutôt que de surcharger le contrôleur j'ai préféré mettre le code dans le fichier turbo stream [app/views/users/orientations/create.turbo_stream.erb](https://github.com/gip-inclusion/rdv-insertion/pull/2512/files#diff-12931bfc917b60d1329f05b6e4eda9445ebc70d5df114f84dc75057b278b2277).
On utilise un form spécifique d'envoi d'email car le contenu change et en désactive la possibilité de mettre une PJ.