### PR TITLE
fix(user): Remove unnecessary logic when importing user

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -129,7 +129,6 @@ module InboundWebhooks
             created_through: "rdv_solidarites_webhook",
             created_from_structure: organisation,
             organisations: [organisation],
-            import_associations_from_rdv_solidarites_on_create: true,
             **rdv_solidarites_user.to_rdvi_attributes.slice(*User::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES).compact_blank
           )
         end

--- a/app/models/concerns/user/creation_origin.rb
+++ b/app/models/concerns/user/creation_origin.rb
@@ -21,7 +21,7 @@ module User::CreationOrigin
     scope :created_through_rdv_solidarites, -> { where(created_through: "rdv_solidarites_webhook") }
   end
 
-  def created_through_rdv_solidarites? = created_through_rdv_solidarites_webhook?
+  def imported_from_rdv_solidarites? = created_through_rdv_solidarites_webhook?
 
   def created_through_rdv_insertion? = !created_through_rdv_solidarites?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
   delegate :name, :number, to: :department, prefix: true
 
   after_commit :import_associations_from_rdv_solidarites, on: :create,
-                                                          if: :import_associations_from_rdv_solidarites_on_create
+                                                          if: :imported_from_rdv_solidarites?
 
   enum :role, { demandeur: "demandeur", conjoint: "conjoint" }
   enum :title, { monsieur: "monsieur", madame: "madame" }

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -258,7 +258,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
               expect(User).to receive(:create!).with(
                 rdv_solidarites_user_id: user_id1,
                 organisations: [organisation],
-                import_associations_from_rdv_solidarites_on_create: true,
                 first_name: "James",
                 last_name: "Cameron",
                 address: "50 rue Victor Hugo 93500 Pantin",
@@ -307,7 +306,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
               expect(User).to receive(:create!).with(
                 rdv_solidarites_user_id: user_id1,
                 organisations: [organisation],
-                import_associations_from_rdv_solidarites_on_create: true,
                 first_name: "James",
                 last_name: "Cameron",
                 address: "50 rue Victor Hugo 93500 Pantin",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -452,7 +452,7 @@ describe User do
   end
 
   describe "#import_associations_from_rdv_solidarites" do
-    let!(:user) { build(:user, import_associations_from_rdv_solidarites_on_create: true) }
+    let!(:user) { build(:user, created_through: "rdv_solidarites_webhook") }
 
     before do
       allow(ImportUserAssociationsFromRdvSolidaritesJob).to receive(:perform_later)
@@ -463,7 +463,7 @@ describe User do
       user.save
     end
 
-    context "when the option import_associations_from_rdv_solidarites_on_create is not set" do
+    context "when the user is not created through rdv_solidarites_webhook" do
       let!(:user) { build(:user) }
 
       it "does not enqueue a job to import associations from rdv_solidarites" do
@@ -473,10 +473,9 @@ describe User do
     end
 
     context "when the user is being updated" do
-      let!(:user) { create(:user) }
+      let!(:user) { create(:user, created_through: "rdv_solidarites_webhook") }
 
       it "does not enqueue a job to import associations from rdv_solidarites" do
-        user.import_associations_from_rdv_solidarites_on_create = true
         expect(ImportUserAssociationsFromRdvSolidaritesJob).not_to receive(:perform_later)
         user.save
       end


### PR DESCRIPTION
Depuis #2642 , il n'y a qu'un seul moyen d'importer un usager déjà créé sur rdv-sp, c'est qu'il soit créé via les webhooks de rdvsp.
Du coup j'enlève l'accessor `import_associations_from_rdv_solidarites_on_create` qui servait à flagger les usagers dont on devait importer les associations, puisque ces usagers sont maintenant les usagers créé par les webhooks rdv-sp.