### PR TITLE
fix(users): improve active filters visuals

### DIFF
--- a/app/helpers/users_filters_helper.rb
+++ b/app/helpers/users_filters_helper.rb
@@ -1,0 +1,40 @@
+module UsersFiltersHelper
+  def filter_list
+    [
+      :search_query,
+      :tag_ids,
+      :status,
+      :orientation_type,
+      :action_required,
+      :referent_id,
+      :creation_date_after,
+      :creation_date_before,
+      :convocation_date_before,
+      :convocation_date_after,
+      :first_invitation_date_before,
+      :first_invitation_date_after,
+      :last_invitation_date_before,
+      :last_invitation_date_after
+    ]
+  end
+
+  def active_filter_list
+    filter_list.select { |filter| params[filter].present? }
+  end
+
+  def invitation_or_convocation_active_filters_count
+    active_filters_count = 0
+
+    active_filters_count += 1 if params[:convocation_date_after].present? || params[:convocation_date_before].present?
+
+    if params[:first_invitation_date_after].present? || params[:first_invitation_date_before].present?
+      active_filters_count += 1
+    end
+
+    if params[:last_invitation_date_after].present? || params[:last_invitation_date_before].present?
+      active_filters_count += 1
+    end
+
+    active_filters_count
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,27 +1,4 @@
 module UsersHelper
-  def filter_list
-    [
-      :search_query,
-      :tag_ids,
-      :status,
-      :orientation_type,
-      :action_required,
-      :referent_id,
-      :creation_date_after,
-      :creation_date_before,
-      :convocation_date_before,
-      :convocation_date_after,
-      :first_invitation_date_before,
-      :first_invitation_date_after,
-      :last_invitation_date_before,
-      :last_invitation_date_after
-    ]
-  end
-
-  def active_filter_list
-    filter_list.select { |filter| params[filter].present? }
-  end
-
   def show_convocation?(category_configuration)
     category_configuration.convene_user?
   end

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </div>
   <div class="active-filters-container d-flex flex-wrap">
-    <% (active_filter_list - [:search_query, :creation_date_before, :creation_date_before]).each do |filter| %>
+    <% (active_filter_list - [:search_query, :creation_date_after, :creation_date_before, :convocation_date_before, :convocation_date_after, :first_invitation_date_before, :first_invitation_date_after, :last_invitation_date_before, :last_invitation_date_after]).each do |filter| %>
       <% if filter == :tag_ids %>
         <% @filtered_tags.each do |tag| %>
           <span class="d-flex me-2 active-filter-badge">
@@ -22,22 +22,6 @@
             Suivi par <%= @referent %>
           <% elsif filter == :orientation_type %>
             Orientation : <%= params[filter] %>
-          <% elsif filter == :creation_date_before %>
-            Créé avant le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :creation_date_after %>
-            Créé après le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :convocation_date_before %>
-            Convoqué avant le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :convocation_date_after %>
-            Convoqué après le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :first_invitation_date_before %>
-            Première invitation avant le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :first_invitation_date_after %>
-            Première invitation après le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :last_invitation_date_before %>
-            Dernière invitation avant le : <%= format_date(params[filter].to_date) %>
-          <% elsif filter == :last_invitation_date_after %>
-            Dernière invitation après le : <%= format_date(params[filter].to_date) %>
           <% elsif filter == :action_required %>
             Intervention nécessaire
           <% elsif filter == :status %>
@@ -49,6 +33,10 @@
         </span>
       <% end %>
     <% end %>
+    <%= render "users/active_filters_recap/creation_date" %>
+    <%= render "users/active_filters_recap/convocation_date" %>
+    <%= render "users/active_filters_recap/first_invitation_date" %>
+    <%= render "users/active_filters_recap/last_invitation_date" %>
     <%= link_to structure_users_path(url_params.except(*active_filter_list)) do %>
       <i class="ri-arrow-go-back-line"></i>
       <span class="btn-link">Réinitialiser</span>

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -6,33 +6,23 @@
     <% end %>
   </div>
   <div class="active-filters-container d-flex flex-wrap">
