### PR TITLE
fix(tags): remove duplicated tags

### DIFF
--- a/lib/chores/clean_duplicated_tags.rb
+++ b/lib/chores/clean_duplicated_tags.rb
@@ -1,0 +1,18 @@
+module Chores
+  class CleanDuplicatedTags
+    def self.call
+      duplicates = TagUser
+        .select('tag_id, user_id')
+        .group(:tag_id, :user_id)
+        .having('COUNT(*) > 1')
+        .pluck(:tag_id, :user_id)
+
+      duplicates.each do |tag_id, user_id|
+        records = TagUser.where(tag_id: tag_id, user_id: user_id).order(:created_at)
+
+        # Keep the first record and delete the others
+        records[1..-1].each(&:destroy)
+      end
+    end
+  end
+end

--- a/lib/tasks/chores/clean_duplicated_tags.rake
+++ b/lib/tasks/chores/clean_duplicated_tags.rake
@@ -1,0 +1,8 @@
+require Rails.root.join("lib/chores/clean_duplicated_tags")
+
+namespace :chores do
+  desc "Remove all duplicate tag-user combinations"
+  task remove_duplicates: :environment do
+    CleanDuplicatedTags.call
+  end
+end

--- a/spec/lib/chores/clean_duplicated_tags_spec.rb
+++ b/spec/lib/chores/clean_duplicated_tags_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require Rails.root.join("lib/chores/clean_duplicated_tags")
+
+RSpec.describe Chores::CleanDuplicatedTags, type: :service do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:tag1) { create(:tag) }
+    let(:tag2) { create(:tag) }
+
+    context "when there are duplicate TagUser records" do
+      before do
+        TagUser.new(tag: tag1, user: user).save(validate: false)
+        TagUser.new(tag: tag1, user: user).save(validate: false)
+        TagUser.new(tag: tag2, user: user).save(validate: false)
+        TagUser.new(tag: tag2, user: user).save(validate: false)
+        TagUser.new(tag: tag2, user: user).save(validate: false)
+      end
+
+      it "removes duplicates and keeps the first record" do
+        expect { described_class.call }.to change(TagUser, :count).by(-3)
+
+        expect(TagUser.where(tag: tag1, user: user).count).to eq(1)
+        expect(TagUser.where(tag: tag2, user: user).count).to eq(1)
+      end
+    end
+
+    context "when there are no duplicates" do
+      before do
+        TagUser.new(tag: tag1, user: user).save(validate: false)
+        TagUser.new(tag: tag2, user: user).save(validate: false)
+      end
+
+      it "does not remove any records" do
+        expect { described_class.call }.not_to(change(TagUser, :count))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ajoute une tache à faire tourner permettant de supprimer les tags dupliqués. 
Nous avons déjà une validation sur l'unicité de la paire tag_id user_id mais il semblerait qu'un bug (frontend ?) ait causé l'enregistrement simultané de dizaines de tag avec des timestamps extrêmement proches qui ont donc peut-être échappé à la validation
Cf : 
<img width="455" alt="image" src="https://github.com/user-attachments/assets/4eee72f8-f6c2-427d-9f76-a45f867d0574" />

Je suggère donc qu'on supprime ces doublons puis qu'on ajoute une contrainte d'unicité au niveau de la DB cette fois. 
Impossible pour le moment