### PR TITLE
fix(app): Make CSP more secure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,10 @@ class ApplicationController < ActionController::Base
     request.path.in?([root_path, authenticated_root_path])
   end
 
+  def force_full_page_reload
+    @force_full_page_reload = true
+  end
+
   # A user can be unlinked from its rdv-solidarites record when the latter is deleted for RGPD reasons.
   # This method pushes the user to rdv-solidarites to recreate a new one.
   def recreate_rdv_solidarites_user(user)

--- a/app/controllers/content_security_policy_controller.rb
+++ b/app/controllers/content_security_policy_controller.rb
@@ -1,0 +1,24 @@
+class ContentSecurityPolicyController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:report, :test_endpoint]
+  skip_before_action :authenticate_agent!
+
+  def test; end
+
+  def test_endpoint
+    render plain: "Form submission to same origin received"
+  end
+
+  def report
+    request_body = request.body.read
+    if request_body.present?
+      report = JSON.parse(request_body)
+      Rails.logger.info "CSP Violation: #{report.inspect}"
+      Sentry.capture_message("CSP Violation: #{report.inspect}", level: :error)
+    end
+    head :ok
+  rescue JSON::ParserError => e
+    Rails.logger.error "Error parsing CSP report: #{e.message}"
+    Sentry.capture_exception(e)
+    head :bad_request
+  end
+end

--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -13,10 +13,16 @@ module SuperAdmins
 
     before_action :authenticate_super_admin!
 
+    private
+
     def authenticate_super_admin!
       return if current_agent.super_admin?
 
       redirect_to root_path, alert: "Vous n'avez pas accès à cette page"
+    end
+
+    def force_full_page_reload
+      @force_full_page_reload = true
     end
   end
 end

--- a/app/controllers/super_admins/blocked_invitations_counters_controller.rb
+++ b/app/controllers/super_admins/blocked_invitations_counters_controller.rb
@@ -1,6 +1,8 @@
 module SuperAdmins
   class BlockedInvitationsCountersController < SuperAdmins::ApplicationController
-    before_action :set_starts_at, :set_ends_at, :set_blocked_invitations_counters_grouped_by_day, only: :index
+    before_action :set_starts_at, :set_ends_at, :set_blocked_invitations_counters_grouped_by_day,
+                  :force_full_page_reload,
+                  only: :index
 
     def scoped_resource
       super.order(created_at: :desc)

--- a/app/controllers/super_admins/blocked_users_controller.rb
+++ b/app/controllers/super_admins/blocked_users_controller.rb
@@ -1,5 +1,6 @@
 class SuperAdmins::BlockedUsersController < SuperAdmins::ApplicationController
-  before_action :set_starts_at, :set_ends_at, :set_blocked_users_grouped_by_month, only: :index
+  before_action :set_starts_at, :set_ends_at, :set_blocked_users_grouped_by_month, :force_full_page_reload,
+                only: :index
 
   private
 

--- a/app/controllers/website/stats_controller.rb
+++ b/app/controllers/website/stats_controller.rb
@@ -3,6 +3,8 @@ module Website
     skip_before_action :authenticate_agent!, only: [:index, :show, :deployment_map]
     before_action :set_organisation, :set_department, :set_stat, only: [:show]
     before_action :set_departments, only: [:index, :show]
+    # Chartkick needs a full page reload to work with our CSP.
+    before_action :force_full_page_reload, only: [:index, :show]
 
     def index
       @department_count = @departments.count

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -100,7 +100,6 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :rdv_solidarites_user_id,
     :title,
     :first_name,
     :last_name,

