### PR TITLE
fix(app): Use preview paths new syntax

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
 
   config.action_controller.asset_host = "http://localhost:8000"
 
-  config.action_mailer.preview_path = Rails.root.join("lib/mailer_previews")
+  config.action_mailer.preview_paths << Rails.root.join("lib/mailer_previews")
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
 
   if ENV['ENABLE_MAILER_PREVIEWS'].present?
     config.action_mailer.show_previews = true
-    config.action_mailer.preview_path = Rails.root.join("lib/mailer_previews")
+    config.action_mailer.preview_paths << Rails.root.join("lib/mailer_previews")
   end
 
   # Use a different cache store in production.


### PR DESCRIPTION
La syntaxe pour rajouter les chemins vers les mailers de preview a changé: https://blog.saeloun.com/2024/10/12/rails-7-1-supports-multiple-preview-paths-for-mailers/