### PR TITLE
feat(assets): Load remix icons at page load

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,7 +5,6 @@
 // Vanilla components
 import "bootstrap";
 import "./stylesheets/application.scss";
-import "remixicon/fonts/remixicon.css";
 import "@hotwired/turbo-rails";
 import { Application } from "@hotwired/stimulus";
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -29,6 +29,7 @@
 @import "./components/agreement_modal";
 @import "./components/rdv_insertion_instance_name";
 @import "tippy.js/dist/tippy.css";
+@import "remixicon/fonts/remixicon.css";
 
 @font-face {
   font-family: 'Marianne';


### PR DESCRIPTION
J'ai remarqué que les icônes ont tendance à apparaître après le chargement des pages sur rdv-i, ce qui peut être un peu perturbant.
Je déplace le loading du css de remix-icon dans `application.scss` plutôt que `application.js` pour être consistant avec ce qu'il se fait sur le reste de l'appli et pour voir si le fait de l'importer plus tôt résout le problème.