### PR TITLE
fix(csv): sanitize csv export params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)

--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -1,6 +1,6 @@
 class CsvExportsController < ApplicationController
   def show
-    csv_export = CsvExport.find_signed(params[:id].to_s) || CsvExport.find(params[:id])
+    csv_export = CsvExport.find_signed(params[:id].to_s)
     authorize csv_export
 
     if csv_export.expired?

--- a/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
+++ b/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
@@ -19,27 +19,27 @@
   <% if @creation_dates_before || @creation_dates_after %>
     <li><strong>Date de création</strong>&nbsp;:
       <% if @creation_dates_after %>
-        entre <%= @creation_dates_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@creation_dates_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+        entre <%= h(@creation_dates_after.to_date&.strftime("%d/%m/%Y")) %> et le <%= h(@creation_dates_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
       <% else %>
-        avant le <%= @creation_dates_before.to_date&.strftime("%d/%m/%Y") %>
+        avant le <%= h(@creation_dates_before.to_date&.strftime("%d/%m/%Y")) %>
       <% end %>
     </li>
   <% end %>
   <% if @first_invitation_date_after || @first_invitation_date_before %>
     <li><strong>Date de première invitation</strong>&nbsp;:
       <% if @first_invitation_date_after %>
-        entre <%= @first_invitation_date_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@first_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+        entre <%= h(@first_invitation_date_after.to_date&.strftime("%d/%m/%Y")) %> et le <%= h(@first_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
       <% else %>
-        avant le <%= @first_invitation_date_before.to_date&.strftime("%d/%m/%Y") %>
+        avant le <%= h(@first_invitation_date_before.to_date&.strftime("%d/%m/%Y")) %>
       <% end %>
     </li>
   <% end %>
   <% if @last_invitation_date_after || @last_invitation_date_before %>
     <li><strong>Date de dernière invitation</strong>&nbsp;:
       <% if @last_invitation_date_after %>
-        entre <%= @last_invitation_date_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@last_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+        entre <%= h(@last_invitation_date_after.to_date&.strftime("%d/%m/%Y")) %> et le <%= h(@last_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
       <% elsif @last_invitation_date_before %>
-        avant le <%= @last_invitation_date_before.to_date&.strftime("%d/%m/%Y") %>
+        avant le <%= h(@last_invitation_date_before.to_date&.strftime("%d/%m/%Y")) %>
       <% end %>
     </li>
   <% end %>
@@ -47,7 +47,7 @@
     <li><strong>Usagers avec intervention nécessaire</strong>&nbsp;: Oui</li>
   <% end %>
   <% if @search_query_filter %>
-    <li><strong>Champ de recherche libre</strong>&nbsp;: <%= @search_query_filter %></li>
+    <li><strong>Champ de recherche libre</strong>&nbsp;: <%= h(@search_query_filter) %></li>
   <% end %>
   <% if @tags_filter %>
     <li><strong>Tags</strong>&nbsp;: <%= @tags_filter.join(", ") %></li>


### PR DESCRIPTION
Je faisais quelques checks pré bug bounty et je me suis rendu compte que: 

- on faisait toujours une vérif sur l'`id` en plus du `signed_id` pour l'export csv. Ça n'a pas de conséquences puisqu'on check l'autorisation sur l'export après mais j'enlève la vérif sur l'`id` qui n'est plus supportée

- on ne nettoyait pas les params que l'on ajoute dans le contenu d'export de csv. Là encore ça n'a pas de conséquences puisque la personne à l'origine de l'envoi de ce mail est la personne le recevant, mais je nettoie au cas où