### PR TITLE
feat(upload): keep ordering intact after edition

### DIFF
--- a/app/controllers/concerns/sort_params.rb
+++ b/app/controllers/concerns/sort_params.rb
@@ -1,6 +1,10 @@
 module SortParams
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :sort_params
+  end
+
   private
 
   def sort_params

--- a/app/controllers/user_list_uploads/user_row_cells_controller.rb
+++ b/app/controllers/user_list_uploads/user_row_cells_controller.rb
@@ -1,5 +1,5 @@
 module UserListUploads
-  class UserRowCellsController < ApplicationController
+  class UserRowCellsController < BaseController
     before_action :set_user_list_upload, :set_user_row
 
     def edit

--- a/app/controllers/user_list_uploads/user_rows_controller.rb
+++ b/app/controllers/user_list_uploads/user_rows_controller.rb
@@ -12,7 +12,7 @@ module UserListUploads
       if @user_row.update(row_params.to_h.symbolize_keys)
         respond_to do |format|
           format.turbo_stream do
-            redirect_to user_list_upload_path(@user_list_upload, user_with_errors: params[:user_with_errors])
+            redirect_to(back_to_list_url)
           end
           format.json { render json: { success: true } }
         end
@@ -36,6 +36,13 @@ module UserListUploads
     end
 
     private
+
+    def back_to_list_url
+      user_list_upload_path(
+        @user_list_upload,
+        { user_with_errors: params[:user_with_errors] }.merge(sort_params)
+      )
+    end
 
     def set_user_list_upload
       @user_list_upload = UserListUpload.find(params[:user_list_upload_id])

--- a/app/javascript/controllers/user_row_cell_controller.js
+++ b/app/javascript/controllers/user_row_cell_controller.js
@@ -8,7 +8,11 @@ export default class extends Controller {
   async edit() {
     const { userListUploadId, userRowId, userRowAttribute } = this.element.dataset;
 
-    const response = await fetch(`/user_list_uploads/${userListUploadId}/user_rows/${userRowId}/user_row_cells/edit?attribute=${userRowAttribute}`);
+    const currentUrl = new URL(window.location.href);
+    const queryString = currentUrl.searchParams.toString();
+    const formattedQueryString = queryString ? `&${queryString}` : "";
+
+    const response = await fetch(`/user_list_uploads/${userListUploadId}/user_rows/${userRowId}/user_row_cells/edit?attribute=${userRowAttribute}${formattedQueryString}`);
     const html = await response.text();
     if (response.ok) {
       window.Turbo.renderStreamMessage(html);

--- a/app/views/common/_url_query_params_as_form_inputs.html.erb
+++ b/app/views/common/_url_query_params_as_form_inputs.html.erb
@@ -1,4 +1,4 @@
-<% url_params.except(*omit).each do |key, value| %>
+<% url_params.except(*local_assigns[:omit] || []).each do |key, value| %>
   <% if value.is_a?(Array) %>
     <% value.each do |v| %>
       <%= form.hidden_field key, value: v, multiple: true %>

--- a/app/views/user_list_uploads/user_list_uploads/_edit_row_attribute.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_edit_row_attribute.html.erb
@@ -23,7 +23,7 @@
     </button>
 
     <button type="submit">
-      <%= link_to user_list_upload_user_row_path(user_list_upload_id: @user_list_upload.id, id: user_row.id, sort_by: params[:sort_by], sort_direction: params[:sort_direction]) do %>
+      <%= link_to user_list_upload_user_row_path({ user_list_upload_id: @user_list_upload.id, id: user_row.id }.merge(sort_params)) do %>
         <i class="ri-close-line text-danger"></i>
       <% end %>
     </button>

--- a/app/views/user_list_uploads/user_list_uploads/_edit_row_attribute.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_edit_row_attribute.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
   url: user_list_upload_user_row_path(
     user_list_upload_id: @user_list_upload.id,
-    id: user_row.id
+    id: user_row.id,
   ),
   data: {
     controller: "user-row-cell",
@@ -9,6 +9,7 @@
   },
   method: :patch
 ) do |form| %>
+  <%= render "common/url_query_params_as_form_inputs", form: %>
   <div class="input-group input-group-sm" data-turbo-prefetch="false">
     <% if attribute == "title" %>
       <%= form.select "user_row[title]", User.titles.keys, { selected: user_row.title }, { class: "form-control" } %>
@@ -22,7 +23,7 @@
     </button>
 
     <button type="submit">
-      <%= link_to user_list_upload_user_row_path(user_list_upload_id: @user_list_upload.id, id: user_row.id) do %>
+      <%= link_to user_list_upload_user_row_path(user_list_upload_id: @user_list_upload.id, id: user_row.id, sort_by: params[:sort_by], sort_direction: params[:sort_direction]) do %>
         <i class="ri-close-line text-danger"></i>
       <% end %>
     </button>


### PR DESCRIPTION
Cette PR permet de conserver l'ordering forcé de la liste lors de l'édition d'un user row

fix https://github.com/gip-inclusion/rdv-insertion/issues/2628