### PR TITLE
fix(migration): Wrong rename table migration

### DIFF
--- a/db/migrate/20250224134608_rename_unavailable_creneau_logs_to_blocked_invitations_counters.rb
+++ b/db/migrate/20250224134608_rename_unavailable_creneau_logs_to_blocked_invitations_counters.rb
@@ -1,5 +1,5 @@
 class RenameUnavailableCreneauLogsToBlockedInvitationsCounters < ActiveRecord::Migration[8.0]
   def change
-    rename_table :blocked_invitations_counters, :blocked_invitations_counters
+    rename_table :unavailable_creneau_logs, :blocked_invitations_counters
   end
 end


### PR DESCRIPTION
en faisant un find and replace j'avais remplacé le nom de la table dans le fichier de migration aussi 😅 . 
Je revert ce changement ici.