-    <% (active_filter_list - [:search_query, :creation_date_after, :creation_date_before, :convocation_date_before, :convocation_date_after, :first_invitation_date_before, :first_invitation_date_after, :last_invitation_date_before, :last_invitation_date_after]).each do |filter| %>
-      <% if filter == :tag_ids %>
-        <% @filtered_tags.each do |tag| %>
-          <span class="d-flex me-2 active-filter-badge">
-            <%= tag.value %>
-            <%= link_to structure_users_path(url_params.merge(tag_ids: params[:tag_ids] - [tag.id.to_s])) do %>
-              <i class="ri-close-line"></i>
-            <% end %>
-          </span>
+    <% ([:status, :orientation_type, :action_required, :referent_id] & active_filter_list).each do |filter| %>
+      <span class="d-flex me-2 active-filter-badge">
+        <% if filter == :referent_id %>
+          Suivi par <%= @referent %>
+        <% elsif filter == :orientation_type %>
+          Orientation : <%= params[filter] %>
+        <% elsif filter == :action_required %>
+          Intervention nécessaire
+        <% elsif filter == :status %>
+          Statut : <%= I18n.t("activerecord.attributes.follow_up.statuses.#{params[filter]}") %>
         <% end %>
-      <% else %>
-        <span class="d-flex me-2 active-filter-badge">
-          <% if filter == :referent_id %>
-            Suivi par <%= @referent %>
-          <% elsif filter == :orientation_type %>
-            Orientation : <%= params[filter] %>
-          <% elsif filter == :action_required %>
-            Intervention nécessaire
-          <% elsif filter == :status %>
-            Statut : <%= I18n.t("activerecord.attributes.follow_up.statuses.#{params[filter]}") %>
-          <% end %>
-          <%= link_to structure_users_path(url_params.except(filter)) do %>
-            <i class="ri-close-line"></i>
-          <% end %>
-        </span>
-      <% end %>
+        <%= link_to structure_users_path(url_params.except(filter)) do %>
+          <i class="ri-close-line"></i>
+        <% end %>
+      </span>
     <% end %>
+    <%= render "users/active_filters_recap/tag_ids" %>
     <%= render "users/active_filters_recap/creation_date" %>
     <%= render "users/active_filters_recap/convocation_date" %>
     <%= render "users/active_filters_recap/first_invitation_date" %>

--- a/app/views/users/_active_filters_recap.html.erb
+++ b/app/views/users/_active_filters_recap.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </div>
   <div class="active-filters-container d-flex flex-wrap">
