### PR TITLE
fix(csp): Add crisp to style_src csp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,7 +20,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.frame_src       :self, *flourish, maze
   policy.object_src      :none
   policy.script_src      :self, matomo, *crisp, *flourish, maze, sentry
-  policy.style_src       :self, :unsafe_inline
+  policy.style_src       :self, :unsafe_inline, *crisp
   policy.connect_src     :self, rdv_solidarites, sentry, matomo, maze, *crisp
   policy.form_action     :self, rdv_solidarites
   policy.frame_ancestors :self, rdv_solidarites, matomo


### PR DESCRIPTION
Suite à #2744 on a des erreurs de violation de content security policy au moment du load des feuilles de style liés à crisp.
J'ajoute du coup crisp dans les autorisations des csp pour les `style_src`.