### PR TITLE
Fix(bug): use same validation email regexp as rdvsp

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,14 @@ class User < ApplicationRecord
     "postal" => :address
   }.freeze
   SEARCH_ATTRIBUTES = [:first_name, :last_name, :affiliation_number, :email, :phone_number].freeze
+  EMAIL_REGEXP = /\A
+    [A-Za-z0-9_%+-]     # the first letter cannot be a dot
+    [A-Za-z0-9._%+-]+   # the rest can include dots
+    @
+    [A-Za-z0-9-]+
+    (\.[A-Za-z0-9-]+)*  # subdomains
+    \.[A-Za-z]{2,}      # TLD cannot be shorter than 2 letters
+  \z/x # x = extended mode = whitespaces ignored + allow comments
 
   include Searchable
   include Notificable
@@ -61,8 +69,7 @@ class User < ApplicationRecord
 
   validates :last_name, :first_name, presence: true
   validates :title, presence: true, if: :require_title_presence
-  validates :email, allow_blank: true,
-                    format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/ }
+  validates :email, allow_blank: true, format: { with: EMAIL_REGEXP }
   validates :rdv_solidarites_user_id, :nir, :france_travail_id,
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -118,6 +118,28 @@ describe User do
       end
     end
 
+    context "wrong email format, begin with a dot" do
+      let(:user) { build(:user, email: ".abc@abc.bc") }
+
+      it "add errors" do
+        expect(user).not_to be_valid
+        expect(user.errors.details).to eq({ email: [{ error: :invalid, value: ".abc@abc.bc" }] })
+        expect(user.errors.full_messages.to_sentence)
+          .to include("Email n'est pas valide")
+      end
+    end
+
+    context "wrong email format, domain is too short" do
+      let(:user) { build(:user, email: "abc@abc.b") }
+
+      it "add errors" do
+        expect(user).not_to be_valid
+        expect(user.errors.details).to eq({ email: [{ error: :invalid, value: "abc@abc.b" }] })
+        expect(user.errors.full_messages.to_sentence)
+          .to include("Email n'est pas valide")
+      end
+    end
+
     context "almost perfect but incorrect email format" do
       let(:user) { build(:user, email: "abc@abc..fr") }
 


### PR DESCRIPTION
Il y a eu des [changements récents](https://github.com/betagouv/rdv-service-public/pull/4945) coté rdvsp sur leur regexp de validation des emails.
Je copie le code de la regexp qu'ils utilisent pour qu'on ai le même comportement des 2 coté.