### PR TITLE
feat(users): do not search in motif

### DIFF
--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with method: :get, url: url, local: true do |form| %>
   <div class="d-flex">
-    <% url_params.except(:search_query).each do |key, value| %>
+    <% url_params.except(:search_query, :motif_category_id).each do |key, value| %>
       <%= form.hidden_field key, value: value %>
     <% end %>
 


### PR DESCRIPTION
Cette PR permet de ne pas rechercher dans les motifs mais de réinitialiser le motif lorsque l'on recherche 

fix https://github.com/gip-inclusion/rdv-insertion/issues/2501