### PR TITLE
fix(ci): Specify chrome version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,14 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+      - name: Setup stable Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
+      # TODO: Remove this workaround that specify the Chrome version used by the CI
+      # inspired by https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
+      # once the linked issue on selenium would have been fixed
       - name: Remove image-bundled Chrome
         run: sudo apt-get purge google-chrome-stable
       - name: Setup stable Chrome


### PR DESCRIPTION
Il semble qu'il y ait eu un changement dans la dernière version du driver de chrome qui fait que la version actuelle de selenium utilisée par capybara raise des erreurs (voir issue liée [ici](https://github.com/teamcapybara/capybara/issues/2800)).

Je m'inspire d'[un des commentaires](https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953) pour spécifier dans la CI que l'on utilise l'ancienne version de chrome pour pouvoir régler l'issue, le temps qu'un patch au niveau de la gem soit released.