### PR TITLE
chore(deps): Update stringio

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,7 +576,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    stringio (3.1.2)
+    stringio (3.1.5)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)


### PR DESCRIPTION
J'ai un souci en local pour faire tourner l'appli à cause d'un conflit de version entre stringio en local et sur l'appli.
J'en profite pour directement mettre à jour la gem.