### PR TITLE
spec(category_configuration): ensure category configuration edition works

### DIFF
--- a/spec/features/agent_can_edit_category_configuration_spec.rb
+++ b/spec/features/agent_can_edit_category_configuration_spec.rb
@@ -1,0 +1,38 @@
+describe "Agents can edit category configuration", :js do
+  let!(:agent) { create(:agent) }
+  let!(:organisation) { create(:organisation) }
+  let!(:category_configuration) { create(:category_configuration, organisation: organisation) }
+  let!(:agent_role) { create(:agent_role, organisation: organisation, agent: agent, access_level: "admin") }
+
+  before do
+    setup_agent_session(agent)
+  end
+
+  context "category configuration edit" do
+    it "allows to edit category configuration" do
+      visit edit_organisation_category_configuration_path(organisation, organisation.category_configurations.first)
+
+      fill_in "category_configuration_phone_number", with: "3234"
+      fill_in "category_configuration_phone_number", with: "3234"
+      fill_in "category_configuration_email_to_notify_rdv_changes", with: "test@test.com"
+      fill_in "category_configuration_email_to_notify_no_available_slots", with: "test@test.com"
+
+      find("input[data-periodic-invites-form-target='enable']").check
+      fill_in "category_configuration_template_rdv_title_override", with: "ceci est un rdv"
+
+      click_button "Enregistrer"
+
+      expect(page).to have_content("3234")
+      expect(page).to have_content("test@test.com")
+      expect(page).to have_content("ceci est un rdv")
+      expect(page).to have_content("Les invitations périodiques sont actives")
+      expect(page).to have_content("les invitations n'expireront jamais.")
+
+      expect(category_configuration.reload.phone_number).to eq("3234")
+      expect(category_configuration.email_to_notify_rdv_changes).to eq("test@test.com")
+      expect(category_configuration.email_to_notify_no_available_slots).to eq("test@test.com")
+      expect(category_configuration.template_rdv_title_override).to eq("ceci est un rdv")
+      expect(category_configuration.number_of_days_between_periodic_invites).to eq(14)
+    end
+  end
+end

--- a/spec/features/agent_can_edit_organisation_spec.rb
+++ b/spec/features/agent_can_edit_organisation_spec.rb
@@ -12,15 +12,25 @@ describe "Agents can edit organisation", :js do
   end
 
   context "organisation edit" do
-    it "allows to set a code safir" do
+    it "allows to edit organisation properties" do
       visit organisation_category_configurations_path(organisation)
       click_link("Modifier", href: edit_organisation_path(organisation))
 
       page.fill_in "organisation_safir_code", with: "153425"
+      page.fill_in "organisation_name", with: "A new name"
+      page.fill_in "organisation_email", with: "new_email@test.com"
+      page.fill_in "organisation_phone_number", with: "3234"
       click_button "Enregistrer"
 
       expect(page).to have_content("153425")
+      expect(page).to have_content("A new name")
+      expect(page).to have_content("new_email@test.com")
+      expect(page).to have_content("3234")
+
       expect(organisation.reload.safir_code).to eq("153425")
+      expect(organisation.name).to eq("A new name")
+      expect(organisation.phone_number).to eq("3234")
+      expect(organisation.email).to eq("new_email@test.com")
     end
   end
 end


### PR DESCRIPTION
Cette PR ajoute des tests e2e à la feature d'édition de category configuration

fix https://github.com/gip-inclusion/rdv-insertion/issues/921