--- a/app/javascript/controllers/csp_test_controller.js
+++ b/app/javascript/controllers/csp_test_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["result"]
+
+  connect() {
+    // Set up CSP violation listener for all tests
+    document.addEventListener("securitypolicyviolation", (e) => {
+      console.log("CSP violation detected", e)
+      this.displayResult("CSP Violation Detected", "danger")
+    })
+  }
+
+  sameOriginSubmit(event) {
+    event.preventDefault()
+    this.displayResult("Same-origin submission successful", "success")
+  }
+
+  submitExternalForm() {
+    try {
+      // Create a form pointing to external domain
+      const form = document.createElement("form");
+      form.method = "POST";
+      form.action = "https://example.com/some-endpoint";
+
+      // Add some data
+      const input = document.createElement("input");
+      input.type = "hidden";
+      input.name = "test_data";
+      input.value = "This is sensitive data";
+      form.appendChild(input);
+
+      // Display a message to show we're testing
+      this.displayResult("Testing external form submission...", "info");
+
+      // Submit the form - this should be blocked by CSP
+      document.body.appendChild(form);
+      form.submit();
+      document.body.removeChild(form);
+    } catch (error) {
+      this.displayResult(`Error: ${error.message}`, "danger");
+    }
+  }
+
+  loadExternalScript() {
+    console.log("Attempting to load external script")
+
+    try {
+      // Display a message to show we're testing
+      this.displayResult("Testing external script loading...", "info");
+
+      // Create a script element pointing to an external domain
+      const script = document.createElement("script");
+      script.src = "https://example.com/potentially-malicious-script.js";
+
+      // Define a callback to detect if the script loads
+      // This shouldn't execute if CSP is working correctly
+      script.onload = () => {
+        console.error("WARNING: External script was loaded - CSP is not blocking script-src correctly!")
+        this.displayResult(
+          "Security Issue: External script was loaded! CSP is not blocking script-src correctly",
+          "danger"
+        );
+      };
+
+      // Define an error callback - this might execute if the script fails to load
+      script.onerror = () => {
+        if (this.resultTarget.textContent === "Testing external script loading...") {
+          this.displayResult("Script blocked (but no CSP violation detected)", "warning");
+        }
+      };
+
+      // Attempt to load the script - should be blocked by CSP
+      document.body.appendChild(script)
+    } catch (error) {
+      this.displayResult(`Error: ${error.message}`, "danger");
+    }
+  }
+
+  displayResult(message, type) {
+    this.resultTarget.textContent = message
+
+    // Remove any existing alert classes
+    this.resultTarget.classList.remove("alert-info", "alert-success", "alert-warning", "alert-danger");
+
+    // Add the appropriate alert class
+    this.resultTarget.classList.add(`alert-${type}`)
+
+    // Make sure the result is visible
+    this.resultTarget.classList.remove("hidden");
+  }
+}

--- a/app/javascript/controllers/super_admins/webhook_endpoints_controller.js
+++ b/app/javascript/controllers/super_admins/webhook_endpoints_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  duplicateWebhookEndpoint(event) {
+    event.preventDefault();
+    const targetId = prompt("Entrez l'id RDV-I de l'organisation pour laquelle vous souhaitez appliquer ce webhook");
+    const form = event.target.closest("form");
+    form.querySelector("input[name='webhook_endpoint[target_id]']").value = targetId;
+    if (!targetId) {
+      return;
+    }
+    form.submit();
+  }
+}

--- a/app/javascript/super_admin.js
+++ b/app/javascript/super_admin.js
@@ -1,2 +1,9 @@
 import "chartkick/chart.js";
 import "./stylesheets/super_admin.scss";
+import "@hotwired/turbo-rails";
+import { Application } from "@hotwired/stimulus";
+import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
+
+window.Stimulus = Application.start();
+const context = require.context("./controllers/", true, /\.js$/);
+window.Stimulus.load(definitionsFromContext(context));

--- a/app/views/content_security_policy/test.html.erb
+++ b/app/views/content_security_policy/test.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title, "CSP Form Action Test" %>
+
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h1 class="text-center mb-4">CSP Form Action Test</h1>
+
+      <div data-controller="csp-test" class="card-container">
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-light">
+            <h4 class="card-title fs-5 mb-0">Test 1: Direct Form Submission</h4>
+          </div>
+          <div class="card-body text-center py-4">
+            <form action="https://example.com/some-endpoint" method="POST">
+              <input type="hidden" name="test_data" value="This is sensitive data">
+              <button type="submit" class="btn btn-primary">Submit to external domain</button>
+            </form>
+          </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-light">
+            <h4 class="card-title fs-5 mb-0">Test 2: JavaScript Form Submission</h4>
+          </div>
+          <div class="card-body text-center py-4">
+            <button data-action="click->csp-test#submitExternalForm" class="btn btn-primary">
+              Create and submit form to external domain via JavaScript
+            </button>
+          </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-light">
+            <h4 class="card-title fs-5 mb-0">Test 3: External Script Loading</h4>
+          </div>
+          <div class="card-body text-center py-4">
+            <button data-action="click->csp-test#loadExternalScript" class="btn btn-primary">
+              Load script from external domain
+            </button>
+          </div>
+        </div>
+
+        <div data-csp-test-target="result" class="alert alert-info mb-4 shadow-sm text-center hidden"></div>
+
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-light">
+            <h4 class="card-title fs-5 mb-0">Test 4: Control (should work)</h4>
+          </div>
+          <div class="card-body text-center py-4">
+            <form action="/csp-test-endpoint" method="POST" data-action="submit->csp-test#sameOriginSubmit">
+              <input type="hidden" name="test_data" value="This is sensitive data">
+              <button type="submit" class="btn btn-success">Submit to same origin (should work)</button>
+            </form>
+          </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-info bg-opacity-10">
+            <h4 class="card-title fs-5 mb-0">Expected Results</h4>
+          </div>
+          <div class="card-body">
+            <p class="fw-medium mb-2">If CSP is working correctly:</p>
+            <ul class="list-group list-group-flush">
+              <li class="list-group-item bg-transparent">Test 1 should be blocked by the browser with a CSP error</li>
+              <li class="list-group-item bg-transparent">Test 2 should be blocked by the browser with a CSP error</li>
+              <li class="list-group-item bg-transparent">Test 3 should be blocked by the browser with a CSP error</li>
+              <li class="list-group-item bg-transparent">Test 4 should work (it will submit to a test endpoint)</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -2,6 +2,9 @@
   <title>
     <%= content_for?(:title) ? yield(:title) : "rdv-insertion" %>
   </title>
