### PR TITLE
feat(dpa): store agent identity

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -10,6 +10,7 @@ class Agent < ApplicationRecord
   has_many :orientations, dependent: :nullify
   has_many :csv_exports, dependent: :destroy
   has_many :parcours_documents, dependent: :nullify
+  has_many :dpa_agreements, dependent: :nullify
 
   has_many :organisations, through: :agent_roles
   has_many :departments, -> { distinct }, through: :organisations

--- a/app/models/dpa_agreement.rb
+++ b/app/models/dpa_agreement.rb
@@ -4,10 +4,11 @@ class DpaAgreement < ApplicationRecord
 
   validates :organisation, uniqueness: true
   validates :agent, presence: true, on: :create
+  validates :agent_full_name, :agent_email, presence: true
 
-  before_save :set_identity
+  before_validation :set_agent_identity
 
-  def set_identity
+  def set_agent_identity
     return if agent.nil?
 
     self.agent_full_name = agent.to_s

--- a/app/models/dpa_agreement.rb
+++ b/app/models/dpa_agreement.rb
@@ -1,6 +1,16 @@
 class DpaAgreement < ApplicationRecord
   belongs_to :organisation
-  belongs_to :agent
+  belongs_to :agent, optional: true
 
   validates :organisation, uniqueness: true
+  validates :agent, presence: true, on: :create
+
+  before_save :set_identity
+
+  def set_identity
+    return if agent.nil?
+
+    self.agent_full_name = agent.to_s
+    self.agent_email = agent.email
+  end
 end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -119,7 +119,9 @@ tables:
       - carnet_de_bord_deploiement_id
 
   - table_name: dpa_agreements
-    anonymized_column_names: []
+    anonymized_column_names:
+      - agent_email
+      - agent_full_name
     non_anonymized_column_names:
       - agent_id
       - organisation_id

--- a/db/migrate/20250227134523_add_dpa_identity_to_dpa_agreement.rb
+++ b/db/migrate/20250227134523_add_dpa_identity_to_dpa_agreement.rb
@@ -1,0 +1,7 @@
+class AddDpaIdentityToDpaAgreement < ActiveRecord::Migration[8.0]
+  def change
+    add_column :dpa_agreements, :agent_email, :string
+    add_column :dpa_agreements, :agent_full_name, :string
+    change_column_null :dpa_agreements, :agent_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_27_134523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -136,6 +136,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
     t.index ["organisation_id"], name: "index_category_configurations_on_organisation_id"
   end
 
+  create_table "creneau_availabilities", force: :cascade do |t|
+    t.integer "number_of_creneaux_available"
+    t.bigint "category_configuration_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_configuration_id"], name: "index_creneau_availabilities_on_category_configuration_id"
+  end
+
   create_table "csv_exports", force: :cascade do |t|
     t.bigint "agent_id", null: false
     t.string "structure_type", null: false
@@ -165,9 +173,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
 
   create_table "dpa_agreements", force: :cascade do |t|
     t.bigint "organisation_id", null: false
-    t.bigint "agent_id", null: false
+    t.bigint "agent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "agent_email"
+    t.string "agent_full_name"
     t.index ["agent_id"], name: "index_dpa_agreements_on_agent_id"
     t.index ["organisation_id"], name: "index_dpa_agreements_on_organisation_id"
   end
@@ -647,6 +657,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_140717) do
   add_foreign_key "category_configurations", "file_configurations"
   add_foreign_key "category_configurations", "motif_categories"
   add_foreign_key "category_configurations", "organisations"
+  add_foreign_key "creneau_availabilities", "category_configurations"
   add_foreign_key "csv_exports", "agents"
   add_foreign_key "dpa_agreements", "agents"
   add_foreign_key "dpa_agreements", "organisations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,14 +136,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_27_134523) do
     t.index ["organisation_id"], name: "index_category_configurations_on_organisation_id"
   end
 
-  create_table "creneau_availabilities", force: :cascade do |t|
-    t.integer "number_of_creneaux_available"
-    t.bigint "category_configuration_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["category_configuration_id"], name: "index_creneau_availabilities_on_category_configuration_id"
-  end
-
   create_table "csv_exports", force: :cascade do |t|
     t.bigint "agent_id", null: false
     t.string "structure_type", null: false
@@ -657,7 +649,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_27_134523) do
   add_foreign_key "category_configurations", "file_configurations"
   add_foreign_key "category_configurations", "motif_categories"
   add_foreign_key "category_configurations", "organisations"
-  add_foreign_key "creneau_availabilities", "category_configurations"
   add_foreign_key "csv_exports", "agents"
   add_foreign_key "dpa_agreements", "agents"
   add_foreign_key "dpa_agreements", "organisations"

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -55,4 +55,23 @@ describe Agent do
 
     it { expect(agent.export_organisations_ids).to include(organisation.id) }
   end
+
+  describe "deletion" do
+    subject { agent.destroy! }
+
+    let!(:agent) { create(:agent) }
+
+    context "dpa_agreement" do
+      let!(:organisation) { create(:organisation, :without_dpa_agreement) }
+      let!(:dpa_agreement) { create(:dpa_agreement, agent:, organisation:) }
+
+      it "nullifies dpa_agreement" do
+        subject
+        dpa_agreement.reload
+
+        expect(dpa_agreement.agent).to be_nil
+        expect(dpa_agreement.agent_email).to eq(agent.email)
+      end
+    end
+  end
 end

--- a/spec/models/dpa_agreement_spec.rb
+++ b/spec/models/dpa_agreement_spec.rb
@@ -1,0 +1,36 @@
+describe DpaAgreement do
+  subject do
+    dpa_agreement.save!
+  end
+
+  let!(:agent) { create(:agent) }
+  let!(:organisation) { create(:organisation, :without_dpa_agreement) }
+  let(:dpa_agreement) { build(:dpa_agreement, agent:, organisation:) }
+
+  describe "callbacks" do
+    it "saves agent identity" do
+      subject
+      expect(dpa_agreement.email).to eq(agent.email)
+      expect(dpa_agreement.agent_full_name).to eq(agent.to_s)
+    end
+
+    context "agent change" do
+      let(:other_agent) { create(:agent) }
+
+      it "refresh agent identity" do
+        subject
+        dpa_agreement.update!(agent: other_agent)
+        expect(dpa_agreement.agent_email).to eq(other_agent.email)
+        expect(dpa_agreement.agent_full_name).to eq(other_agent.to_s)
+      end
+    end
+  end
+
+  describe "validations" do
+    let!(:agent) { nil }
+
+    it "requires an agent on creation" do
+      expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/models/dpa_agreement_spec.rb
+++ b/spec/models/dpa_agreement_spec.rb
@@ -10,7 +10,7 @@ describe DpaAgreement do
   describe "callbacks" do
     it "saves agent identity" do
       subject
-      expect(dpa_agreement.email).to eq(agent.email)
+      expect(dpa_agreement.agent_email).to eq(agent.email)
       expect(dpa_agreement.agent_full_name).to eq(agent.to_s)
     end
 


### PR DESCRIPTION
Cette PR permet de stocker l'identité de la personne qui valide le DPA. 

En complément je ferai tourner le code suivant sur la prod une fois déployé : 
```ruby
DpaAgreement.all.find_each do |dpa_agreement|
  dpa_agreement.touch
end
```

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2645