### PR TITLE
feat(upload): make new import the default

### DIFF
--- a/app/javascript/controllers/full_screen_banner_controller.js
+++ b/app/javascript/controllers/full_screen_banner_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  close() {
+    this.element.remove()
+  }
+}

--- a/app/javascript/stylesheets/components/_banner.scss
+++ b/app/javascript/stylesheets/components/_banner.scss
@@ -11,3 +11,17 @@
     color: white;
   }
 }
+
+.fullscreen-banner {
+  background-color: #6363E6;
+  color: white; 
+
+  a {
+    color: white;
+
+    &:hover {
+      color: white;
+    }
+  }
+}
+

--- a/app/views/common/_fullscreen_banner.html.erb
+++ b/app/views/common/_fullscreen_banner.html.erb
@@ -1,0 +1,18 @@
+<div class="fullscreen-banner d-flex" data-controller="full-screen-banner">
+  <div class="container pt-2 pb-3 px-5">
+    <div class="d-flex justify-content-between align-items-center">
+      <div class="d-flex justify-content-between  flex-column">
+          <h5>
+            <i class="ri-information-line me-1 fs-4"></i>
+            <%= title %>
+          </h5>
+        <p class="mb-0">
+          <%= yield%>
+        </p>
+      </div>
+      <button class="btn text-white align-self-start p-0" data-action="click->full-screen-banner#close">
+          <i class="ri-close-line fs-4"></i>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_application_base.html.erb
+++ b/app/views/layouts/_application_base.html.erb
@@ -6,6 +6,7 @@
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= content_for :header %>
     <%= render 'common/flashes' %>
+    <%= content_for :fullscreen_banner %>
     <div class="wrapper">
       <%= turbo_frame_tag "remote_modal", target: "_top" %>
       <%= yield %>

--- a/app/views/layouts/user_list_upload.html.erb
+++ b/app/views/layouts/user_list_upload.html.erb
@@ -10,6 +10,7 @@
   <body data-matomo-mask class="bg-white">
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= content_for :header %>
+    <%= content_for :fullscreen_banner %>
     <%= render 'common/flashes' %>
     <div class="wrapper">
       <%= turbo_frame_tag "remote_modal", target: "_top" %>

--- a/app/views/user_list_uploads/category_selections/_fullscreen_banner.html.erb
+++ b/app/views/user_list_uploads/category_selections/_fullscreen_banner.html.erb
@@ -1,0 +1,5 @@
+<%= render "common/fullscreen_banner", title: "Bienvenue sur la nouvelle version d’import de fichier de rdv-insertion !" do %>
+  Nous l’avons conçue pour simplifier la gestion des dossiers usagers et l’envoi des invitations en masse. 
+  <%= link_to "Consulter notre tutoriel", "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion-and-faq/invitation-and-convocation/import-des-usagers-nouvelle-version", target: "_blank", class: "btn-link" %> ou 
+  <%= link_to "revenir sur l’ancienne version", new_structure_upload_path, class: "btn-link" %>.      
+<% end %>

--- a/app/views/user_list_uploads/category_selections/new.html.erb
+++ b/app/views/user_list_uploads/category_selections/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Charger un fichier usagers - #{structure_name_with_context(current_structure)} - rdv-insertion" %>
+<%= content_for :fullscreen_banner, render("fullscreen_banner") %>
 
 <div class="container p-3">
   <div class="row text-dark-blue col-md-10 mx-auto">

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -125,7 +125,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to(new_structure_upload_path, class: "dropdown-item") do %>
+          <%= link_to(new_structure_user_list_uploads_category_selection_path, class: "dropdown-item") do %>
             Charger fichier usagers
           <% end %>
         </li>

--- a/app/views/users/uploads/_fullscreen_banner.html.erb
+++ b/app/views/users/uploads/_fullscreen_banner.html.erb
@@ -1,0 +1,4 @@
+<%= render "common/fullscreen_banner", title: "Vous êtes sur l’ancienne interface de création et d’invitation des usagers." do %>
+  Cette interface vient d’être rénovée. Cette version ne sera plus disponible à partir du 01 mai 2025. Vous pouvez 
+  <%= link_to "essayer la nouvelle version.", new_structure_user_list_uploads_category_selection_path, class: "btn-link" %>
+<% end %>

--- a/app/views/users/uploads/category_selection.html.erb
+++ b/app/views/users/uploads/category_selection.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Importer des usagers - #{current_structure.name} - rdv-insertion" %>
+<% content_for :fullscreen_banner, render("fullscreen_banner") %>
 
 <div class="container mt-5">
   <div class="row mt-5 justify-content-center">


### PR DESCRIPTION
Cette PR rend le nouvel upload l'upload par défaut et ajoute 2 bannières d'information : une sur le nouvel upload et une sur l'ancienne, permettant de switcher de l'un vers l'autre. 

Pour info les liens ont un text-decoration underline (à cause de btn-link) qui ne respecte pas la maquette mais celui-ci changera au moment du DSFR et prendra automatiquement la bonne bordure par défaut, inutile donc de faire du spécifique ici.

## Nouvel upload 
<img width="1646" alt="Screenshot 2025-03-31 at 14 48 15" src="https://github.com/user-attachments/assets/0a56b76a-6610-4ee7-bad0-2d33d5c99ac6" />

## Ancien upload 
<img width="1616" alt="image" src="https://github.com/user-attachments/assets/e2233654-747e-4768-8877-4df30860a127" />
