### PR TITLE
fix(xss): prevent any kind of xss injections

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  include Sanitizeable
   include Serializable
 
   def self.first

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -2,14 +2,31 @@ module Sanitizeable
   extend ActiveSupport::Concern
 
   included do
-    before_save do
-      attributes.each do |attr, value|
-        self[attr] = ActionView::Base.full_sanitizer.sanitize(value) if value.is_a?(String)
+    before_save :sanitize_attributes
+  end
 
-        next if value == self[attr]
+  private
 
-        Sentry.capture_message("Potential XSS attempt on #{self.class.name}", extra: { id:, value: })
-      end
+  def sanitize_attributes
+    changed_attributes.each_key do |attr|
+      original_value = self[attr]
+      next unless original_value.is_a?(String)
+
+      sanitized_value = ActionView::Base.full_sanitizer.sanitize(self[attr])
+
+      next if sanitized_value == original_value
+
+      self[attr] = sanitized_value
+
+      Sentry.capture_message(
+        "Potential XSS attempt on #{self.class.name}",
+        extra: {
+          id:,
+          attribute: attr,
+          original_value:,
+          sanitized_value:
+        }
+      )
     end
   end
 end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -55,8 +55,6 @@ module Sanitizeable
   end
 
   def sanitize_hash(hash)
-    return hash unless hash.values.any? { |v| v.is_a?(String) || v.is_a?(Array) || v.is_a?(Hash) }
-
-    hash.transform_values { |v| sanitize_value(v) }
+    hash.deep_transform_values { |v| sanitize_value(v) }
   end
 end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -1,0 +1,15 @@
+module Sanitizeable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save do
+      attributes.each do |attr, value|
+        self[attr] = ActionView::Base.full_sanitizer.sanitize(value) if value.is_a?(String)
+
+        next if value == self[attr]
+
+        Sentry.capture_message("Potential XSS attempt on #{self.class.name}", extra: { id:, value: })
+      end
+    end
+  end
+end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -33,9 +33,9 @@ module Sanitizeable
     when String
       sanitize_string(value)
     when Array
-      sanitize_array(value)
+      value.map { |v| sanitize_value(v) }
     when Hash
-      sanitize_hash(value)
+      hash.transform_values { |v| sanitize_value(v) }
     else
       value
     end
@@ -46,15 +46,5 @@ module Sanitizeable
 
     sanitized_value = ActionView::Base.full_sanitizer.sanitize(value)
     CGI.unescapeHTML(sanitized_value)
-  end
-
-  def sanitize_array(values)
-    return values unless values.any? { |v| v.is_a?(String) }
-
-    values.map { |v| sanitize_string(v) }
-  end
-
-  def sanitize_hash(hash)
-    hash.deep_transform_values { |v| sanitize_value(v) }
   end
 end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -10,10 +10,8 @@ module Sanitizeable
   def sanitize_attributes
     changed_attributes.each_key do |attr|
       original_value = self[attr]
-      next unless original_value.is_a?(String)
 
-      sanitized_value = ActionView::Base.full_sanitizer.sanitize(self[attr])
-
+      sanitized_value = sanitize_value(original_value)
       next if sanitized_value == original_value
 
       self[attr] = sanitized_value
@@ -28,5 +26,29 @@ module Sanitizeable
         }
       )
     end
+  end
+
+  def sanitize_value(value)
+    case value
+    when String
+      sanitize_string(value)
+    when Array
+      sanitize_array(value)
+    else
+      value
+    end
+  end
+
+  def sanitize_string(value)
+    return value unless value.is_a?(String)
+
+    sanitized_value = ActionView::Base.full_sanitizer.sanitize(value)
+    CGI.unescapeHTML(sanitized_value)
+  end
+
+  def sanitize_array(values)
+    return values unless values.any? { |v| v.is_a?(String) }
+
+    values.map { |v| sanitize_string(v) }
   end
 end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -35,7 +35,7 @@ module Sanitizeable
     when Array
       value.map { |v| sanitize_value(v) }
     when Hash
-      hash.transform_values { |v| sanitize_value(v) }
+      value.transform_values { |v| sanitize_value(v) }
     else
       value
     end

--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -34,6 +34,8 @@ module Sanitizeable
       sanitize_string(value)
     when Array
       sanitize_array(value)
+    when Hash
+      sanitize_hash(value)
     else
       value
     end
@@ -50,5 +52,11 @@ module Sanitizeable
     return values unless values.any? { |v| v.is_a?(String) }
 
     values.map { |v| sanitize_string(v) }
+  end
+
+  def sanitize_hash(hash)
+    return hash unless hash.values.any? { |v| v.is_a?(String) || v.is_a?(Array) || v.is_a?(Hash) }
+
+    hash.transform_values { |v| sanitize_value(v) }
   end
 end

--- a/spec/features/agent_can_add_or_remove_user_from_organisations_spec.rb
+++ b/spec/features/agent_can_add_or_remove_user_from_organisations_spec.rb
@@ -181,7 +181,11 @@ describe "Agents can add or remove user from organisations", :js do
     context "with xss attempt" do
       let(:xss_payload) { "<img src=1 onerror=alert(1)>" }
       let!(:organisation) do
-        create(:organisation, department:, name: "PLIE Valence #{xss_payload}")
+        create(:organisation, department:)
+      end
+
+      before do
+        organisation.update_column(:name, "PLIE Valence #{xss_payload}")
       end
 
       it "prevents xss" do

--- a/spec/features/agent_can_assign_referents_spec.rb
+++ b/spec/features/agent_can_assign_referents_spec.rb
@@ -69,7 +69,12 @@ describe "Agents can assign referents", :js do
       let(:xss_payload) { "<img src=1 onerror=alert(1)>" }
 
       let!(:user) do
