### PR TITLE
fix(super_admin): Super admin header improvement

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,32 +51,6 @@ module ApplicationHelper
     Rack::Utils.parse_nested_query(request.query_string).deep_symbolize_keys
   end
 
-  def tooltip_tag_attributes(stimulus_action:, **dataset)
-    attributes = {
-      data: {
-        controller: "tooltip",
-        action: stimulus_action
-      }.merge(dataset || {})
-    }
-
-    tag.attributes(attributes)
-  end
-
-  def tooltip_errors_tag_attributes(title:, errors:)
-    tag.attributes(tooltip_errors_attributes(title: title, errors: errors))
-  end
-
-  def tooltip_errors_attributes(title:, errors:)
-    {
-      data: {
-        controller: "tooltip",
-        action: "mouseover->tooltip#showErrors",
-        title: title,
-        errors: errors.to_json
-      }
-    }
-  end
-
   def render_turbo_stream_flash_messages
     turbo_stream.prepend "flashes", partial: "common/flashes"
   end

--- a/app/helpers/super_admin_header_helper.rb
+++ b/app/helpers/super_admin_header_helper.rb
@@ -1,0 +1,5 @@
+module SuperAdminHeaderHelper
+  def super_admin_header_closed?
+    cookies[:super_admin_header_closed] == "true"
+  end
+end

--- a/app/helpers/tooltip_helper.rb
+++ b/app/helpers/tooltip_helper.rb
@@ -1,0 +1,27 @@
+module TooltipHelper
+  def tooltip_tag_attributes(stimulus_action:, **dataset)
+    attributes = {
+      data: {
+        controller: "tooltip",
+        action: stimulus_action
+      }.merge(dataset || {})
+    }
+
+    tag.attributes(attributes)
+  end
+
+  def tooltip_errors_tag_attributes(title:, errors:)
+    tag.attributes(tooltip_errors_attributes(title: title, errors: errors))
+  end
+
+  def tooltip_errors_attributes(title:, errors:)
+    {
+      data: {
+        controller: "tooltip",
+        action: "mouseover->tooltip#showErrors",
+        title: title,
+        errors: errors.to_json
+      }
+    }
+  end
+end

--- a/app/javascript/controllers/super_admin_header_controller.js
+++ b/app/javascript/controllers/super_admin_header_controller.js
@@ -1,27 +1,22 @@
 import { Controller } from "@hotwired/stimulus";
+import Cookies from "js-cookie";
 
 export default class extends Controller {
-  initialize() {
-    if (localStorage.getItem("super-admin-header-closed") === "true")
-      this.hide()
-    else
-      this.show();
-  }
-
   toggle() {
-    if (this.element.classList.contains("hidden"))
+    if (this.element.classList.contains("hidden")) {
       this.show()
-    else
+    } else {
       this.hide();
+    }
   }
 
   show() {
     this.element.classList.remove("hidden");
-    localStorage.setItem("super-admin-header-closed", "false");
+    Cookies.set("super_admin_header_closed", "false", { path: "/", expires: 365 });
   }
 
   hide() {
     this.element.classList.add("hidden");
-    localStorage.setItem("super-admin-header-closed", "true");
+    Cookies.set("super_admin_header_closed", "true", { path: "/", expires: 365 });
   }
 }

--- a/app/views/common/_header_super_admin_bar.html.erb
+++ b/app/views/common/_header_super_admin_bar.html.erb
@@ -1,4 +1,4 @@
-<div class="top-bar d-flex hidden" data-controller="super-admin-header">
+<div class="top-bar d-flex <%= "hidden" if super_admin_header_closed? %>" data-controller="super-admin-header">
   <div class="container d-flex position-relative top-bar-content">
     <div class="container d-flex justify-content-start px-3">
       <p class="mb-0">Bonjour <%= current_agent.first_name %>, voulez-vous accéder au SuperAdmin ?</p>

--- a/app/views/common/_header_super_admin_bar_impersonated.html.erb
+++ b/app/views/common/_header_super_admin_bar_impersonated.html.erb
@@ -1,4 +1,4 @@
-<div class="top-bar d-flex hidden dark-blue-style" data-controller="super-admin-header">
+<div class="top-bar d-flex dark-blue-style <%= "hidden" if super_admin_header_closed? %>" data-controller="super-admin-header">
   <div class="container d-flex position-relative top-bar-content">
     <div class="container d-flex justify-content-start px-3">
       <p class="mb-0">Vous êtes connecté.e en tant que <%= current_agent.to_s %></p>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chartkick": "^4.1.1",
     "css-loader": "^6.9.1",
     "flatpickr": "^4.6.13",
+    "js-cookie": "^3.0.5",
     "mini-css-extract-plugin": "^2.7.7",
     "mobx": "^6.10.0",
     "mobx-react-lite": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,6 +2782,11 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Closes #2491 .

J'en avais marre de voir l'animation sur le bandeau super admin à chaque fois que je naviguais sur l'appli du coup j'ai décidé de faire un fix 😂 . 
Pour se faire j'utilise les cookies plutôt que le local storage pour afficher/cacher le bandeau. Ainsi le bandeau est rendu ou caché par le html renvoyé par le serveur.
J'ajoute la libraire "js-cookie" pour manipuler les cookies de manière plus sûr et plus sereine. 
J'aurais éventuellement pu ajouter des routes côté serveur pour faire ça côté serveur plutôt que côté client mais: 
- on ne bénéficierait plus de l'animation
- ça complexifierait possiblement le code

J'en profite pour faire un peu de ménage dans `ApplicationHelper` pour extraire des helpers séparés.