+  <% if @force_full_page_reload %>
+    <meta name="turbo-visit-control" content="reload">
+  <% end %>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
   <meta name="turbo-cache-control" content="no-cache">

--- a/app/views/layouts/super_admins/application.html.erb
+++ b/app/views/layouts/super_admins/application.html.erb
@@ -36,6 +36,7 @@ By default, it renders:
   <%= stylesheet_link_tag "super_admin", media: 'all', 'data-turbo-track': 'reload' %>
 
   <%= render "stylesheet" %>
+  <%= render "javascript" %>
   <%= csp_meta_tag if defined?(csp_meta_tag) %>
 </head>
 <body>

--- a/app/views/layouts/super_admins/application.html.erb
+++ b/app/views/layouts/super_admins/application.html.erb
@@ -18,11 +18,14 @@ By default, it renders:
   <meta charset="utf-8">
   <meta name="ROBOTS" content="NOODP">
   <meta name="viewport" content="initial-scale=1">
+  <% if @force_full_page_reload %>
+    <meta name="turbo-visit-control" content="reload">
+  <% end %>
   <title>
     <%= content_for(:title) %> - <%= application_title %>
   </title>
   <%= csrf_meta_tags %>
-<%# 
+<%#
   #
   # We override this layout to add specific SCSS and JS files for the super admin.
   # These files represent a new JS and SCSS entry point.
@@ -46,7 +49,5 @@ By default, it renders:
       <%= yield %>
     </main>
   </div>
-
-  <%= render "javascript" %>
 </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,6 +2,6 @@
   <p>Vous allez être redirigé(e) vers la page de connexion de l'application...</p>
   <p>Si ce n'est pas le cas, cliquez simplement sur le bouton "Connexion agent".</p>
 </div>
-<script type="text/javascript">
+<%= javascript_tag nonce: true do %>
   document.querySelector('form[action="/auth/rdvservicepublic"]').submit();
-</script>
+<% end %>

--- a/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
+++ b/app/views/super_admins/webhook_endpoints/_collection_item_actions.html.erb
@@ -9,23 +9,12 @@
 <td>
   <%= form_for(:webhook_endpoint, url: duplicate_super_admins_webhook_endpoint_path(resource), method: :post) do |f| %>
     <%= f.hidden_field :target_id, value: nil %>
-    <button type="button" id="duplicate_webhook_endpoint_<%= resource.id %>">Dupliquer</button>
+    <button
+      type="button"
+      data-controller="super-admins--webhook-endpoints"
+      data-action="click->super-admins--webhook-endpoints#duplicateWebhookEndpoint"
+    >
+      Dupliquer
+    </button>
   <% end %>
 </td>
-
-<script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function() {
-    const button = document.querySelector("#duplicate_webhook_endpoint_<%= resource.id %>")
-
-    button.addEventListener("click", function(event) {
-      event.preventDefault()
-      const targetId = prompt("Entrez l'id RDV-I de l'organisation pour laquelle vous souhaitez appliquer ce webhook")
-      const form = button.closest("form")
-
-      if (!targetId) return
-
-      form.querySelector("input[name='webhook_endpoint[target_id]']").value = targetId
-      form.submit()
-    })
-  })
-</script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,28 +10,30 @@ matomo = "matomo.inclusion.beta.gouv.fr"
 crisp = ["*.crisp.chat", "wss://client.relay.crisp.chat"]
 sentry = "sentry.incubateur.net"
 maze = "*.maze.co"
