### PR TITLE
crisp(bug): fixing incompatibility with turbo and logoff only when needed

### DIFF
--- a/app/javascript/controllers/crisp_controller.js
+++ b/app/javascript/controllers/crisp_controller.js
@@ -9,11 +9,17 @@ export default class extends Controller {
   };
 
   connect() {
-    if (!this.displayCrispValue) {
+    if (!this.displayCrispValue && window.$crisp) {
       // If the user is logged out from the app but crisp is still loaded, we loggout the user from crisp
       if (window.$crisp) { this.logout(); };
       return;
     }
+    if (!this.displayCrispValue) { return; }
+
+    // Ajout du safe mode pour supprimer l'avertissement dans la console lié aux modifs du MutationObserver
+    window.$crisp = window.$crisp || [];
+    window.$crisp.push(["safe", true]);
+    this.setupMutationObserverOverride();
 
     if (window.CRISP_TOKEN_ID === this.userCrispTokenValue) {
       // If the user is already logged in, we don't need to do anything
@@ -30,9 +36,62 @@ export default class extends Controller {
     this.handleFirstVisit();
   }
 
+  setupMutationObserverOverride() {
+    // Fix pour faire fonctionner Crisp avec Turbo : https://github.com/crisp-im/crisp-sdk-web/issues/39
+    if (!window.originalMutationObserver) {  // Changed from this.originalMutationObserver
+      window.originalMutationObserver = window.MutationObserver;  // Store it on window instead of this
+      window.listOfObservers = [];  // Store it on window instead of this
+
+      window.MutationObserver = function(aFunction) {
+        /* eslint new-cap: ["error", { "newIsCap": false }] */
+
+        const observer = new window.originalMutationObserver(aFunction);  // Use window.originalMutationObserver
+        const { stack } = new Error();
+
+        if (stack?.includes("crisp")) {
+          window.listOfObservers.push(observer);  // Use window.listOfObservers
+        }
+
+        return observer;
+      };
+
+      window.CRISP_READY_TRIGGER = () => this.onCrispReady();
+    }
+  }
+
+  disconnectAllObservers() {
+    window.listOfObservers?.forEach((observer) => {  // Use window.listOfObservers
+      observer.disconnect();
+    });
+  }
+
+  reconnectAllObservers() {
+    window.listOfObservers?.forEach((observer) => {  // Use window.listOfObservers
+      observer.reconnect();
+    });
+  }
+
+  moveCrispToPermanentContainer() {
+    const crispWidget = document.querySelector(".crisp-client");
+    const crispWrapper = document.getElementById("crisp-wrapper");
+
+    if (crispWidget && crispWrapper && !crispWrapper.contains(crispWidget)) {
+      this.disconnectAllObservers();
+      crispWrapper.appendChild(crispWidget);
+      this.reconnectAllObservers();
+    }
+  }
+
+  onCrispReady() {
+    this.moveCrispToPermanentContainer();
+  }
+
   initCrisp(user) {
     window.$crisp = [];
     window.CRISP_WEBSITE_ID = process.env.CRISP_WEBSITE_ID;
+
+    // Ajout du safe mode pour supprimer l'avertissement dans la console lié aux modifs du MutationObserver
+    window.$crisp.push(["safe", true]);
 
     if (user) {
       window.CRISP_TOKEN_ID = user.crispToken;
@@ -62,7 +121,8 @@ export default class extends Controller {
 
   logout() {
     if (window.$crisp) {
-      window.CRISP_TOKEN_ID = null;
+      window.CRISP_WEBSITE_ID = undefined;
+      window.CRISP_TOKEN_ID = undefined;
       window.$crisp.push(["do", "session:reset"]);
       window.$crisp.push(["do", "session:destroy"]);
       window.$crisp.push(["do", "chat:hide"]);

--- a/app/views/common/_crisp.html.erb
+++ b/app/views/common/_crisp.html.erb
@@ -4,3 +4,4 @@
      data-crisp-user-nickname-value="<%= current_agent&.to_s %>"
      data-crisp-user-crisp-token-value="<%= current_agent&.crisp_token %>">
 </div>
+<div id="crisp-wrapper" data-turbo-permanent></div>


### PR DESCRIPTION
Cette PR règle 2 problèmes : 
- Un problème d'incompatibilité entre Turbo et Crisp ([voir l'issue ici](https://github.com/crisp-im/crisp-sdk-web/issues/39))
- Ne pas appeler la méthode logout quand ce n'est pas nécessaire (quand l'agent n'est pas encore connecté)