### PR TITLE
tech(clean/bug): clean old conjoint behavior

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
@@ -37,14 +37,6 @@ module InboundWebhooks
         # in RDV-I because we need it to keep it for the uid.
         @data.delete(:affiliation_number) if affiliation_number.blank?
 
-        # If a user is created without email in RDV-S, for the conjoint for example, we do not
-        # want the email to be nil in RDV-I or we cannot invite by email
-        # Remove this after conjoints email migration
-        if email.blank?
-          @data.delete(:email)
-          @data.delete(:notification_email)
-        end
-
         # We store the user's email in email field whether it is the devise account email or the notification email
         @data[:email] = email if email.present?
       end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_user_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_user_job_spec.rb
@@ -50,17 +50,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessUserJob do
       end
     end
 
-    context "when the email received is nil" do
-      before { data.merge!(email: nil) }
-
-      it "enqueues an upsert record job without the email" do
-        filtered_data = data.except(:email)
-        expect(UpsertRecordJob).to receive(:perform_later)
-          .with("User", filtered_data, { last_webhook_update_received_at: timestamp })
-        subject
-      end
-    end
-
     context "when notification_email is present but email is nil" do
       let!(:data) do
         {
@@ -79,27 +68,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessUserJob do
           .with("User", hash_including(email: "notification@example.com"),
                 { last_webhook_update_received_at: timestamp })
         subject
-      end
-
-      context "when both email and notification_email are nil" do
-        let!(:data) do
-          {
-            "id" => rdv_solidarites_user_id,
-            "first_name" => "John",
-            "last_name" => "Doe",
-            "phone_number" => "+33624242424",
-            "affiliation_number" => "CAUCSCUAHSC",
-            "email" => nil,
-            "notification_email" => nil
-          }.deep_symbolize_keys
-        end
-
-        it "removes email from the upsert data" do
-          filtered_data = data.except(:email, :notification_email)
-          expect(UpsertRecordJob).to receive(:perform_later)
-            .with("User", filtered_data, { last_webhook_update_received_at: timestamp })
-          subject
-        end
       end
     end
 


### PR DESCRIPTION
Suite à la mise en place des `notification_email` on avait gardé le fonctionnement qui empêchait un email d'être nullifié dans rdvi si l'email est nullifié coté rdvsp (c'était pour éviter de perdre les emails des conjoints).
J'ai rattrapé tout les emails en prod (j'ai mis à jour les `notification_email` de rdvsp avec nos emails quand les usagers n'avaient pas d'email dans rdvsp mais qu'ils en avaient un chez nous) on peut donc enlever ce mécanisme qui est inutile et pourrait poser des problèmes de cohérence dans le cas ou l'email est update à nil coté rdvsp.