-    <% (active_filter_list - [:search_query]).each do |filter| %>
+    <% (active_filter_list - [:search_query, :creation_date_before, :creation_date_before]).each do |filter| %>
       <% if filter == :tag_ids %>
         <% @filtered_tags.each do |tag| %>
           <span class="d-flex me-2 active-filter-badge">

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -2,12 +2,9 @@
   <div class="w-100">
     <%= link_to(new_structure_creation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
       <button class="btn btn-grey w-100">
-        <% if params[:creation_date_after].present? %>
-          Créés entre le <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> et le <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %> <span class="filter-active">1</span>
-        <% elsif params[:creation_date_before].present? %>
-          Créés avant le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %> <span class="filter-active">1</span>
-        <% else %>
-          Filtrer par date de création
+        Filtrer par date de création 
+        <% if params[:creation_date_after].present? || params[:creation_date_before].present? %>
+          <span class="filter-active">1</span>
         <% end %>
       </button>
     <% end %>

--- a/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
@@ -1,28 +1,21 @@
 <div class="mb-1">
   <div class="w-100">
     <%= link_to(new_structure_choose_date_kind_path(url_params), data: { turbo_frame: 'remote_modal' }, class: 'btn btn-grey w-100 d-flex align-items-center justify-content-between') do %>
-      <% if params[:first_invitation_date_before] || params[:first_invitation_date_after] || params[:last_invitation_date_before] || params[:last_invitation_date_after] || params[:convocation_date_after] %>
-        <div class="invitations-date-filter-content">
-          <% if params[:first_invitation_date_after].present? %>
-            <p>Première invitation entre le <%= format_date(params[:first_invitation_date_after].to_date) %> et le <%= format_date((params[:first_invitation_date_before]&.to_date || Time.zone.now)) %></p> 
-          <% elsif params[:first_invitation_date_before].present? %>
-            <p>Première invitation avant le <%= format_date(params[:first_invitation_date_before].to_date) %></p> 
-          <% end %>
-          <% if params[:last_invitation_date_after].present? %>
-            <p>Dernière invitation entre le <%= format_date(params[:last_invitation_date_after].to_date) %> et le <%= format_date((params[:last_invitation_date_before]&.to_date || Time.zone.now)) %></p>
-          <% elsif params[:last_invitation_date_before].present? %>
-            <p>Dernière invitation avant le <%= format_date(params[:last_invitation_date_before].to_date) %></p>
-          <% end %>
-          <% if params[:convocation_date_after] %>
-            <p>Convocations entre le <%= format_date(params[:convocation_date_after].to_date) %> et le <%= format_date((params[:convocation_date_before]&.to_date || Time.zone.now)) %></p>
-          <% elsif params[:convocation_date_before] %>
-            <p>Convocations avant le <%= format_date(params[:convocation_date_before].to_date) %></p>
-          <% end %>
-        </div>
-        <span class="filter-active convocation-date-filter-active">1</span>
-        <i class="ri-pencil-fill text-dark-blue"></i>
-      <% else %>
-        <span class="w-100">Filtrer par date d'invitation ou de convocation</span>
+      <span class="w-100">Filtrer par date d'invitation ou de convocation</span>
+      <% if params[:convocation_date_after].present? || params[:convocation_date_before].present? || params[:first_invitation_date_after].present? || params[:first_invitation_date_before].present? || params[:last_invitation_date_after].present? || params[:last_invitation_date_before].present? %>
+      <span class="filter-active convocation-date-filter-active">
+        <% active_filters = 0 %>
+
+        <% active_filters += 1 if params[:convocation_date_after].present? || params[:convocation_date_before].present? %>
+        <% active_filters += 1 if params[:first_invitation_date_after].present? || params[:first_invitation_date_before].present? %>
+        <% active_filters += 1 if params[:last_invitation_date_after].present? || params[:last_invitation_date_before].present? %>
+
+        <% if active_filters > 0 %>
+          <span class="filter-active convocation-date-filter-active">
+            <%= active_filters %>
+          </span>
+        <% end %>
+      </span>
       <% end %>
     <% end %>
   </div>

--- a/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitation_or_convocation_dates_button.html.erb
@@ -4,15 +4,9 @@
       <span class="w-100">Filtrer par date d'invitation ou de convocation</span>
       <% if params[:convocation_date_after].present? || params[:convocation_date_before].present? || params[:first_invitation_date_after].present? || params[:first_invitation_date_before].present? || params[:last_invitation_date_after].present? || params[:last_invitation_date_before].present? %>
       <span class="filter-active convocation-date-filter-active">
-        <% active_filters = 0 %>
-
-        <% active_filters += 1 if params[:convocation_date_after].present? || params[:convocation_date_before].present? %>
-        <% active_filters += 1 if params[:first_invitation_date_after].present? || params[:first_invitation_date_before].present? %>
-        <% active_filters += 1 if params[:last_invitation_date_after].present? || params[:last_invitation_date_before].present? %>
-
-        <% if active_filters > 0 %>
+        <% if invitation_or_convocation_active_filters_count > 0 %>
           <span class="filter-active convocation-date-filter-active">
-            <%= active_filters %>
+            <%= invitation_or_convocation_active_filters_count %>
           </span>
         <% end %>
       </span>

--- a/app/views/users/active_filters_recap/_convocation_date.html.erb
+++ b/app/views/users/active_filters_recap/_convocation_date.html.erb
@@ -1,0 +1,14 @@
+<% if params[:convocation_date_before].present? || params[:convocation_date_after].present? %>
+  <span class="d-flex me-2 active-filter-badge">
+    <% if params[:convocation_date_before].present? && params[:convocation_date_after].present? %>
+      Convoqué entre le : <%= format_date(params[:convocation_date_after].to_date) %> et le <%= format_date(params[:convocation_date_before].to_date) %>
+    <% elsif params[:convocation_date_before].present? %>
+      Convoqué avant le : <%= format_date(params[:convocation_date_before].to_date) %>
+    <% elsif params[:convocation_date_after].present? %>
+      Convoqué aprés le : <%= format_date(params[:convocation_date_after].to_date) %>
+    <% end %>
+    <%= link_to structure_users_path(url_params.except(:convocation_date_before, :convocation_date_after)) do %>
+      <i class="ri-close-line"></i>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/users/active_filters_recap/_creation_date.html.erb
+++ b/app/views/users/active_filters_recap/_creation_date.html.erb
@@ -1,0 +1,14 @@
+<% if params[:creation_date_before].present? || params[:creation_date_after].present? %>
+  <span class="d-flex me-2 active-filter-badge">
+    <% if params[:creation_date_before].present? && params[:creation_date_after].present? %>
+      Créé entre le : <%= format_date(params[:creation_date_after].to_date) %> et le <%= format_date(params[:creation_date_before].to_date) %>
+    <% elsif params[:creation_date_before].present? %>
+      Créé avant le : <%= format_date(params[:creation_date_before].to_date) %>
+    <% elsif params[:creation_date_after].present? %>
+      Créé aprés le : <%= format_date(params[:creation_date_after].to_date) %>
+    <% end %>
+    <%= link_to structure_users_path(url_params.except(:creation_date_before, :creation_date_after)) do %>
+      <i class="ri-close-line"></i>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/users/active_filters_recap/_first_invitation_date.html.erb
+++ b/app/views/users/active_filters_recap/_first_invitation_date.html.erb
@@ -1,0 +1,14 @@
+<% if params[:first_invitation_date_before].present? || params[:first_invitation_date_after].present? %>
+  <span class="d-flex me-2 active-filter-badge">
+    <% if params[:first_invitation_date_before].present? && params[:first_invitation_date_after].present? %>
+      Première invitation envoyée entre le : <%= format_date(params[:first_invitation_date_after].to_date) %> et le <%= format_date(params[:first_invitation_date_before].to_date) %>
+    <% elsif params[:first_invitation_date_before].present? %>
+      Première invitation envoyée avant le : <%= format_date(params[:first_invitation_date_before].to_date) %>
+    <% elsif params[:first_invitation_date_after].present? %>
+      Première invitation envoyée aprés le : <%= format_date(params[:first_invitation_date_after].to_date) %>
+    <% end %>
+    <%= link_to structure_users_path(url_params.except(:first_invitation_date_before, :first_invitation_date_after)) do %>
+      <i class="ri-close-line"></i>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/users/active_filters_recap/_last_invitation_date.html.erb
+++ b/app/views/users/active_filters_recap/_last_invitation_date.html.erb
@@ -1,0 +1,14 @@
+<% if params[:last_invitation_date_before].present? || params[:last_invitation_date_after].present? %>
+  <span class="d-flex me-2 active-filter-badge">
+    <% if params[:last_invitation_date_before].present? && params[:last_invitation_date_after].present? %>
+      Dernière invitation envoyée entre le : <%= format_date(params[:last_invitation_date_after].to_date) %> et le <%= format_date(params[:last_invitation_date_before].to_date) %>
+    <% elsif params[:last_invitation_date_before].present? %>
+      Dernière invitation envoyée avant le : <%= format_date(params[:last_invitation_date_before].to_date) %>
+    <% elsif params[:last_invitation_date_after].present? %>
+      Dernière invitation envoyée aprés le : <%= format_date(params[:last_invitation_date_after].to_date) %>
+    <% end %>
+    <%= link_to structure_users_path(url_params.except(:last_invitation_date_before, :last_invitation_date_after)) do %>
+      <i class="ri-close-line"></i>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/users/active_filters_recap/_tag_ids.html.erb
+++ b/app/views/users/active_filters_recap/_tag_ids.html.erb
@@ -1,0 +1,10 @@
+<% if params[:tag_ids] %>
+  <% @filtered_tags.each do |tag| %>
+    <span class="d-flex me-2 active-filter-badge">
+      <%= tag.value %>
+      <%= link_to structure_users_path(url_params.merge(tag_ids: params[:tag_ids] - [tag.id.to_s])) do %>
+        <i class="ri-close-line"></i>
+      <% end %>
+    </span>
+  <% end %>
+<% end %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1241,21 +1241,4 @@ describe UsersController do
       end
     end
   end
-
-  describe "active filters view" do
-    include UsersHelper
-
-    # This test ensures that the active_filters_recap handles every possible filter
-    # It might turn red if we add a new filter and forget to handle its associated
-    # view in the active_filters_recap.
-    # To fix it, you just need to add an if statement to the view
-    it "handles and single filter possibilities" do
-      view_content = Rails.root.join("app/views/users/_active_filters_recap.html.erb").read
-      (filter_list - [:search_query]).each do |filter|
-        expect(view_content).to include("filter == :#{filter}").or(
-          include("active_filters_recap/#{filter.to_s.gsub('_before', '').gsub('_after', '')}")
-        )
-      end
-    end
-  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1252,7 +1252,9 @@ describe UsersController do
     it "handles and single filter possibilities" do
       view_content = Rails.root.join("app/views/users/_active_filters_recap.html.erb").read
       (filter_list - [:search_query]).each do |filter|
-        expect(view_content).to include("filter == :#{filter}")
+        expect(view_content).to include("filter == :#{filter}").or(
+          include("active_filters_recap/#{filter.to_s.gsub('_before', '').gsub('_after', '')}")
+        )
       end
     end
   end

--- a/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
+++ b/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
@@ -49,7 +49,7 @@ describe "Agents can visualize active filters on index page", :js do
     expect(page).to have_content("correspondant à votre recherche \"coucou\"")
     expect(page).to have_content("Suivi par #{agent}")
     expect(page).to have_content("Convoqué entre le : 03/05/2025 et le 07/05/2025")
-    expect(page).to hace_content("Créé entre le : 05/05/2025 et le 07/05/2025")
+    expect(page).to have_content("Créé entre le : 05/05/2025 et le 07/05/2025")
     expect(page).to have_content("Dernière invitation envoyée entre le : 03/05/2025 et le 05/05/2025")
     expect(page).to have_content("Première invitation envoyée entre le : 03/05/2025 et le 05/05/2025")
   end

--- a/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
+++ b/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
@@ -1,0 +1,56 @@
+describe "Agents can visualize active filters on index page", :js do
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:organisation) { create(:organisation) }
+  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation") }
+  let!(:category_configuration) do
+    create(:category_configuration, organisation: organisation, motif_category: motif_category)
+  end
+  let!(:motif) { create(:motif, motif_category: motif_category, organisation: organisation) }
+  let!(:user1) { create(:user, first_name: "Bertrand", last_name: "Blier") }
+  let!(:user2) { create(:user, first_name: "Amanda", last_name: "Ajer") }
+  let!(:user3) { create(:user, first_name: "Claire", last_name: "Casubolo") }
+
+  let!(:users_organisation1) do
+    create(:users_organisation, user: user1, organisation: organisation, created_at: Time.zone.now)
+  end
+  let!(:users_organisation2) do
+    create(:users_organisation, user: user2, organisation: organisation, created_at: 1.day.ago)
+  end
+  let!(:users_organisation3) do
+    create(:users_organisation, user: user3, organisation: organisation, created_at: 2.days.ago)
+  end
+
+  let(:orientation_type) { create(:orientation_type, name: "Sociale", casf_category: "social") }
+  let!(:orientation) { create(:orientation, organisation: organisation, user: user1, orientation_type:) }
+
+  before do
+    setup_agent_session(agent)
+    visit organisation_users_path(
+      organisation, 
+      orientation_type: "Sociale",
+      status: "rdv_seen",
+      search_query: "coucou",
+      motif_category_id: motif_category.id,
+      referent_id: agent.id,
+      convocation_date_before: "2025-05-07",
+      convocation_date_after: "2025-05-03",
+      creation_date_after: "2025-05-05",
+      creation_date_before: "2025-05-07",
+      last_invitation_date_before: "2025-05-05",
+      last_invitation_date_after: "2025-05-03",
+      first_invitation_date_before: "2025-05-05",
+      first_invitation_date_after: "2025-05-03"
+    )
+  end
+
+  it "shows a recap of all active filters" do
+    expect(page).to have_content("Orientation : Sociale")
+    expect(page).to have_content("Statut : RDV honoré")
+    expect(page).to have_content("correspondant à votre recherche \"coucou\"")
+    expect(page).to have_content("Suivi par #{agent}")
+    expect(page).to have_content("Convoqué entre le : 03/05/2025 et le 07/05/2025")
+    expect(page).to hace_content("Créé entre le : 05/05/2025 et le 07/05/2025")
+    expect(page).to have_content("Dernière invitation envoyée entre le : 03/05/2025 et le 05/05/2025")
+    expect(page).to have_content("Première invitation envoyée entre le : 03/05/2025 et le 05/05/2025")
+  end
+end

--- a/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
+++ b/spec/features/agent_can_visualize_active_filters_on_index_page_spec.rb
@@ -26,7 +26,7 @@ describe "Agents can visualize active filters on index page", :js do
   before do
     setup_agent_session(agent)
     visit organisation_users_path(
-      organisation, 
+      organisation,
       orientation_type: "Sociale",
       status: "rdv_seen",
       search_query: "coucou",


### PR DESCRIPTION
Cette PR améliore le visuel des filtres actifs en gérant mieux les filtres par dates. 

J'ai adapté le test associé, bon je suis pas hyper satisfait de ce test mais il fait le job

<img width="984" alt="Screenshot 2025-02-19 at 16 57 50" src="https://github.com/user-attachments/assets/3c52c00c-f0d6-4534-aaea-3a27f61d9a5e" />

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2588