### PR TITLE
gem(stringio): update stringio gem to fix RubyLSP crash on vscode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,7 +545,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.1.1)
+    stringio (3.1.2)
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)


### PR DESCRIPTION
En utilisant Vscode et l'extension RubyLSP je me retrouve avec cette erreur, ce qui provoque des comportements inattendus de cette extension (qui est déjà un peu capricieuse).
Si c'est ok pour vous, mettre à jour la gem avec la version 3.1.2 règle le problème.

> Ruby LSP Rails failed to initialize server: /Users/XXX/.asdf/installs/ruby/3.3.3/lib/ruby/gems/3.3.0/gems/ruby-lsp-rails-0.3.27/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb:112:in `rescue in initialize': /Users/XXX/.asdf/installs/ruby/3.3.3/lib/ruby/gems/3.3.0/gems/bundler-2.5.3/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated stringio 3.1.2, but your Gemfile requires stringio 3.1.1. 