### PR TITLE
fix(creneaux): limit creneaux relevant count to 200

### DIFF
--- a/app/jobs/creneaux/store_number_of_creneaux_available_job.rb
+++ b/app/jobs/creneaux/store_number_of_creneaux_available_job.rb
@@ -1,6 +1,6 @@
 module Creneaux
   class StoreNumberOfCreneauxAvailableJob < ApplicationJob
-    sidekiq_options retry: 5
+    sidekiq_options retry: 5, queue: "creneaux"
 
     def perform(category_configuration_id)
       category_configuration = CategoryConfiguration.joins(:motif_category, organisation: :agents)

--- a/app/services/creneaux/store_number_of_creneaux_available.rb
+++ b/app/services/creneaux/store_number_of_creneaux_available.rb
@@ -1,5 +1,7 @@
 module Creneaux
   class StoreNumberOfCreneauxAvailable < BaseService
+    MAX_RELEVANT_CRENEAUX_COUNT_LIMIT = 200
+
     attr_reader :category_configuration
 
     def initialize(category_configuration:)
@@ -25,7 +27,8 @@ module Creneaux
             motif_category_short_name: motif_category.short_name,
             organisation_ids: [organisation.rdv_solidarites_organisation_id]
           },
-          total_count: true
+          total_count: true,
+          max_relevant_creneaux_count_limit: MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
         ).creneau_availability_count
       end
     end

--- a/app/services/rdv_solidarites_api/retrieve_creneau_availability.rb
+++ b/app/services/rdv_solidarites_api/retrieve_creneau_availability.rb
@@ -1,7 +1,7 @@
 module RdvSolidaritesApi
   class RetrieveCreneauAvailability < Base
-    def initialize(link_params:, total_count: false)
-      @link_params = link_params.merge(total_count:)
+    def initialize(link_params:, total_count: false, max_relevant_creneaux_count_limit: nil)
+      @link_params = link_params.merge(total_count:, max_relevant_creneaux_count_limit:)
     end
 
     def call

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,8 @@
 :queues:
   - default
   - stats
+  - creneaux
 
 :limits:
   stats: 2
+  creneaux: 1


### PR DESCRIPTION
Cette PR déplace le calcul des créneaux dispo dans une queue creneaux, empêche la parallélisation sur ce job et rajoute une limitation à 200 pour permettre d'accélerer le calcul et d'éviter les timeout. 

À merger après le déploiement de https://github.com/betagouv/rdv-service-public/pull/5194