### PR TITLE
fix(users): prevent sending tag_ids as string

### DIFF
--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,7 +1,13 @@
 <%= form_with method: :get, url: url, local: true do |form| %>
   <div class="d-flex">
     <% url_params.except(:search_query, :motif_category_id).each do |key, value| %>
-      <%= form.hidden_field key, value: value %>
+      <% if value.is_a?(Array) %>
+        <% value.each do |v| %>
+          <%= form.hidden_field key.to_s + "[]", value: v %>
+        <% end %>
+      <% else %>
+        <%= form.hidden_field key, value: value %>
+      <% end %>
     <% end %>
 
     <%= form.text_field :search_query, placeholder: "Prénom, nom, email, n° CAF...", class: "form-control mb-0", value: params[:search_query] %>


### PR DESCRIPTION
Cette PR permet de formatter correctement les params tag_ids. 
En effet ce param étant un array il était envoyé dans les params du form de recherche comme une value string classique. 

Pour info, il est impossible de simplement le passer dans l'url du form plutôt que comme un input dans le body du form à cause du fonctionnement intrinsèque des form HTML : https://stackoverflow.com/questions/1116019/when-submitting-a-get-form-the-query-string-is-removed-from-the-action-url

Le form HTML en méthode GET ne fait pas qu'overrider les params donnés en query, il les enlève completement, ce qui implique donc de reconstruire entièrement les params. 

Le bug a été rendu visible par cette PR : https://github.com/gip-inclusion/rdv-insertion/commit/2ce1157127f826a94118d34b197e12c426a580e6

```ruby
# app/views/users/_active_filters_recap.html.erb
tag_ids: params[:tag_ids] - [tag.id.to_s]
```
Ici on traitait les params de tag_ids comme un array. 

Sauf qu'effectuer une recherche (qui ne gérait pas les valeurs array) transformait `tag_id[]=1&tag_id[]=2` en `tag_id=1+2` 

Côté serveur on fait `where(tag_id: params[:tag_id])` ce qui engendre un `params[:tag_id].to_i`, ce qui donne `1` au lieu de `[1, 2]`. **Ce qui fait que déjà en prod avoir des tags + de la recherche ne fonctionnait pas.** 

Cette PR corrige donc le bug sentry ci-dessous mais corrige aussi le bug silencieux qui était causé par le fait d'avoir d'avoir des filtres sur les tags + une recherche


Fix https://sentry.incubateur.net/organizations/betagouv/issues/144877/?project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=1