### PR TITLE
feat: storing the creneaux available every morning

### DIFF
--- a/app/jobs/category_configurations/store_all_number_of_creneaux_available_job.rb
+++ b/app/jobs/category_configurations/store_all_number_of_creneaux_available_job.rb
@@ -1,0 +1,9 @@
+module CategoryConfigurations
+  class StoreAllNumberOfCreneauxAvailableJob < ApplicationJob
+    def perform
+      CategoryConfiguration.find_each do |category_configuration|
+        CategoryConfigurations::StoreNumberOfCreneauxAvailable.perform_later(category_configuration.id)
+      end
+    end
+  end
+end

--- a/app/jobs/category_configurations/store_number_of_creneaux_available_job.rb
+++ b/app/jobs/category_configurations/store_number_of_creneaux_available_job.rb
@@ -1,0 +1,12 @@
+module CategoryConfigurations
+  class StoreNumberOfCreneauxAvailableJob < ApplicationJob
+    def perform(category_configuration_id)
+      category_configuration = CategoryConfiguration.joins(:motif_category, organisation: :agents)
+                                                    .find_by(id: category_configuration_id)
+
+      return if category_configuration.blank?
+
+      call_service!(StoreNumberOfCreneauxAvailable, category_configuration:)
+    end
+  end
+end

--- a/app/models/creneau_availability.rb
+++ b/app/models/creneau_availability.rb
@@ -1,0 +1,3 @@
+class CreneauAvailability < ApplicationRecord
+  belongs_to :category_configuration
+end

--- a/app/services/category_configurations/store_number_of_creneaux_available.rb
+++ b/app/services/category_configurations/store_number_of_creneaux_available.rb
@@ -1,0 +1,32 @@
+module CategoryConfigurations
+  class StoreNumberOfCreneauxAvailable < BaseService
+    attr_reader :category_configuration
+
+    def initialize(category_configuration:)
+      @category_configuration = category_configuration
+    end
+
+    def call
+      number_of_creneaux_available = get_number_of_creneaux(
+        category_configuration.motif_category,
+        category_configuration.organisation
+      )
+
+      save_record!(CreneauAvailability.new(category_configuration:, number_of_creneaux_available:))
+    end
+
+    private
+
+    def get_number_of_creneaux(motif_category, organisation)
+      organisation.agents.first.with_rdv_solidarites_session do
+        RdvSolidaritesApi::RetrieveCreneauAvailability.call(
+          link_params: {
+            motif_category_short_name: motif_category.short_name,
+            organisation_ids: [organisation.rdv_solidarites_organisation_id]
+          },
+          total_count: true
+        ).creneau_availability_count
+      end
+    end
+  end
+end

--- a/app/services/rdv_solidarites_api/retrieve_creneau_availability.rb
+++ b/app/services/rdv_solidarites_api/retrieve_creneau_availability.rb
@@ -1,12 +1,13 @@
 module RdvSolidaritesApi
   class RetrieveCreneauAvailability < Base
-    def initialize(link_params:)
-      @link_params = link_params
+    def initialize(link_params:, extra: {})
+      @link_params = link_params.merge(extra)
     end
 
     def call
       request!
       result.creneau_availability = rdv_solidarites_response_body["creneau_availability"]
+      result.creneau_availability_count = rdv_solidarites_response_body["creneau_availability_count"]
     end
 
     private

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,6 +28,9 @@ upsert_monthly_stats_job:
 refresh_out_of_date_follow_up_statuses_job:
   cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "RefreshOutOfDateFollowUpStatusesJob"
+store_all_number_of_creneaux_available_job:
+  cron: "0 5 * * *" # we refresh out of date statuses once a day, at 21:00
+  class: "CategoryConfigurations::StoreAllNumberOfCreneauxAvailableJob"
 remove_organisation_users_for_expired_archives_job:
   cron: "0 23 * * *" # we remove expired archived users from organisations once a day, at 23:00
   class: "RemoveOrganisationUsersForExpiredArchivesJob"

--- a/db/migrate/20250225134047_create_creneau_availabilities.rb
+++ b/db/migrate/20250225134047_create_creneau_availabilities.rb
@@ -1,0 +1,10 @@
+class CreateCreneauAvailabilities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :creneau_availabilities do |t|
+      t.integer :number_of_creneaux_available
+      t.references :category_configuration, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_25_134047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -134,6 +134,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
     t.index ["file_configuration_id"], name: "index_category_configurations_on_file_configuration_id"
     t.index ["motif_category_id"], name: "index_category_configurations_on_motif_category_id"
     t.index ["organisation_id"], name: "index_category_configurations_on_organisation_id"
+  end
+
+  create_table "creneau_availabilities", force: :cascade do |t|
+    t.integer "number_of_creneaux_available"
+    t.bigint "category_configuration_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_configuration_id"], name: "index_creneau_availabilities_on_category_configuration_id"
   end
 
   create_table "csv_exports", force: :cascade do |t|
@@ -647,6 +655,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
   add_foreign_key "category_configurations", "file_configurations"
   add_foreign_key "category_configurations", "motif_categories"
   add_foreign_key "category_configurations", "organisations"
+  add_foreign_key "creneau_availabilities", "category_configurations"
   add_foreign_key "csv_exports", "agents"
   add_foreign_key "dpa_agreements", "agents"
   add_foreign_key "dpa_agreements", "organisations"

--- a/spec/services/category_configurations/store_number_of_creneaux_available_spec.rb
+++ b/spec/services/category_configurations/store_number_of_creneaux_available_spec.rb
@@ -1,0 +1,22 @@
+describe CategoryConfigurations::StoreNumberOfCreneauxAvailable, type: :service do
+  subject do
+    described_class.call(category_configuration:)
+  end
+
+  let!(:category_configuration) { create(:category_configuration) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [category_configuration.organisation]) }
+
+  context "when API call succeeds" do
+    before do
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to(
+        receive(:call).and_return(OpenStruct.new(creneau_availability_count: 3))
+      )
+    end
+
+    it "stores the number of creneaux available" do
+      subject
+      expect(CreneauAvailability.last.number_of_creneaux_available).to eq(3)
+      expect(CreneauAvailability.last.category_configuration).to eq(category_configuration)
+    end
+  end
+end


### PR DESCRIPTION
Cette PR permet de requêter tous les matins à 5H l'API de creneaux disponible de rendez-vous solidarites, et ce pour chacune des category_configuration que nous avons. 

En l'état nous stockons tous les jours les ~930 résultats. 
À voir à terme si on veut mettre en place un système de cleanup. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2580