### PR TITLE
Enqueue testing fix

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  config.active_job.queue_adapter = :test
 end

--- a/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
@@ -100,6 +100,11 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
           .and_raise(FranceTravailApi::RetrieveUserToken::UserNotFound, "Aucun usager trouvé")
       end
 
+      around do |example|
+        ActiveJob::Base.queue_adapter = :test
+        example.run
+      end
+
       it "discards the job without raising an error" do
         expect do
           perform_enqueued_jobs do

--- a/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
@@ -100,11 +100,6 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
           .and_raise(FranceTravailApi::RetrieveUserToken::UserNotFound, "Aucun usager trouvé")
       end
 
-      around do |example|
-        ActiveJob::Base.queue_adapter = :test
-        example.run
-      end
-
       it "discards the job without raising an error" do
         expect do
           perform_enqueued_jobs do


### PR DESCRIPTION
Suite à la maj de rails un test qui vérifie l'existence d'un job ne passait plus. (assert_no_enqueued_jobs requires the Active Job test adapter, you're using ActiveJob::QueueAdapters::SidekiqAdapter.)
On configure ActiveJob pour utiliser l'adaptateur de test par défaut dans l'environnement de test et éviter l'erreur.
Je ne sais pas trop comment le test a pu passer sans cela avant.