### PR TITLE
fix(xss): ensure we notify Sentry only when needed

### DIFF
--- a/app/models/concerns/sanitizeable.rb
+++ b/app/models/concerns/sanitizeable.rb
@@ -29,7 +29,12 @@ module Sanitizeable
   def sanitize_string(value)
     return value unless value.is_a?(String)
 
+    # full_sanitizer also removes some special characters
+    # so we need to remove them first otherwise
+    # we would have many false positives when comparing
+    # sanitized values with the original
     partially_sanitized_value = value.gsub("\r", "").gsub(" ", " ")
+
     sanitized_value = ActionView::Base.full_sanitizer.sanitize(partially_sanitized_value)
     fully_sanitized_value = CGI.unescapeHTML(sanitized_value)
 

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -12,6 +12,32 @@ describe Archive do
     it "strips all html" do
       expect(archive.reload.archiving_reason).to eq("\">")
     end
+
+    describe "attempt logging on sentry" do
+      subject { create(:archive, archiving_reason:, organisation:, user: other_user) }
+
+      let(:other_user) { create(:user) }
+
+      context "message is legit" do
+        let(:archiving_reason) do
+          "Suivi accompagnement\n\r\t Envoyer des offres &  d'emploi et d'entreprises pour son alternance "
+        end
+
+        it "does not log" do
+          expect(Sentry).not_to receive(:capture_message)
+          subject
+        end
+      end
+
+      context "message is not legit" do
+        let(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
+
+        it "logs on sentry" do
+          expect(Sentry).to receive(:capture_message).once
+          subject
+        end
+      end
+    end
   end
 
   describe "no collision" do


### PR DESCRIPTION
Sentry se fait flood car la sanitization enlève des éléments légitimes (sauts de ligne inutiles de window `\r`, whitespaces). 

Étant donné qu'il n'existe pas de moyens de rendre `ActionView::Base.full_sanitizer.sanitize` permissif sur ces éléments (on peut uniquement spécifier des tags autorisés, cf https://github.com/flavorjones/loofah/blob/main/lib/loofah/html5/safelist.rb, Loofah est la lib sous jacente), nous devons faire une pré-sanitization de la valeur à comparer pour s'assurer que la string une fois sanitized est réellement suspecte et mérite donc d'être envoyée sur Sentry. 

Sachant que la valeur originale peut-être un array ou une hash, je dois déplacer cette pré-sanitization au moment ou on itère réellement sur la string à changer pour y faire la comparaison à ce moment. 

La conséquence est qu'un array contenant 5 strings suspectes engendrera 5 appels au lieu d'un, mais la comparaison dans Sentry sera plus évidente. 
On perd également le nom de l'attribute affecté mais ça me semble vraiment pas grave étant donné qu'on conserve le nom de la classe et l'ID de l'objet

Fix https://sentry.incubateur.net/organizations/betagouv/issues/160822/?environment=production&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0