### PR TITLE
feat(rgpd): partition motifs by org type

### DIFF
--- a/app/controllers/category_configurations_controller.rb
+++ b/app/controllers/category_configurations_controller.rb
@@ -14,7 +14,8 @@ class CategoryConfigurationsController < ApplicationController
                 only: [:index, :new, :create, :show, :edit, :update, :destroy]
   before_action :set_category_configuration, :set_file_configuration, :set_template,
                 only: [:show, :edit, :update, :destroy]
-  before_action :set_department, :set_file_configurations, only: [:new, :create, :edit, :update]
+  before_action :set_department, :set_file_configurations, :set_authorized_motif_categories,
+                only: [:new, :create, :edit, :update]
   before_action :set_back_to_users_list_url, :set_messages_configuration, :set_category_configurations, only: [:index]
 
   def index
@@ -105,6 +106,10 @@ class CategoryConfigurationsController < ApplicationController
 
   def set_organisation
     @organisation = current_organisation
+  end
+
+  def set_authorized_motif_categories
+    @authorized_motif_categories = MotifCategory.authorized_for_organisation(@organisation)
   end
 
   def user_count_by_tag_id

--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -18,4 +18,14 @@ class MotifCategory < ApplicationRecord
 
   enum motif_category_type: { autre: "autre", siae: "siae", rsa_orientation: "rsa_orientation",
                               rsa_accompagnement: "rsa_accompagnement" }
+
+  RSA_RELATED_TYPES = %w[rsa_orientation rsa_accompagnement].freeze
+
+  scope :authorized_for_organisation, lambda { |organisation|
+    if organisation.rsa_related?
+      where(motif_category_type: RSA_RELATED_TYPES)
+    else
+      where.not(motif_category_type: organisation.organisation_type)
+    end
+  }
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -62,6 +62,7 @@ class Organisation < ApplicationRecord
   def with_parcours_access?
     organisation_type.in?(ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
   end
+  alias_method :rsa_related?, :with_parcours_access?
 
   def requires_dpa_acceptance?
     dpa_agreement.nil?

--- a/app/views/category_configurations/_category_configuration_form.html.erb
+++ b/app/views/category_configurations/_category_configuration_form.html.erb
@@ -22,7 +22,7 @@
               required="true"
             >
               <option value=""> - </option>
-              <% MotifCategory.all.each do |motif_category| %>
+              <% @authorized_motif_categories.each do |motif_category| %>
                 <option value="<%= motif_category.id %>"><%= motif_category.name %></option>
               <% end %>
             </select>

--- a/spec/factories/motif_category.rb
+++ b/spec/factories/motif_category.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :motif_category do
     template
-    motif_category_type { "autre" }
+    motif_category_type { "rsa_orientation" }
     sequence(:short_name) { |n| "rsa_orientation_#{n}" }
     name { "RSA orientation" }
   end

--- a/spec/features/agent_can_create_category_configuration_spec.rb
+++ b/spec/features/agent_can_create_category_configuration_spec.rb
@@ -1,0 +1,63 @@
+describe "Agents can edit category configuration", :js do
+  let!(:agent) { create(:agent) }
+  let!(:organisation) { create(:organisation, organisation_type: "delegataire_rsa") }
+  let!(:agent_role) { create(:agent_role, organisation: organisation, agent: agent, access_level: "admin") }
+  let!(:motif_category) do
+    create(
+      :motif_category,
+      name: "RSA Follow up",
+      short_name: "rsa_follow_up",
+      motif_category_type: "rsa_accompagnement"
+    )
+  end
+
+  let!(:category_configuration) { create(:category_configuration, organisation:, file_configuration:) }
+  let(:file_configuration) { create(:file_configuration) }
+
+  before do
+    stub_rdv_solidarites_activate_motif_category_territories(
+      organisation.rdv_solidarites_organisation_id,
+      motif_category.short_name
+    )
+    setup_agent_session(agent)
+  end
+
+  context "category configuration edit" do
+    it "allows to create category configuration" do
+      visit new_organisation_category_configuration_path(organisation)
+
+      fill_in "category_configuration_phone_number", with: "3234"
+      fill_in "category_configuration_email_to_notify_rdv_changes", with: "test@test.com"
+      fill_in "category_configuration_email_to_notify_no_available_slots", with: "test@test.com"
+
+      select "RSA Follow up", from: "category_configuration[motif_category_id]"
+
+      find("input[name=\"category_configuration[file_configuration_id]\"]").click
+
+      click_button "Enregistrer"
+
+      expect(page).to have_content("3234")
+      expect(page).to have_content("test@test.com")
+
+      new_category_configuration = CategoryConfiguration.last
+      expect(new_category_configuration.reload.phone_number).to eq("3234")
+      expect(new_category_configuration.email_to_notify_rdv_changes).to eq("test@test.com")
+      expect(new_category_configuration.email_to_notify_no_available_slots).to eq("test@test.com")
+    end
+
+    context "motif category selection" do
+      let!(:motif_category2) do
+        create(:motif_category, name: "Autre", short_name: "autre", motif_category_type: "autre")
+      end
+
+      it "allows to select authorized motif categories" do
+        visit new_organisation_category_configuration_path(organisation)
+
+        expect(page).to have_select(
+          "category_configuration[motif_category_id]", options: ["-", "RSA Follow up",
+                                                                 category_configuration.motif_category.name]
+        )
+      end
+    end
+  end
+end

--- a/spec/features/agent_can_edit_category_configuration_spec.rb
+++ b/spec/features/agent_can_edit_category_configuration_spec.rb
@@ -13,7 +13,6 @@ describe "Agents can edit category configuration", :js do
       visit edit_organisation_category_configuration_path(organisation, organisation.category_configurations.first)
 
       fill_in "category_configuration_phone_number", with: "3234"
-      fill_in "category_configuration_phone_number", with: "3234"
       fill_in "category_configuration_email_to_notify_rdv_changes", with: "test@test.com"
       fill_in "category_configuration_email_to_notify_no_available_slots", with: "test@test.com"
 

--- a/spec/support/stub_helper.rb
+++ b/spec/support/stub_helper.rb
@@ -15,6 +15,14 @@ module StubHelper
     )
   end
 
+  def stub_rdv_solidarites_activate_motif_category_territories(rdv_solidarites_organisation_id, motif_name)
+    stub_request(
+      :post, "http://www.rdv-solidarites-test.localhost/api/rdvinsertion/motif_category_territories"
+    ).with(
+      body: "{\"motif_category_short_name\":\"#{motif_name}\",\"organisation_id\":#{rdv_solidarites_organisation_id}}"
+    ).to_return(status: 200, body: "", headers: {})
+  end
+
   def stub_rdv_solidarites_assign_many_referents(rdv_solidarites_user_id)
     stub_request(
       :post, "#{ENV['RDV_SOLIDARITES_URL']}/api/rdvinsertion/referent_assignations/create_many"


### PR DESCRIPTION
Cette PR empêche l'ajout de motifs non désirés en restreignant les organisations à n'utiliser que les motifs autorisés pour leur structure. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2460