### PR TITLE
fix(tests): Remove failing tests after csp

### DIFF
--- a/spec/features/agent_cannot_use_stored_xss_to_execute_scripts_spec.rb
+++ b/spec/features/agent_cannot_use_stored_xss_to_execute_scripts_spec.rb
@@ -411,57 +411,5 @@ describe "Agent cannot use stored XSS to execute malicious script", :js do
 
       alert.accept
     end
-
-    it "detects XSS from onmouseover events and verifies expectation behavior" do
-      visit "/"
-      # First verify no alert exists initially
-      expect { page.driver.browser.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-
-      # Create a div with onmouseover XSS and trigger it
-      page.execute_script("
-        const div = document.createElement('div');
-        div.setAttribute('onmouseover', 'alert(\"Mouseover XSS\")');
-        div.textContent = 'Hover me';
-        document.body.appendChild(div);
-        div.dispatchEvent(new MouseEvent('mouseover'));
-      ")
-
-      # Verify we can access the alert (would raise NoSuchAlertError if no alert present)
-      alert = page.driver.browser.switch_to.alert
-      expect(alert.text).to eq("Mouseover XSS")
-
-      # Verify our main test expectation fails when an alert exists
-      expect do
-        expect { page.driver.browser.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-
-      alert.accept
-    end
-
-    it "detects XSS from javascript: URLs and verifies expectation behavior" do
-      visit "/"
-      # First verify no alert exists initially
-      expect { page.driver.browser.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-
-      # Create a link with javascript: URL and click it
-      page.execute_script("
-        const link = document.createElement('a');
-        link.setAttribute('href', 'javascript:alert(\"Click XSS\")');
-        link.textContent = 'Click me';
-        document.body.appendChild(link);
-        link.click();
-      ")
-
-      # Verify we can access the alert (would raise NoSuchAlertError if no alert present)
-      alert = page.driver.browser.switch_to.alert
-      expect(alert.text).to eq("Click XSS")
-
-      # Verify our main test expectation fails when an alert exists
-      expect do
-        expect { page.driver.browser.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-
-      alert.accept
-    end
   end
 end


### PR DESCRIPTION
J'enlève deux tests rajoutés dans [ce commit](https://github.com/gip-inclusion/rdv-insertion/pull/2743/commits/e711084e72ea488f40bb9c278ff42852b6376a7a) qui n'étaient pas très intéressants: ils ne servaient qu'à tester que nos tests marchent bien dans un cas très précis. Il y en a un qui passe plus au vu des nouvelles CSP (on ne peut plus exécuter le script sur la page), donc j'ai décidé de les enlever entièrement.