### PR TITLE
fix(creneaux): ensure category configuration remains destroyable

### DIFF
--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -3,6 +3,8 @@ class CategoryConfiguration < ApplicationRecord
   belongs_to :file_configuration
   belongs_to :organisation
 
+  has_many :creneau_availabilities, dependent: :destroy
+
   validates :organisation, uniqueness: { scope: :motif_category,
                                          message: "a déjà une category_configuration pour cette catégorie de motif" }
   validate :minimum_invitation_duration,

--- a/spec/factories/creneau_availability.rb
+++ b/spec/factories/creneau_availability.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :creneau_availability do
+    number_of_creneaux_available { rand(0..30) }
+    category_configuration
+  end
+end

--- a/spec/models/category_configuration_spec.rb
+++ b/spec/models/category_configuration_spec.rb
@@ -9,6 +9,17 @@ describe CategoryConfiguration do
     end
   end
 
+  describe "associations" do
+    context "category_configuration is destroyed" do
+      let(:category_configuration) { create(:category_configuration) }
+      let!(:creneau_availability) { create(:creneau_availability, category_configuration: category_configuration) }
+
+      it "destroys creneaux_availability" do
+        expect { category_configuration.destroy }.to change(CreneauAvailability, :count).by(-1)
+      end
+    end
+  end
+
   describe "delays validation" do
     context "number_of_days_before_invitations_expire is superior to 3" do
       let(:category_configuration) do


### PR DESCRIPTION
Cette PR permet de garantir qu'une CategoryConfiguration puisse être supprimée en précisant que les creneaux associés doivent être également supprimés. 

Fix https://mattermost.incubateur.net/betagouv/pl/nk3ndsifmjf9xkfsmf5s8pka1w 