### PR TITLE
fix(tag): prevent crashing when receiving dupes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,11 @@ class User < ApplicationRecord
     Organisation.where(id: archives.map(&:organisation_id))
   end
 
+  def tag_users_attributes=(attributes)
+    unique_attributes = attributes.uniq { |attr| attr["tag_id"] }
+    super(unique_attributes)
+  end
+
   private
 
   def import_associations_from_rdv_solidarites

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
   broadcasts_refreshes
 
   accepts_nested_attributes_for :follow_ups, reject_if: :follow_up_category_handled_already?
-  accepts_nested_attributes_for :tag_users
+  accepts_nested_attributes_for :tag_users, reject_if: :duplicated_tag_id?
 
   validates :last_name, :first_name, presence: true
   validates :email, allow_blank: true,
@@ -229,6 +229,10 @@ class User < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "n'est pas valide")
+  end
+
+  def duplicated_tag_id?(attributes)
+    tag_users.exists?(tag_id: attributes["tag_id"])
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,7 +196,7 @@ class User < ApplicationRecord
   def tag_users_attributes=(attributes)
     attributes.map!(&:with_indifferent_access)
     attributes.uniq! { |attr| attr["tag_id"] }
-    attributes.reject! { |attr| tag_users.reload.exists?(tag_id: attr["tag_id"]) }
+    attributes.reject! { |attr| tag_users.any? { |tu| tu.tag_id == attr["tag_id"] } }
 
     super(attributes)
   end

--- a/spec/factories/tag_users.rb
+++ b/spec/factories/tag_users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tag_user do
-    tags { nil }
-    users { nil }
+    tag { nil }
+    user { nil }
   end
 end

--- a/spec/features/agent_can_edit_uploaded_user_list_spec.rb
+++ b/spec/features/agent_can_edit_uploaded_user_list_spec.rb
@@ -84,7 +84,7 @@ describe "Agents can upload user list", :js do
       expect(User.last.first_name).to eq("hello")
       expect(User.last.last_name).to eq("hello")
       expect(User.last.role).to eq("conjoint")
-      expect(User.last.tags.pluck(:value)).to eq(%w[Gentils cool])
+      expect(User.last.tags.pluck(:value)).to eq(%w[Gentils Cool])
     end
   end
 end

--- a/spec/features/agent_can_edit_uploaded_user_list_spec.rb
+++ b/spec/features/agent_can_edit_uploaded_user_list_spec.rb
@@ -33,7 +33,7 @@ describe "Agents can upload user list", :js do
     setup_agent_session(agent)
     stub_user_creation(rdv_solidarites_user_id)
     organisation.tags << create(:tag, value: "Gentils")
-    organisation.tags << create(:tag, value: "cool")
+    organisation.tags << create(:tag, value: "Cool")
   end
 
   context "at organisation level" do
@@ -69,7 +69,7 @@ describe "Agents can upload user list", :js do
           modal.click_button("Enregistrer")
           expect(page).to have_no_content("Modifier les tags")
 
-          expect(column).to have_content("Gentils, cool")
+          expect(column).to have_content("Gentils, Cool")
         else
           column
             .double_click

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -155,6 +155,32 @@ describe User do
     end
   end
 
+  describe "tag_users validation" do
+    context "duplicated tag_id in the attrs" do
+      let(:tag) { create(:tag) }
+      let(:tag_users_attributes) { [{ tag_id: tag.id }, { tag_id: tag.id }] }
+
+      it "cleans the attributes" do
+        user = create(:user, tag_users_attributes:)
+        expect(user.tag_users.size).to eq(1)
+        expect(user.tag_users.first.tag_id).to eq(tag.id)
+      end
+    end
+
+    context "duplicated tag_id in DB" do
+      let(:tag) { create(:tag) }
+      let(:user) { create(:user) }
+      let!(:tag_user) { create(:tag_user, user:, tag:) }
+      let(:tag_users_attributes) { [{ tag_id: tag.id }] }
+
+      it "skips the duplicated tag" do
+        user.update!(tag_users_attributes:)
+        expect(user.tag_users.size).to eq(1)
+        expect(user.tag_users.first.tag_id).to eq(tag.id)
+      end
+    end
+  end
+
   describe "affiliation number format validation" do
     context "valid affiliation number" do
       let(:user) { create(:user, affiliation_number: "1234567") }


### PR DESCRIPTION
Cette PR permet d'éviter de lever la contrainte d'unicité lorsque l'on reçoit dans les nested attributes des éléments déjà présent en base de données. 

De plus cette PR permet de dédupliquer les éléments reçus si jamais le array d'attributes contient des tag_id dupliqués. 

En effet 2 cas se détachent qui pourraient amener à ces erreurs https://sentry.incubateur.net/organizations/betagouv/issues/141816/?project=16&referrer=webhooks_plugin

Le premier consiste à updater un user qui possède déjà le tag 1 en lui donnant `tag_users_attributes: [{ tag_id: 1 }]`
Le second consiste à créer (ou updater) un user en lui donnant dès sa création `tag_users_attributes: [{ tag_id: 1 }, { tag_id: 1 }]`

Cette PR fixe donc ces 2 cas ou la combinaison des deux
