### PR TITLE
tech(ci): fix ubuntu version in ci to 22.04 to keep  wkhtmltopdf compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   linters:
     name: Linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -24,7 +24,7 @@ jobs:
         run: yarn lint
   test_unit:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:13.2
@@ -87,7 +87,7 @@ jobs:
 
   test_features:
     name: Feature Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Le passage en 24.04 des os des CI Github (https://github.com/actions/runner-images/issues/10636) n'a pas du tout plu à wkhtmltopdf (qui n'est plus maintenu). On fix ici la version ubuntu de la ci en attendant de se débarasser de wkhtmltopdf.