-        create(:user, first_name: "Derek", last_name: "Sheperd #{xss_payload}", organisations: [organisation])
+        create(:user, first_name: "Derek", organisations: [organisation])
+      end
+
+      before do
+        # Skipping validation to ensure payload goes through
+        user.update_column(:last_name, "Sheperd #{xss_payload}")
       end
 
       it "prevents xss" do

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -5,6 +5,15 @@ describe Archive do
   let!(:organisation) { create(:organisation, department:) }
   let!(:user) { create(:user) }
 
+  describe "xss attempt" do
+    let(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
+    let!(:archive) { create(:archive, archiving_reason:, organisation:, user:) }
+
+    it "strips all html" do
+      expect(archive.reload.archiving_reason).to eq("\"&gt;")
+    end
+  end
+
   describe "no collision" do
     context "when the user is not archived" do
       let(:archive) { build(:archive, organisation: organisation, user: user) }

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -10,7 +10,7 @@ describe Archive do
     let!(:archive) { create(:archive, archiving_reason:, organisation:, user:) }
 
     it "strips all html" do
-      expect(archive.reload.archiving_reason).to eq("\"&gt;")
+      expect(archive.reload.archiving_reason).to eq("\">")
     end
   end
 

--- a/spec/models/csv_export_spec.rb
+++ b/spec/models/csv_export_spec.rb
@@ -25,4 +25,19 @@ describe CsvExport do
       expect(csv_export.purged_at).to be_present
     end
   end
+
+  describe "xss attempt" do
+    describe "on request_params" do
+      let(:export) do
+        build(:csv_export, request_params: { no_xss: "coucou", xss: "\"><img src=1 onerror=alert(1)>" })
+      end
+
+      it "strips all html" do
+        export.save!
+
+        expect(export.request_params["no_xss"]).to eq("coucou")
+        expect(export.request_params["xss"]).to eq("\">")
+      end
+    end
+  end
 end

--- a/spec/models/csv_export_spec.rb
+++ b/spec/models/csv_export_spec.rb
@@ -33,7 +33,11 @@ describe CsvExport do
                 no_xss: "coucou",
                 xss: "\"><img src=1 onerror=alert(1)>",
                 nested: {
-                  params: ["\"><img src=1 onerror=alert(1)>"],
+                  params: [
+                    "\"><img src=1 onerror=alert(1)>",
+                    { key: "\"><img src=1 onerror=alert(1)>" },
+                    ["\"><img src=1 onerror=alert(1)>"]
+                  ],
                   xss: "\"><img src=1 onerror=alert(1)>"
                 }
               })
@@ -44,7 +48,7 @@ describe CsvExport do
 
         expect(export.request_params["no_xss"]).to eq("coucou")
         expect(export.request_params["xss"]).to eq("\">")
-        expect(export.request_params.dig("nested", "params")).to eq(["\">"])
+        expect(export.request_params.dig("nested", "params")).to eq(["\">", { "key" => "\">" }, ["\">"]])
         expect(export.request_params.dig("nested", "xss")).to eq("\">")
       end
     end

--- a/spec/models/csv_export_spec.rb
+++ b/spec/models/csv_export_spec.rb
@@ -29,7 +29,14 @@ describe CsvExport do
   describe "xss attempt" do
     describe "on request_params" do
       let(:export) do
-        build(:csv_export, request_params: { no_xss: "coucou", xss: "\"><img src=1 onerror=alert(1)>" })
+        build(:csv_export, request_params: {
+                no_xss: "coucou",
+                xss: "\"><img src=1 onerror=alert(1)>",
+                nested: {
+                  params: ["\"><img src=1 onerror=alert(1)>"],
+                  xss: "\"><img src=1 onerror=alert(1)>"
+                }
+              })
       end
 
       it "strips all html" do
@@ -37,6 +44,8 @@ describe CsvExport do
 
         expect(export.request_params["no_xss"]).to eq("coucou")
         expect(export.request_params["xss"]).to eq("\">")
+        expect(export.request_params.dig("nested", "params")).to eq(["\">"])
+        expect(export.request_params.dig("nested", "xss")).to eq("\">")
       end
     end
   end

--- a/spec/models/messages_configuration_spec.rb
+++ b/spec/models/messages_configuration_spec.rb
@@ -2,7 +2,8 @@ describe MessagesConfiguration do
   describe "signature_lines" do
     context "xss attempt" do
       let(:messages_configuration) do
-        build(:messages_configuration, organisation: create(:organisation), signature_lines: ["\"><img src=1 onerror=alert(1)>", "coucou"])
+        build(:messages_configuration, organisation: create(:organisation),
+                                       signature_lines: ["\"><img src=1 onerror=alert(1)>", "coucou"])
       end
 
       it "strips all html tags" do

--- a/spec/models/messages_configuration_spec.rb
+++ b/spec/models/messages_configuration_spec.rb
@@ -1,4 +1,18 @@
 describe MessagesConfiguration do
+  describe "signature_lines" do
+    context "xss attempt" do
+      let(:messages_configuration) do
+        build(:messages_configuration, organisation: create(:organisation), signature_lines: ["\"><img src=1 onerror=alert(1)>", "coucou"])
+      end
+
+      it "strips all html tags" do
+        messages_configuration.save!
+        expect(messages_configuration.signature_lines.first).to eq("\">")
+        expect(messages_configuration.signature_lines.last).to eq("coucou")
+      end
+    end
+  end
+
   describe "remove_blank_array_fields validation" do
     context "some signature_lines fileds are blank" do
       let(:messages_configuration) do


### PR DESCRIPTION
Cette PR rajoute un hook global pour strip le contenu html de tout attribut string stocké en DB, évitant ainsi tout risque d'injection de code malveillant.