### PR TITLE
wording(alert): change mm alert wording in case of convoc rdv without phone

### DIFF
--- a/app/services/concerns/notifications/sender_phone_number_validation.rb
+++ b/app/services/concerns/notifications/sender_phone_number_validation.rb
@@ -5,9 +5,9 @@ module Notifications
 
       MattermostClient.send_unique_message(
         channel_type: :private,
-        text: "Une convocation a été envoyée par l'organisation #{notification.organisation.name} sans numéro" \
-              " de téléphone de l'organisation, du lieu ou de la catégorie pour le rendez-vous" \
-              " avec l'ID #{notification.rdv.id} et l'usager avec l'ID #{notification.participation.user.id}."
+        text: "Un rendez-vous de convocation (#{notification.rdv.id}) a été placé pour cet usager" \
+              " (#{notification.participation.user.id}) mais la convocation n'a pas été envoyée car l'organisation" \
+              " #{notification.organisation.name} n'a pas de numéro de téléphone."
       )
 
       fail!("Le numéro de téléphone de l'organisation, du lieu ou de la catégorie doit être renseigné")

--- a/spec/services/notifications/send_email_spec.rb
+++ b/spec/services/notifications/send_email_spec.rb
@@ -164,10 +164,11 @@ describe Notifications::SendEmail, type: :service do
       it "sends a message to mattermost" do
         expect(MattermostClient).to receive(:send_unique_message).with(
           channel_type: :private,
-          text: "Une convocation a été envoyée par l'organisation #{organisation.name} sans numéro de téléphone de " \
-                "l'organisation, du lieu ou de la catégorie pour le rendez-vous avec l'ID #{rdv.id} " \
-                "et l'usager avec l'ID #{user.id}."
+          text: "Un rendez-vous de convocation (#{rdv.id}) a été placé pour cet usager" \
+                " (#{user.id}) mais la convocation n'a pas été envoyée car l'organisation" \
+                " #{organisation.name} n'a pas de numéro de téléphone."
         )
+
         subject
       end
     end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2546

En plus de ce qui était demandé dans l'issue je me suis permis de laisser entre parenthèses les ids du rdv et de l'usager. Ca donne :

"Un rendez-vous de convocation (54321) a été placé pour cet usager (12345) mais la convocation n'a pas été envoyée car l'organisation _NOM de l'orga_ n'a pas de numéro de téléphone."