### PR TITLE
fix(upload): Change checkbox name and id

### DIFF
--- a/app/controllers/user_list_uploads/invitation_attempts_controller.rb
+++ b/app/controllers/user_list_uploads/invitation_attempts_controller.rb
@@ -34,7 +34,7 @@ module UserListUploads
     end
 
     def invitation_formats
-      [params[:email], params[:sms]].compact.map(&:downcase)
+      [params[:format_email], params[:format_sms]].compact.map(&:downcase)
     end
   end
 end

--- a/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
@@ -48,12 +48,12 @@
               <div class="d-flex justify-content-around align-items-center">
                 <div class="align-middle">Inviter la sélection par:</div>
                 <div class="form-check mx-3">
-                  <%= check_box_tag "email", "Email", checked: invitation_format_checked?("email", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "email" } %>
-                  <%= label_tag "email", "Email", class: "form-check-label" %>
+                  <%= check_box_tag "format_email", "Email", checked: invitation_format_checked?("email", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "email" } %>
+                  <%= label_tag "format_email", "Email", class: "form-check-label" %>
                 </div>
                 <div class="form-check mx-3">
-                  <%= check_box_tag "sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "sms" } %>
-                  <%= label_tag "sms", "SMS", class: "form-check-label" %>
+                  <%= check_box_tag "format_sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "sms" } %>
+                  <%= label_tag "format_sms", "SMS", class: "form-check-label" %>
                 </div>
                 <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", disabled: @number_of_user_rows_selected.zero? %>
               </div>

--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -854,10 +854,10 @@ describe "Agents can upload user list", :js do
       expect(christian_row.reload.selected_for_invitation).to be_truthy
 
       # Uncheck email format
-      expect(page).to have_css("input[type='checkbox'][name='email']:checked")
-      expect(page).to have_css("input[type='checkbox'][name='sms']:checked")
-      find("input[type='checkbox'][name='email']").click
-      expect(page).to have_css("input[type='checkbox'][name='email']:not(:checked)")
+      expect(page).to have_css("input[type='checkbox'][name='format_email']:checked")
+      expect(page).to have_css("input[type='checkbox'][name='format_sms']:checked")
+      find("input[type='checkbox'][name='format_email']").click
+      expect(page).to have_css("input[type='checkbox'][name='format_email']:not(:checked)")
 
       # it unchecks users that can't be invited by email
       expect(page).to have_content("1 usager sélectionné sur 2", wait: 20)
@@ -868,9 +868,9 @@ describe "Agents can upload user list", :js do
       expect(christian_row.reload.selected_for_invitation).to be_falsey
 
       # Uncheck sms format
-      expect(page).to have_css("input[type='checkbox'][name='sms']:checked")
-      find("input[type='checkbox'][name='sms']").click
-      expect(page).to have_css("input[type='checkbox'][name='sms']:not(:checked)")
+      expect(page).to have_css("input[type='checkbox'][name='format_sms']:checked")
+      find("input[type='checkbox'][name='format_sms']").click
+      expect(page).to have_css("input[type='checkbox'][name='format_sms']:not(:checked)")
 
       # it unchecks users that can't be invited by sms
       expect(page).to have_css("input[type='checkbox'][data-user-row-id='#{hernan_row.id}']:not(:checked)")
@@ -885,8 +885,8 @@ describe "Agents can upload user list", :js do
 
       # It keeps the formats on page refresh
       page.refresh
-      expect(page).to have_css("input[type='checkbox'][name='sms']:not(:checked)")
-      expect(page).to have_css("input[type='checkbox'][name='email']:not(:checked)")
+      expect(page).to have_css("input[type='checkbox'][name='format_sms']:not(:checked)")
+      expect(page).to have_css("input[type='checkbox'][name='format_email']:not(:checked)")
     end
 
     context "when user has already been invited" do


### PR DESCRIPTION
Je change le name et l'id de l'input pour checker le format email qui était `email` pour éviter les interférences avec des extensions chrome qui target tous les `input[name="email"]`