### PR TITLE
feat(search): add active search view

### DIFF
--- a/app/controllers/concerns/users/filterable.rb
+++ b/app/controllers/concerns/users/filterable.rb
@@ -22,9 +22,10 @@ module Users::Filterable
   def filter_users_by_tags
     return if params[:tag_ids].blank?
 
+    @filtered_tags = Tag.where(id: params[:tag_ids])
     user_ids = TagUser
                .select(:user_id)
-               .where(tag_id: params[:tag_ids])
+               .where(tag_id: @filtered_tags)
                .group(:user_id)
                .having("COUNT(DISTINCT tag_id) = ?", [params[:tag_ids]].flatten.count)
                .pluck(:user_id)
@@ -58,7 +59,8 @@ module Users::Filterable
   def filter_users_by_referent
     return if params[:referent_id].blank?
 
-    @users = @users.joins(:referents).where(referents: { id: params[:referent_id] })
+    @referent = Agent.find(params[:referent_id])
+    @users = @users.joins(:referents).where(referents: { id: @referent.id })
   end
 
   def filter_users_by_search_query

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,27 @@
 module UsersHelper
+  def filter_list
+    [
+      :search_query,
+      :tag_ids,
+      :status,
+      :orientation_type,
+      :action_required,
+      :referent_id,
+      :creation_date_after,
+      :creation_date_before,
+      :convocation_date_before,
+      :convocation_date_after,
+      :first_invitation_date_before,
+      :first_invitation_date_after,
+      :last_invitation_date_before,
+      :last_invitation_date_after
+    ]
+  end
+
+  def active_filter_list
+    filter_list.select { |filter| params[filter].present? }
+  end
+
   def show_convocation?(category_configuration)
     category_configuration.convene_user?
   end
@@ -15,13 +38,8 @@ module UsersHelper
     users.empty? && params[:search_query].present?
   end
 
-  def display_back_to_list_button? # rubocop:disable Metrics/AbcSize
-    [
-      params[:search_query], params[:status], params[:action_required], params[:first_invitation_date_before],
-      params[:last_invitation_date_before], params[:first_invitation_date_after], params[:last_invitation_date_after],
-      params[:referent_id], params[:creation_date_after], params[:creation_date_before], params[:tag_ids],
-      params[:convocation_date_before], params[:convocation_date_after], params[:orientation_type]
-    ].any?(&:present?)
+  def display_back_to_list_button?
+    active_filter_list.any?
   end
 
   def options_for_select_status(statuses_count)

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -10,6 +10,7 @@ $orange-light: #ffb88e;
 $dark-blue: #083b66;
 $dark-blue-dim: #083c66ab;
 $light-blue-alt: #d8e1f4;
+$light-blue-alt-2: #E9F2FA;
 $light: #f9fbff;
 $green: #57EE93 ;
 $rdv_solidarites_blue: #222e5c;

--- a/app/javascript/stylesheets/pages/_users.scss
+++ b/app/javascript/stylesheets/pages/_users.scss
@@ -61,3 +61,17 @@
     width: 80%;
   }
 }
+
+.active-filters-recap {
+  > div:first-child {
+    min-width: 110px;
+  }
+  .active-filter-badge {
+    background-color: $light-blue-alt-2;
+    border-radius: 20px;
+    padding: 5px 10px;
+    margin-right: 5px;
+    margin-bottom: 5px;
+    font-size: 14px;
+  }
+}

--- a/app/javascript/stylesheets/pages/_users.scss
+++ b/app/javascript/stylesheets/pages/_users.scss
@@ -90,4 +90,8 @@
   font-size: 12px;
   line-height: 21px;
   left: 5px;
+
+  &.convocation-date-filter-active {
+    left: -2px;
+  }
 }

--- a/app/javascript/stylesheets/pages/_users.scss
+++ b/app/javascript/stylesheets/pages/_users.scss
@@ -64,7 +64,7 @@
 
 .active-filters-recap {
   > div:first-child {
-    min-width: 110px;
+    min-width: 85px;
   }
   .active-filter-badge {
     background-color: $light-blue-alt-2;
@@ -73,5 +73,21 @@
     margin-right: 5px;
     margin-bottom: 5px;
     font-size: 14px;
+
+    a {
+      margin-left: 5px;
+    }
   }
+}
+
+.filter-active {
+  position: relative;
+  display: inline-block;
+  background-color: $light-blue-alt-2;
+  width: 23px;
+  height: 23px;
+  border-radius: 100%;
+  font-size: 12px;
+  line-height: 21px;
+  left: 5px;
 }

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -19,37 +19,31 @@
       <% else %>
         <span class="d-flex me-2 active-filter-badge">
           <% if filter == :referent_id %>
