### PR TITLE
fix(csp): New crisp CSP addings

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,8 +14,8 @@ flourish = ["flo.uri.sh", "https://public.flourish.studio/resources/embed.js"] #
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src     :self
-  policy.font_src        :self, :data
-  policy.img_src         :self, :data, s3_bucket
+  policy.font_src        :self, :data, *crisp
+  policy.img_src         :self, :data, s3_bucket, *crisp
   policy.media_src       :self, s3_bucket
   policy.frame_src       :self, *flourish, maze
   policy.object_src      :none


### PR DESCRIPTION
Il s'avère que suite à #2749 , d'autres CSP violations ont été reporté sur les font et sur les images que crisp essaie d'importer.
J'ajoute donc crisp aux url autorisés pour ces propriétés.