### PR TITLE
fix(creneaux_unavailable): avoid taking expireable invites into account

### DIFF
--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -3,7 +3,7 @@ class NotifyUnavailableCreneauJob < ApplicationJob
 
   def perform(organisation_id)
     result =
-      Invitations::VerifyOrganisationCreneauxAvailability.call(organisation_id: organisation_id)
+      Invitations::AggregateInvitationWithoutCreneauxByCategory.call(organisation_id: organisation_id)
     return if result.grouped_invitation_params_by_category.empty?
 
     # grouped_invitation_params_by_category = [{

--- a/app/services/invitations/aggregate_invitation_without_creneaux_by_category.rb
+++ b/app/services/invitations/aggregate_invitation_without_creneaux_by_category.rb
@@ -9,14 +9,14 @@ module Invitations
     def call
       # On prend le premier agent de l'organisation pour les appels à l'API RDVSP
       @organisation.agents.first.with_rdv_solidarites_session do
-        aggregate_invitations_without_creneaux
+        aggregate_invitations_params_without_creneaux
         result.grouped_invitation_params_by_category = group_invitations_without_creneaux_by_category
       end
     end
 
     private
 
-    def aggregate_invitations_without_creneaux
+    def aggregate_invitations_params_without_creneaux
       return if organisation_valid_invitations.empty?
 
       invitations_params.each do |params|

--- a/spec/jobs/notify_unavailable_creneau_job_spec.rb
+++ b/spec/jobs/notify_unavailable_creneau_job_spec.rb
@@ -28,7 +28,7 @@ describe NotifyUnavailableCreneauJob do
   end
 
   before do
-    allow(Invitations::VerifyOrganisationCreneauxAvailability).to receive(:call)
+    allow(Invitations::AggregateInvitationWithoutCreneauxByCategory).to receive(:call)
       .and_return(OpenStruct.new(success?: true,
                                  grouped_invitation_params_by_category: grouped_invitation_params_by_category))
     allow(OrganisationMailer).to receive(:creneau_unavailable).and_return(organisation_mail)

--- a/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
+++ b/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
@@ -42,12 +42,6 @@ describe Invitations::AggregateInvitationWithoutCreneauxByCategory, type: :servi
       address: "3 Rue Test 75010 Paris"
     )
   end
-  let!(:user4) do
-    create(
-      :user,
-      address: "4 Rue Test 75010 Paris"
-    )
-  end
   let!(:user_with_no_address) do
     create(
       :user,

--- a/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
+++ b/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
@@ -1,4 +1,4 @@
-describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
+describe Invitations::AggregateInvitationWithoutCreneauxByCategory, type: :service do
   subject do
     described_class.call(organisation_id: organisation.id)
   end
@@ -13,6 +13,7 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
     create(:follow_up, motif_category: category_rsa_orientation)
   end
   let!(:follow_up2_without_creneau) { create(:follow_up, motif_category: category_rsa_orientation) }
+  let!(:follow_up3_without_creneau) { create(:follow_up, motif_category: category_rsa_orientation) }
   let!(:follow_up_with_creneau) { create(:follow_up, motif_category: category_rsa_accompagnement_sociopro) }
   let!(:follow_up_with_referent_without_creneau) do
     create(:follow_up, motif_category: category_rsa_accompagnement_social)
@@ -39,6 +40,12 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
     create(
       :user,
       address: "3 Rue Test 75010 Paris"
+    )
+  end
+  let!(:user4) do
+    create(
+      :user,
+      address: "4 Rue Test 75010 Paris"
     )
   end
   let!(:user_with_no_address) do
@@ -100,6 +107,17 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1bRueTest&city_code=12255&departement=12&invitation_token=ZIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
       format: "email",
       follow_up: follow_up2_without_creneau
+    )
+  end
+  let!(:invitation3_with_no_creneau_but_periodic) do
+    create(
+      :invitation,
+      user: user2,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1bRueTest&city_code=12255&departement=12&invitation_token=ZIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
+      format: "email",
+      follow_up: follow_up3_without_creneau,
+      expires_at: nil
     )
   end
   let!(:invitation2_with_no_creneau_relevant_params) do
@@ -167,6 +185,7 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
         when invitation_with_no_creneau_no_user_address_relevant_params,
           invitation_with_no_creneau_relevant_params,
           invitation2_with_no_creneau_relevant_params,
+          invitation3_with_no_creneau_but_periodic,
           invitation_with_referent_without_creneau_relevant_params
           OpenStruct.new(success?: true, creneau_availability: false)
         when invitation_with_creneau_relevant_params

--- a/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
+++ b/spec/services/invitations/aggregate_invitation_without_creneaux_by_category_spec.rb
@@ -103,7 +103,7 @@ describe Invitations::AggregateInvitationWithoutCreneauxByCategory, type: :servi
       follow_up: follow_up2_without_creneau
     )
   end
-  let!(:invitation3_with_no_creneau_but_periodic) do
+  let!(:invitation3_with_no_creneau_but_not_expireable) do
     create(
       :invitation,
       user: user2,
@@ -179,7 +179,7 @@ describe Invitations::AggregateInvitationWithoutCreneauxByCategory, type: :servi
         when invitation_with_no_creneau_no_user_address_relevant_params,
           invitation_with_no_creneau_relevant_params,
           invitation2_with_no_creneau_relevant_params,
-          invitation3_with_no_creneau_but_periodic,
+          invitation3_with_no_creneau_but_not_expireable,
           invitation_with_referent_without_creneau_relevant_params
           OpenStruct.new(success?: true, creneau_availability: false)
         when invitation_with_creneau_relevant_params


### PR DESCRIPTION
Dans cette PR je fais en sorte d'exclure les invitations qui n'expirent pas des messages d'alerte envoyés aux organisations.

J'ai également ajouté un renommage de la classe `VerifyOrganisationCreneauxAvailability` qui réellement ne vérifiait pas mais aggregait. 
Ça me semble beaucoup plus lisible de cette façon

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2551