-            suivi par <%= @referent %>
-          <% end %>
-          <% if filter == :orientation_type %>
+            Suivi par <%= @referent %>
+          <% elsif filter == :orientation_type %>
             Orientation : <%= params[filter] %>
-          <% end %>
-          <% if filter == :creation_date_before %>
+          <% elsif filter == :creation_date_before %>
             Créé avant le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :creation_date_after %>
+          <% elsif filter == :creation_date_after %>
             Créé après le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :convocation_date_before %>
+          <% elsif filter == :convocation_date_before %>
             Convoqué avant le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :convocation_date_after %>
+          <% elsif filter == :convocation_date_after %>
             Convoqué après le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :first_invitation_date_before %>
+          <% elsif filter == :first_invitation_date_before %>
             Première invitation avant le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :first_invitation_date_after %>
+          <% elsif filter == :first_invitation_date_after %>
             Première invitation après le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :last_invitation_date_before %>
+          <% elsif filter == :last_invitation_date_before %>
             Dernière invitation avant le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :last_invitation_date_after %>
+          <% elsif filter == :last_invitation_date_after %>
             Dernière invitation après le : <%= format_date(params[filter].to_date) %>
-          <% end %>
-          <% if filter == :action_required %>
+          <% elsif filter == :action_required %>
             Intervention nécessaire
+          <% elsif filter == :status %>
+            Statut : <%= I18n.t("activerecord.attributes.follow_up.statuses.#{params[filter]}") %>
+          <% else %>
+            <%= params[filter] %>
           <% end %>
           <%= link_to structure_users_path(url_params.except(filter)) do %>
             <i class="ri-close-line"></i>

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -42,8 +42,6 @@
             Intervention nécessaire
           <% elsif filter == :status %>
             Statut : <%= I18n.t("activerecord.attributes.follow_up.statuses.#{params[filter]}") %>
-          <% else %>
-            <%= params[filter] %>
           <% end %>
           <%= link_to structure_users_path(url_params.except(filter)) do %>
             <i class="ri-close-line"></i>

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -1,0 +1,60 @@
+<div class="mb-2 active-filters-recap align-items-start d-flex">
+  <div class="me-2">
+    <%= @users.total_count %> dossier(s) 
+    <% if params[:search_query].present? %>
+    correspondant à votre recherche "<strong><%= params[:search_query] %></strong>"
+    <% end %>
+  </div>
+  <div class="active-filters-container d-flex flex-wrap">
+    <% (active_filter_list - [:search_query]).each do |filter| %>
+      <% if filter == :tag_ids %>
+        <% @filtered_tags.each do |tag| %>
+          <span class="d-flex me-2 active-filter-badge">
+            <%= tag.value %>
+          </span>
+        <% end %>
+      <% else %>
+        <span class="d-flex me-2 active-filter-badge">
+          <% if filter == :referent_id %>
+            suivi par <%= @referent %>
+          <% end %>
+          <% if filter == :orientation_type %>
+            Orientation : <%= params[filter] %>
+          <% end %>
+          <% if filter == :creation_date_before %>
+            Créé avant le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :creation_date_after %>
+            Créé après le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :convocation_date_before %>
+            Convoqué avant le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :convocation_date_after %>
+            Convoqué après le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :first_invitation_date_before %>
+            Première invitation avant le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :first_invitation_date_after %>
+            Première invitation après le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :last_invitation_date_before %>
+            Dernière invitation avant le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :last_invitation_date_after %>
+            Dernière invitation après le : <%= format_date(params[filter].to_date) %>
+          <% end %>
+          <% if filter == :action_required %>
+            Intervention nécessaire
+          <% end %>
+        </span>
+      <% end %>
+    <% end %>
+    <%= link_to structure_users_path(url_params.except(*active_filter_list)) do %>
+      <i class="ri-arrow-go-back-line"></i>
+      <span class="btn-link">Réinitialiser</span>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -11,6 +11,9 @@
         <% @filtered_tags.each do |tag| %>
           <span class="d-flex me-2 active-filter-badge">
             <%= tag.value %>
