### PR TITLE
fix(users): prevent breaking user filters when filtering by dates

### DIFF
--- a/app/views/common/_with_clean_users_query_params.html.erb
+++ b/app/views/common/_with_clean_users_query_params.html.erb
@@ -1,0 +1,9 @@
+<% url_params.except(*omit).each do |key, value| %>
+  <% if value.is_a?(Array) %>
+    <% value.each do |v| %>
+      <%= form.hidden_field key, value: v, multiple: true %>
+    <% end %>
+  <% else %>
+    <%= form.hidden_field key, value: value %>
+  <% end %>
+<% end %>

--- a/app/views/dates_filterings/convocation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/convocation_dates_filterings/new.html.erb
@@ -1,8 +1,6 @@
 <%= render "common/remote_modal", title: "Filtrer par date de convocation" do %>
   <%= form_with method: :get, local: true, url: structure_users_path, data: { "turbo-frame" => "_top" } do |form| %>
-    <% url_params.except(:convocation_date_before, :convocation_date_after, :department_id, :organisation_id).each do |key, value| %>
-      <%= form.hidden_field key, value: value %>
-    <% end %>
+    <%= render "common/with_clean_users_query_params", form:, omit: [:convocation_date_before, :convocation_date_after, :department_id, :organisation_id] %>
 
     <div class="d-flex mb-2">
       <%= form.text_field :convocation_date_after,

--- a/app/views/dates_filterings/creation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/creation_dates_filterings/new.html.erb
@@ -1,9 +1,7 @@
 <%= render "common/remote_modal", title: "Filtrer par date de création" do %>
   <%= form_with method: :get, local: true, url: structure_users_path, data: { "turbo-frame" => "_top" } do |form| %>
-    <% url_params.except(:creation_date_after, :creation_date_before).each do |key, value| %>
-      <%= form.hidden_field key, value: value %>
-    <% end %>
-
+    <%= render "common/with_clean_users_query_params", form:, omit: [:creation_date_after, :creation_date_before] %>
+    
     <p class="mb-2">Date de création</p>
     <div class="d-flex mb-3">
       <%= form.text_field :creation_date_after,

--- a/app/views/dates_filterings/invitation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/invitation_dates_filterings/new.html.erb
@@ -1,8 +1,6 @@
 <%= render "common/remote_modal", title: "Filtrer par date d'invitation" do %>
   <%= form_with method: :get, local: true, url: structure_users_path, data: { "turbo-frame" => "_top" } do |form| %>
-    <% url_params.except(:first_invitation_date_after, :first_invitation_date_before, :last_invitation_date_after, :last_invitation_date_before, :department_id, :organisation_id).each do |key, value| %>
-      <%= form.hidden_field key, value: value %>
-    <% end %>
+    <%= render "common/with_clean_users_query_params", form:, omit: [:first_invitation_date_after, :first_invitation_date_before, :last_invitation_date_after, :last_invitation_date_before, :department_id, :organisation_id] %>
 
     <p class="mb-2">Première invitation</p>
     <div class="d-flex mb-3">

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,14 +1,6 @@
 <%= form_with method: :get, url: url, local: true do |form| %>
   <div class="d-flex">
-    <% url_params.except(:search_query, :motif_category_id).each do |key, value| %>
-      <% if value.is_a?(Array) %>
-        <% value.each do |v| %>
-          <%= form.hidden_field key, value: v, multiple: true %>
-        <% end %>
-      <% else %>
-        <%= form.hidden_field key, value: value %>
-      <% end %>
-    <% end %>
+    <%= render "common/with_clean_users_query_params", form:, omit: [:search_query, :motif_category_id] %>
 
     <%= form.text_field :search_query, placeholder: "Prénom, nom, email, n° CAF...", class: "form-control mb-0", value: params[:search_query] %>
     <%= form.submit "Rechercher", name: nil, class: "btn btn-blue-out ms-3" %>


### PR DESCRIPTION
Cette PR corrige un problème global sur les filtres de type recherche qui cassait le formatage du filtre des tags après l'envoi du formulaire.