### PR TITLE
bug(ft): fix encoding changes in ft apis causing jobs to fail

### DIFF
--- a/app/services/france_travail_api/create_participation.rb
+++ b/app/services/france_travail_api/create_participation.rb
@@ -26,8 +26,10 @@ module FranceTravailApi
         headers: ft_user_headers
       )
 
-      if response.success? && JSON.parse(response.body)["id"].present?
-        @participation.update_column(:france_travail_id, JSON.parse(response.body)["id"])
+      response_body = response.body.force_encoding("UTF-8")
+
+      if response.success? && JSON.parse(response_body)["id"].present?
+        @participation.update_column(:france_travail_id, JSON.parse(response_body)["id"])
       else
         handle_failure!(response)
       end
@@ -36,9 +38,10 @@ module FranceTravailApi
     end
 
     def handle_failure!(response)
+      response_body = response.body.force_encoding("UTF-8")
       fail!(
         "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Création de Participation).\n" \
-        "Status: #{response.status}\n Body: #{response.body}"
+        "Status: #{response.status}\n Body: #{response_body}"
       )
     end
 

--- a/app/services/france_travail_api/delete_participation.rb
+++ b/app/services/france_travail_api/delete_participation.rb
@@ -34,7 +34,7 @@ module FranceTravailApi
     def handle_failure!(response)
       fail!(
         "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).\n" \
-        "Status: #{response.status}\n Body: #{response.body}"
+        "Status: #{response.status}\n Body: #{response.body.force_encoding('UTF-8')}"
       )
     end
 

--- a/app/services/france_travail_api/retrieve_access_token.rb
+++ b/app/services/france_travail_api/retrieve_access_token.rb
@@ -50,14 +50,14 @@ module FranceTravailApi
       end
 
       if response.success?
-        response_body = JSON.parse(response.body)
+        response_body = JSON.parse(response.body.force_encoding("UTF-8"))
         @france_travail_access_token, @expires_in = [
           response_body["access_token"], response_body["expires_in"]
         ]
       else
         fail!(
           "la requête d'authentification à FT n'a pas pu aboutir.\n" \
-          "Status: #{response.status}\n Body: #{response.body}"
+          "Status: #{response.status}\n Body: #{response.body.force_encoding('UTF-8')}"
         )
       end
     end

--- a/app/services/france_travail_api/retrieve_user_token.rb
+++ b/app/services/france_travail_api/retrieve_user_token.rb
@@ -17,7 +17,7 @@ module FranceTravailApi
 
     def send_request!
       response = FranceTravailClient.retrieve_user_token(payload: user_payload, headers: headers)
-      @response_body = JSON.parse(response.body)
+      @response_body = JSON.parse(response.body.force_encoding("UTF-8"))
 
       if response.success? && !user_not_found?(response)
         @france_travail_user_token = @response_body["jetonUsager"]
@@ -26,7 +26,7 @@ module FranceTravailApi
       else
         fail!(
           "Erreur lors de l'appel à l'api recherche-usager FT.\n" \
-          "Status: #{response.status}\n Body: #{response.body}"
+          "Status: #{response.status}\n Body: #{response.body.force_encoding('UTF-8')}"
         )
       end
     end

--- a/app/services/france_travail_api/update_participation.rb
+++ b/app/services/france_travail_api/update_participation.rb
@@ -33,7 +33,7 @@ module FranceTravailApi
     def handle_failure!(response)
       fail!(
         "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Update de Participation).\n" \
-        "Status: #{response.status}\n Body: #{response.body}"
+        "Status: #{response.status}\n Body: #{response.body.force_encoding('UTF-8')}"
       )
     end
 


### PR DESCRIPTION
On a des erreurs de compatibilité d'encodage des réponses FT depuis quelques jours (le 12 mars). Ils ont du changer leur encodage.
Cette PR force la conversion en UTF-8 pour ne pas que l'on ai de soucis à l'avenir.

https://sentry.incubateur.net/organizations/betagouv/issues/156159/?environment=demo&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0