### PR TITLE
NewUpload(ux): preserve category selection on browser back navigation

### DIFF
--- a/app/controllers/user_list_uploads/category_selections_controller.rb
+++ b/app/controllers/user_list_uploads/category_selections_controller.rb
@@ -4,6 +4,8 @@ module UserListUploads
       @category_configurations = policy_scope(current_structure.category_configurations_sorted)
                                  .preload(:motif_category)
                                  .uniq(&:motif_category_id)
+
+      @selected_category_id = params[:category_configuration_id]
     end
   end
 end

--- a/app/javascript/controllers/radio_submit_controller.js
+++ b/app/javascript/controllers/radio_submit_controller.js
@@ -4,11 +4,19 @@ export default class extends Controller {
   static targets = ["submit", "radio"]
 
   connect() {
-    this.submitTarget.disabled = !this.#hasSelectedRadio()
+    this.toggleSubmit()
   }
 
   toggleSubmit() {
-    this.submitTarget.disabled = false
+    this.submitTarget.disabled = !this.#hasSelectedRadio()
+  }
+
+  updateUrl(event) {
+    const url = new URL(window.location)
+    url.searchParams.set("category_configuration_id", event.target.value)
+    window.history.replaceState({}, "", url)
+
+    this.toggleSubmit()
   }
 
   #hasSelectedRadio() {

--- a/app/views/user_list_uploads/category_selections/new.html.erb
+++ b/app/views/user_list_uploads/category_selections/new.html.erb
@@ -31,7 +31,11 @@
                 :category_configuration_id,
                 config.id,
                 class: "form-check-input",
-                data: { radio_submit_target: "radio", action: "change->radio-submit#toggleSubmit" }
+                checked: @selected_category_id == config.id.to_s,
+                data: {
+                  radio_submit_target: "radio",
+                  action: "change->radio-submit#updateUrl"
+                }
               ) %>
               <%= f.label "category_configuration_id_#{config.id}", config.motif_category.name, class: "form-check-label" %>
             </div>
@@ -41,7 +45,11 @@
               :category_configuration_id,
               "none",
               class: "form-check-input",
-              data: { radio_submit_target: "radio", action: "change->radio-submit#toggleSubmit" }
+              checked: @selected_category_id == "none",
+              data: {
+                radio_submit_target: "radio",
+                action: "change->radio-submit#updateUrl"
+              }
             ) %>
             <%= f.label :category_configuration_id_none, "Aucune catégorie de suivi", class: "form-check-label" %>
           </div>

--- a/app/views/user_list_uploads/user_list_uploads/new.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/new.html.erb
@@ -78,7 +78,7 @@
         <div class="d-flex justify-content-between my-5">
           <div>
             <i class="ri-arrow-left-s-line"></i>
-            <%= link_to "Revenir à l'étape précédente", new_structure_user_list_uploads_category_selection_path, class: "btn btn-link" %>
+            <%= link_to "Revenir à l'étape précédente", new_structure_user_list_uploads_category_selection_path(category_configuration_id: params[:category_configuration_id]), class: "btn btn-link" %>
           </div>
           <div>
             <%= f.submit "Charger les données usagers",


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2734
J'en ai profité également pour appliquer le même comportement au lien "Revenir à l'étape précédente" de la page d'upload du fichier.
Ainsi que ce soit avec le retour du navigateur ou le lien de retour en arrière de l'application, la catégorie sélectionnée initialement le restera et le CTA Valider la selection est activé.

https://github.com/user-attachments/assets/373d7fe6-caad-4104-b468-12498ecd901b

