### PR TITLE
fix(migration): Remove null constraint on agent_id for parcours_documents

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_16_135605) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_20_125249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -363,7 +363,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_16_135605) do
   create_table "parcours_documents", force: :cascade do |t|
     t.bigint "department_id", null: false
     t.bigint "user_id", null: false
-    t.bigint "agent_id", null: false
+    t.bigint "agent_id"
     t.string "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Répare cette erreur sur Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/142388/?project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=9

j'avais fait en sorte dans #2434 de spécifier dans le model `parcours_document` que l'appartenance à un agent était optionnel dans le cas où celui-ci était supprimé, mais je n'avais pas fait la migration associée que je fais ici.