### PR TITLE
fix(spec): Fix failing test after cell edit

### DIFF
--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -196,7 +196,7 @@ describe "Agents can upload user list", :js do
       last_name_cell.double_click
 
       within(table_row) do
-        fill_in "user_row[last_name]", with: "CRESPOGOAL"
+        fill_in "user_row[last_name]", with: "CRESPOGOAL", fill_options: { clear: :backspace }
         find("i.ri-check-line").click
       end
 


### PR DESCRIPTION
Suite à #2654 , le test faisait qu'on ajouter du contenu à la cellule plutôt que de changer le contenu de la cellule.