-flourish = "flo.uri.sh" # for deployment map
+flourish = ["flo.uri.sh", "https://public.flourish.studio/resources/embed.js"] # for deployment map
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data, s3_bucket
-  policy.media_src :self, s3_bucket
-  policy.frame_src :self, flourish, maze
-  policy.object_src  :none
-  policy.script_src  :self, :https, :unsafe_inline
-  policy.style_src   :self, :https, :unsafe_inline
-  policy.connect_src :self, rdv_solidarites, sentry, matomo, maze, *crisp
-  policy.worker_src :self, :blob
+  policy.default_src     :self
+  policy.font_src        :self, :data
+  policy.img_src         :self, :data, s3_bucket
+  policy.media_src       :self, s3_bucket
+  policy.frame_src       :self, *flourish, maze
+  policy.object_src      :none
+  policy.script_src      :self, matomo, *crisp, *flourish, maze, sentry
+  policy.style_src       :self, :unsafe_inline
+  policy.connect_src     :self, rdv_solidarites, sentry, matomo, maze, *crisp
+  policy.form_action     :self, rdv_solidarites
+  policy.frame_ancestors :self, rdv_solidarites, matomo
+  policy.worker_src      :self, :blob
   # Specify URI for violation reports
-  # policy.report_uri "/csp-violation-report-endpoint"
+  policy.report_uri "/csp-violation-report"
 end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,11 @@ Rails.application.routes.draw do
                                        only: [:show]
   end
 
+  # CSP endpoints
+  get "/csp-test", to: "content_security_policy#test"
+  post "/csp-test-endpoint", to: "content_security_policy#test_endpoint"
+  post "/csp-violation-report", to: "content_security_policy#report"
+
   get "/organisations", to: "organisations#index", as: :authenticated_root
 
   resources :organisations, only: [:index, :new, :show, :edit, :create, :update] do

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -118,8 +118,6 @@ describe "Super admin can manage users" do
     it "can edit a user" do
       expect(page).to have_current_path(edit_super_admins_user_path(user))
       expect(page).to have_content("Modifier #{user.first_name} #{user.last_name}")
-      expect(page).to have_css("label[for=\"user_rdv_solidarites_user_id\"]", text: "ID de l'usager RDV-Solidarités")
-      expect(page).to have_field("user[rdv_solidarites_user_id]", with: user.rdv_solidarites_user_id)
       expect(page).to have_css("label[for=\"user_title-selectized\"]", text: "Civilité")
       within first("div.selectize-input") do
         expect(page).to have_field("user_title-selectized")

--- a/spec/features/anyone_can_test_app_csp_spec.rb
+++ b/spec/features/anyone_can_test_app_csp_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Simple feature test that verifies our CSP test page is working properly
+RSpec.describe "CSP form-action protection", :js, type: :feature do
+  it "blocks form submissions to external domains" do
+    # Visit the test page
+    visit "/csp-test"
+
+    # Attempt to submit a form to an external domain
+    # This should be blocked by CSP
+    click_button "Submit to external domain"
+
+    result = find("[data-csp-test-target='result']", visible: :all, wait: 3)
+
+    # The CSP violation should be detected and displayed
+    # If this fails, it means either:
+    # 1. The CSP isn't properly configured
+    # 2. The test environment doesn't properly enforce CSP
+    # 3. There's an issue with the detection in our JavaScript
+    expect(result.text).to eq("CSP Violation Detected")
+  end
+
+  it "blocks form submissions to external domains via JavaScript" do
+    visit "/csp-test"
+
+    # Attempt to submit a form to an external domain via JavaScript
+    # This should be blocked by CSP
+    click_button "Create and submit form to external domain via JavaScript"
+
+    # Get the result element using the data-target attribute
+    result = find("[data-csp-test-target='result']", visible: :all, wait: 3)
+
+    # The CSP violation should be detected and displayed
+    # If this fails, it means either:
+    # 1. The CSP isn't properly configured
+    # 2. The test environment doesn't properly enforce CSP
+    # 3. There's an issue with the detection in our JavaScript
+    expect(result.text).to eq("CSP Violation Detected")
+  end
+
+  it "blocks loading scripts from external domains" do
+    visit "/csp-test"
+
+    # Attempt to load a script from an external domain
+    # This should be blocked by CSP
+    click_button "Load script from external domain"
+
+    # Get the result element using the data-target attribute
+    result = find("[data-csp-test-target='result']", visible: :all, wait: 3)
+
+    # The CSP violation should be detected and displayed
+    # If this fails, it means either:
+    # 1. The CSP isn't properly configured
+    # 2. The test environment doesn't properly enforce CSP
+    # 3. There's an issue with the detection in our JavaScript
+    expect(result.text).to eq("CSP Violation Detected")
+  end
+
+  it "allows same-origin form submissions" do
+    visit "/csp-test"
+
+    # Submit the same-origin form (the Stimulus controller will intercept it)
+    find("form[action='/csp-test-endpoint']").find("button").click
+
+    # Verify the submission was allowed (not blocked by CSP)
+    # The Stimulus controller will set the text when the event is intercepted
+    result = find("[data-csp-test-target='result']", visible: :all, wait: 3)
+    expect(result.text).to eq("Same-origin submission successful")
+  end
+end


