### PR TITLE
fix(app): Infinite redirects bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     params[:page] || 1
   end
 
-  def root_url?
+  def current_url_is_root_url?
     request.path.in?([root_path, authenticated_root_path])
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,10 @@ class ApplicationController < ActionController::Base
     params[:page] || 1
   end
 
+  def root_url?
+    request.path.in?([root_path, authenticated_root_path])
+  end
+
   # A user can be unlinked from its rdv-solidarites record when the latter is deleted for RGPD reasons.
   # This method pushes the user to rdv-solidarites to recreate a new one.
   def recreate_rdv_solidarites_user(user)

--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -53,6 +53,7 @@ module CurrentStructure
   def current_structure_id = current_organisation_id || current_department_id
 
   def current_structure
+    return if root_url?
     return unless session[:department_id] || session[:organisation_id]
 
     @current_structure ||=

--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -53,7 +53,7 @@ module CurrentStructure
   def current_structure_id = current_organisation_id || current_department_id
 
   def current_structure
-    return if root_url?
+    return if current_url_is_root_url?
     return unless session[:department_id] || session[:organisation_id]
 
     @current_structure ||=

--- a/app/controllers/concerns/modal_agreements_concern.rb
+++ b/app/controllers/concerns/modal_agreements_concern.rb
@@ -25,7 +25,6 @@ module ModalAgreementsConcern
 
   def should_accept_dpa?
     return false if current_agent.nil?
-    return false if current_organisation.nil?
     return false if agent_impersonated?
     # If params[:organisation_id] is nil, it means that
     # the agent is not actively browsing the current_organisation

--- a/app/controllers/website/static_pages_controller.rb
+++ b/app/controllers/website/static_pages_controller.rb
@@ -5,7 +5,7 @@ module Website
     def welcome
       flash[:error] = "Echec de la connexion" if request.env["omniauth.error"]
 
-      redirect_to(organisations_path) if current_agent
+      redirect_to(authenticated_root_path) if current_agent
     end
 
     def legal_notice; end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
                                        only: [:show]
   end
 
+  get "/organisations", to: "organisations#index", as: :authenticated_root
+
   resources :organisations, only: [:index, :new, :show, :edit, :create, :update] do
     get :geolocated, on: :collection
     get :search, on: :collection


### PR DESCRIPTION
Nous avions un bug qui faisait qu'un agent connecté avait une erreur de redirections infinie dès lors qu'il essayait d'accédait à une page d'une structure à laquelle il n'était pas autorisé.

Cela se produisait comme suit: 

- l'agent essaie d'accéder à une page d'une structure non autorisé
- l'agent est redirigé vers le `root_url` (`StaticPagesController#welcome`)
- l'agent est alors redirigé vers l'index des organisations 
- la méthode `current_organisation` était appelée via le before_action `:set_should_display_accept_dpa` dans le `ModalAgreementConcern`. [Cette ligne](https://github.com/gip-inclusion/rdv-insertion/commit/29ebb20d1c42e4ce613bb7fb5f7bcb0e804089aa) n'a pas besoin d'être appelée puisqu'on fait un check sur la présence du `params[:organisation_id]` juste après
- La méthode `current_structure` demandait l'accès à la structure non autorisée dont l'id est resté en session
- L'agent est redirigé vers le `root_url`
- ...
- ...


### Fix

- Dans un premier temps j'enlève le check qui n'est pas nécessaire dans le `ModalAgreementConcern`: https://github.com/gip-inclusion/rdv-insertion/commit/29ebb20d1c42e4ce613bb7fb5f7bcb0e804089aa
- Dans un deuxième temps je fais en sorte que ce bug ne puisse plus arriver: https://github.com/gip-inclusion/rdv-insertion/commit/e61aad3527e757637837ab023bcb9a946a76357d