+            <%= link_to structure_users_path(url_params.merge(tag_ids: params[:tag_ids] - [tag.id.to_s])) do %>
+              <i class="ri-close-line"></i>
+            <% end %>
           </span>
         <% end %>
       <% else %>
@@ -47,6 +50,9 @@
           <% end %>
           <% if filter == :action_required %>
             Intervention nécessaire
+          <% end %>
+          <%= link_to structure_users_path(url_params.except(filter)) do %>
+            <i class="ri-close-line"></i>
           <% end %>
         </span>
       <% end %>

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -3,9 +3,9 @@
     <%= link_to(new_structure_creation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
       <button class="btn btn-grey w-100">
         <% if params[:creation_date_after].present? %>
-          Créés entre le <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> et le <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %>
+          Créés entre le <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> et le <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %> <span class="filter-active">1</span>
         <% elsif params[:creation_date_before].present? %>
-          Créés avant le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %>
+          Créés avant le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %> <span class="filter-active">1</span>
         <% else %>
           Filtrer par date de création
         <% end %>

--- a/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
@@ -19,7 +19,7 @@
             <p>Convocations avant le <%= format_date(params[:convocation_date_before].to_date) %></p>
           <% end %>
         </div>
-        <span class="filter-active" style="left: -2px">1</span>
+        <span class="filter-active convocation-date-filter-active">1</span>
         <i class="ri-pencil-fill text-dark-blue"></i>
       <% else %>
         <span class="w-100">Filtrer par date d'invitation ou de convocation</span>

--- a/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
@@ -4,9 +4,9 @@
       <% if params[:first_invitation_date_before] || params[:first_invitation_date_after] || params[:last_invitation_date_before] || params[:last_invitation_date_after] || params[:convocation_date_after] %>
         <div class="invitations-date-filter-content">
           <% if params[:first_invitation_date_after].present? %>
-            <p>Première invitation entre le <%= format_date(params[:first_invitation_date_after].to_date) %> et le <%= format_date((params[:first_invitation_date_before]&.to_date || Time.zone.now)) %></p>
+            <p>Première invitation entre le <%= format_date(params[:first_invitation_date_after].to_date) %> et le <%= format_date((params[:first_invitation_date_before]&.to_date || Time.zone.now)) %></p> 
           <% elsif params[:first_invitation_date_before].present? %>
-            <p>Première invitation avant le <%= format_date(params[:first_invitation_date_before].to_date) %></p>
+            <p>Première invitation avant le <%= format_date(params[:first_invitation_date_before].to_date) %></p> 
           <% end %>
           <% if params[:last_invitation_date_after].present? %>
             <p>Dernière invitation entre le <%= format_date(params[:last_invitation_date_after].to_date) %> et le <%= format_date((params[:last_invitation_date_before]&.to_date || Time.zone.now)) %></p>
@@ -19,6 +19,7 @@
             <p>Convocations avant le <%= format_date(params[:convocation_date_before].to_date) %></p>
           <% end %>
         </div>
+        <span class="filter-active" style="left: -2px">1</span>
         <i class="ri-pencil-fill text-dark-blue"></i>
       <% else %>
         <span class="w-100">Filtrer par date d'invitation ou de convocation</span>

--- a/app/views/users/_filter_by_orientation_type_button.html.erb
+++ b/app/views/users/_filter_by_orientation_type_button.html.erb
@@ -17,6 +17,9 @@
         Filtrer par type d'orientation
       <% end %>
     </span>
+    <% if selected_orientation.present? %>
+      <span class="filter-active">1</span>
+    <% end %>
     <i class="ri-arrow-down-s-line"></i>
   </span>
 </div>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -4,7 +4,7 @@
       <%= form.hidden_field key, value: value %>
     <% end %>
 
-    <%= form.text_field :search_query, placeholder: "Prénom, nom, email, n° CAF...", class: "form-control mb-0" %>
+    <%= form.text_field :search_query, placeholder: "Prénom, nom, email, n° CAF...", class: "form-control mb-0", value: params[:search_query] %>
     <%= form.submit "Rechercher", name: nil, class: "btn btn-blue-out ms-3" %>
   </div>
 <% end %>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with method: :get, url: url, local: true do |form| %>
   <div class="d-flex">
-    <% url_params.except(:search_query).each do |key, value| %>
+    <% url_params.except(:search_query, :motif_category_id).each do |key, value| %>
       <%= form.hidden_field key, value: value %>
     <% end %>
 

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -13,7 +13,7 @@
         <span class="label-alt position-absolute bg-white pe-none">
           <span class="status-label-alt">
             <% if selected_status.present? %>
-              Statut : <%= selected_status[0] %>
+              Statut : <%= selected_status[0] %> <span class="filter-active">1</span>
             <% else %>
               Filtrer par statut
             <% end %>
@@ -36,7 +36,7 @@
       <span class="label-alt position-absolute bg-white pe-none">
         <span class="referent-label-alt">
           <% if selected_referent.present? %>
-            Suivis par : <%= selected_referent %>
+            Suivis par : <%= selected_referent %> <span class="filter-active">1</span>
           <% else %>
             Filtrer par référent
           <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,17 +1,7 @@
 <div class="container mt-5 mb-5">
   <%= render "users_list_header" %>
   <div class="row card-white justify-content-center">
-    <% if params[:search_query].present? %>
-      <div class="d-flex mb-2">
-        <div class="me-2">
-          <%= @users.total_count %> dossier(s) correspondant à votre recherche "<strong><%= params[:search_query] %></strong>"
-        </div>
-        <%= link_to structure_users_path(url_params.except(:search_query)) do %>
-          <i class="ri-arrow-go-back-line"></i>
-          <span class="btn-link">Réinitialiser</span>
-        <% end %>
-      </div>
-    <% end %>
+    <%= render "active_filters_recap" if active_filter_list.any? %>
     <% if @all_configurations.empty? %>
       Merci de configurer votre organisation avant de pouvoir inviter des usagers
     <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,17 @@
 <div class="container mt-5 mb-5">
   <%= render "users_list_header" %>
   <div class="row card-white justify-content-center">
+    <% if params[:search_query].present? %>
+      <div class="d-flex mb-2">
+        <div class="me-2">
+          <%= @users.total_count %> dossier(s) correspondant à votre recherche "<strong><%= params[:search_query] %></strong>"
+        </div>
+        <%= link_to structure_users_path(url_params.except(:search_query)) do %>
+          <i class="ri-arrow-go-back-line"></i>
+          <span class="btn-link">Réinitialiser</span>
+        <% end %>
+      </div>
+    <% end %>
     <% if @all_configurations.empty? %>
       Merci de configurer votre organisation avant de pouvoir inviter des usagers
     <% else %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -621,7 +621,7 @@ describe UsersController do
 
       context "when a single tag is given as string" do
         let!(:index_params) do
-          { organisation_id: organisation.id, tag_ids: tags[2].id }
+          { organisation_id: organisation.id, tag_ids: [tags[2].id] }
         end
 
         it "filters by this tag" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1241,4 +1241,19 @@ describe UsersController do
       end
     end
   end
+
+  describe "active filters view" do
+    include UsersHelper
+
+    # This test ensures that the active_filters_recap handles every possible filter
+    # It might turn red if we add a new filter and forget to handle its associated
+    # view in the active_filters_recap.
+    # To fix it, you just need to add an if statement to the view
+    it "handles and single filter possibilities" do
+      view_content = Rails.root.join("app/views/users/_active_filters_recap.html.erb").read
+      (filter_list - [:search_query]).each do |filter|
+        expect(view_content).to include("filter == :#{filter}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Cette PR ajoute un visuel sur la recherche en cours avec la possibilité de réinitilialiser les filtres individuellement et également de modifier à partir de la recherche en cours. 
On retrouve aussi un petit badge montrant les filtres actifs au niveau des filtres en eux même

<img width="997" alt="image" src="https://github.com/user-attachments/assets/7233d9e5-ede0-49f8-824c-55d1fb5b34dd" />


fix https://github.com/gip-inclusion/rdv-insertion/issues/2504