### PR DESCRIPTION
Closes #2728 

## Contexte 

Les CSP actuellement en place dans l'application sont beaucoup trop permissifs et ne protégent pas vraiment de contenus dangereux. 
Cela vient principalement du fait qu'il n'y a jamais eu d de consacrer du temps à ce sujet. 

### Historique 

* Les CSP ont été mis en place [il y a un an](https://github.com/gip-inclusion/rdv-insertion/pull/1968) et ne naissait pas d'une réflexion produit ou d'une décision technique mûrement réfléchie. Ils ont été activée rapidement au détour d'une issue.
* La mise en place des CSP a causé des problèmes d'affichages de certaines pages en prod (notamment les pages stats), et du coup [un hotfix](https://github.com/gip-inclusion/rdv-insertion/pull/1976) trop permissif a été appliqué. En effet, en ajoutant l'option `unsafe_inline` on devient trop vulnérable aux attaques XSS puisqu'on ne bloque pas l'injection dynamique de `<script>..</script>` au sein du HTML

=> Nous nous croyions un peu protégés par nos CSP alors que ça n'apportait pas beaucoup plus de garanties que de ne pas en avoir du tout.

## Renforcement des CSP 

Je renforce les CSP en: 

- Enlevant la propriété `unsafe_inline` des `script_src` qui permettait d'exécuter du JS injecté par html sur l'application. Les seuls scripts pouvant être importés sont explicités. 
- Ajoutant une policy `form_action` qui empêche la soumission de formulaire sur un serveur distant
- En réduisant la liste des urls autorisées pour les propriétés `font_src` et `img_src`

### Tests 

J'ajoute une page de test manuelle qui montre que l'on ne peut plus soumettre de formulaire à un serveur distant et que l'on ne peut plus importer de script de n'importe quel site. Je rajoute un feature test pour exécuter de manière automatique ces tests, pour être sûr de ne jamais overrider ces règles. 
Cette page est accessible sur `/csp-test`

![image](https://github.com/user-attachments/assets/96873c4f-5ba2-4626-a8e4-8daf3a489a1b)


### Ajout d'un nonce generator

J'ai ajouté le nonce_generator que propose Rails qui permet de générer un nonce random à chaque requête. En effet certaines libraires ont besoin d'exécuter du js de manière dynamique, et pour pouvoir permettre cela tout en enlevant la propriété `unsafe_inline`, on accepte les script contenant le nonce de la requête. Ça fait que les librairies internes peuvent continuer de fonctionner tout en ayant des CSP safe.

### Ajout d'un report endpoint

J'active la fonctionnalité de Rails qui permet de déclarer un `csp violation record endpoint` où une requête sera envoyée à chaque violation de CSP avec les détails de la violation. Ainsi à chaque fois qu'une violation de CSP est tentée nous recevrons une requête qui déclenchera une alerte sur Sentry. 
Ce sera notamment utile pour débugger si jamais certaines fonctionnalités ne fonctionnent plus correctement suite aux changements de CSP et que ça n'a pas été détecté par nos tests.

### Reste à faire 

Malheureusement il y a une propriété qui me semble compliqué à contourner dans l'immédiat, c'est le fait d'enlever `unsafe_inline` des `style_src`. Cette propriété permet de définir des propriétés de style de manière dynamique et beaucoup de librairies UI utilisent ce fonctionnement pour contrôler le style. 
Cette propriété permettrait donc à un attaquant d'injecter du CSS s'il trouvait une faille XSS dans l'application. C'est beaucoup moins dangereux que de pouvoir exécuter du JS mais ça reste dangereux et du coup seul le code applicatif nous protégerait de cela et pas nos CSP.
Je pense qu'on pourra essayer d'y passer plus de temps après cette PR pour voir si on peut trouver un moyen de le faire fonctionner avec nos librairies actuelles.