### PR TITLE
fix(webhooks): Do not import already deleted users

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -110,11 +110,13 @@ module InboundWebhooks
         rdv_solidarites_rdv.user_ids
       end
 
+      # rubocop:disable Metrics/AbcSize
       def find_or_create_users
         existing_users = User.where(rdv_solidarites_user_id: rdv_solidarites_user_ids).to_a
 
-        new_rdv_solidarites_users = rdv_solidarites_rdv.users.reject do |user|
-          user.id.in?(existing_users.map(&:rdv_solidarites_user_id))
+        new_rdv_solidarites_users = rdv_solidarites_rdv.users.select do |user|
+          !user.id.in?(existing_users.map(&:rdv_solidarites_user_id)) &&
+            !user.id.in?(previously_deleted_users.map(&:old_rdv_solidarites_user_id))
         end
 
         new_users = new_rdv_solidarites_users.map do |rdv_solidarites_user|
@@ -129,6 +131,12 @@ module InboundWebhooks
         end
 
         @users = existing_users + new_users
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # if we process this webhook after a user has been deleted, we should not re-create it
+      def previously_deleted_users
+        @previously_deleted_users ||= User.where(old_rdv_solidarites_user_id: rdv_solidarites_user_ids)
       end
 
       def participations_attributes_destroyed

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -342,6 +342,51 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
             subject
           end
         end
+
+        context "when a user is previously deleted" do
+          let!(:previously_deleted_rdv_solidarites_user_id) { rand(1000) }
+          let!(:user) { create(:user, old_rdv_solidarites_user_id: previously_deleted_rdv_solidarites_user_id) }
+
+          let!(:users) do
+            [
+              { id: previously_deleted_rdv_solidarites_user_id, first_name: "James", last_name: "Cameron",
+                phone_number: "0755929249", email: "james@cameron.com" },
+              { id: user_id2, first_name: "Jane", last_name: "Campion", created_at: "2021-05-29 14:20:20 +0200",
+                email: "jane@campion.com", phone_number: nil, birth_date: nil, address: nil }
+            ]
+          end
+
+          it "does not create the user" do
+            expect(User).not_to receive(:create!)
+            subject
+          end
+
+          it "discards the previously deleted user participation" do
+            expect(UpsertRecordJob).to receive(:perform_later)
+              .with(
+                "Rdv",
+                data,
+                {
+                  participations_attributes: [{
+                    id: nil,
+                    status: "unknown",
+                    created_by: "user",
+                    user_id: user2.id,
+                    rdv_solidarites_participation_id: 999,
+                    follow_up_id: follow_up2.id,
+                    convocable: false,
+                    rdv_solidarites_agent_prescripteur_id: nil
+                  }],
+                  agent_ids: [agent.id],
+                  organisation_id: organisation.id,
+                  motif_id: motif.id,
+                  lieu_id: lieu.id,
+                  last_webhook_update_received_at: timestamp
+                }
+              )
+            subject
+          end
+        end
       end
 
       context "for a participation update and destroy" do


### PR DESCRIPTION
closes #2516 .

Il arrive que certains usagers soient supprimés, puis qu'on les recrée si on process un webhook de rdv associé après la suppression de ces usagers.
Comme il n'y a rien qui nous garantisse qu'un webhook de rdv ne soit pas processé après le webhook de suppression de l'usager, je fais en sorte de vérifié que les usagers qu'on importe n'ont pas déjà été supprimé auparavant (grâce à la colonne `old_rdv_solidarites_user_id`)  