### PR TITLE
feat(upload): add warning when too many lines sent

### DIFF
--- a/app/javascript/controllers/user_list_upload_controller.js
+++ b/app/javascript/controllers/user_list_upload_controller.js
@@ -5,7 +5,7 @@ import { parameterizeObjectKeys, parameterizeObjectValues } from "../lib/paramet
 import { formatInput, formatAffiliationNumber, formatDateInput, formatAddress, formatRole, formatTitle, formatTags } from "../lib/inputFormatters"
 
 export default class extends Controller {
-  static targets = ["dropZone", "input", "uploadedFileInfo", "fileName", "fileInputInstruction", "userCount", "submitButton"]
+  static targets = ["dropZone", "input", "uploadedFileInfo", "fileName", "fileInputInstruction", "userCount", "submitButton", "warning"]
 
   connect() {
     this.fileConfigurationColumnAttributes = JSON.parse(this.element.dataset.fileConfigurationColumnAttributes)
@@ -195,10 +195,20 @@ export default class extends Controller {
   #setFileSelected(file) {
     this.#updateFileName(file.name)
     this.#updateUserCount(this.rows.length)
+    
+    this.#toggleTooManyLinesWarning()
     this.fileInputInstructionTarget.classList.add("d-none")
     this.uploadedFileInfoTarget.classList.remove("d-none")
     if (this.rows.length > 0) {
       this.submitButtonTarget.classList.remove("disabled")
+    }
+  }
+
+  #toggleTooManyLinesWarning() {
+    if (this.rows.length > 500) {
+      this.warningTarget.classList.remove("d-none")
+    } else {
+      this.warningTarget.classList.add("d-none")
     }
   }
 

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -1,4 +1,5 @@
 $purple: #6570C5;
+$violet: #6363E6;
 $purple-light: #9199D6;
 $very-light-grey: #F4F4F4;
 $very-dark-grey: #6F747A;

--- a/app/javascript/stylesheets/components/_banner.scss
+++ b/app/javascript/stylesheets/components/_banner.scss
@@ -13,7 +13,6 @@
 }
 
 .announcement-banner {
-  background-color: #6363E6;
   color: white; 
 
   a {

--- a/app/javascript/stylesheets/components/_color.scss
+++ b/app/javascript/stylesheets/components/_color.scss
@@ -10,6 +10,10 @@
   background-color: $warning;
 }
 
+.background-violet {
+  background-color: $violet;
+}
+
 .background-green-light {
   background-color: $green-light;
 }

--- a/app/views/user_list_uploads/category_selections/_announcement_banner.html.erb
+++ b/app/views/user_list_uploads/category_selections/_announcement_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="announcement-banner d-flex" data-controller="announcement-banner">
+<div class="announcement-banner background-violet d-flex" data-controller="announcement-banner">
   <div class="container pt-2 pb-3 px-5">
     <div class="d-flex justify-content-between align-items-center">
       <div class="d-flex justify-content-between  flex-column">

--- a/app/views/user_list_uploads/user_list_uploads/new.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/new.html.erb
@@ -59,9 +59,18 @@
               <div class="px-2">
                 <i class="ri-file-text-line ri-2x"></i>
               </div>
-              <div class="px-2">
+              <div class="px-2 text-start">
                 <p>Fichier « <span data-user-list-upload-target="fileName"></span> »</p>
                 <p class="text-start text-muted small" data-user-list-upload-target="userCount"></p>
+                <div class="d-flex text-brown position-relative d-none position-absolute" data-user-list-upload-target="warning">
+                  <div class="d-flex">
+                    <i class="ri-information-line me-1 fs-4"></i>
+                    <p class="w-50">
+                      Votre fichier contient plus de 500 lignes. Cela risque de ralentir les importations. 
+                      Nous vous conseillons de découper votre fichier et d’effectuer plusieurs imports. 
+                    </p>
+                  </div>
+                </div>
               </div>
               <div class="px-2">
                 <i class="ri-close-line ri-2x btn btn-link text-decoration-none" data-action="click->user-list-upload#handleFileRemove"></i>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -127,6 +127,9 @@
         <li>
           <%= link_to(new_structure_user_list_uploads_category_selection_path, class: "dropdown-item") do %>
             Charger fichier usagers
+            <span class="badge background-violet ms-2">
+              Nouveau
+            </span>
           <% end %>
         </li>
       </ul>

--- a/app/views/users/uploads/_announcement_banner.html.erb
+++ b/app/views/users/uploads/_announcement_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="announcement-banner d-flex" data-controller="announcement-banner">
+<div class="announcement-banner background-violet d-flex" data-controller="announcement-banner">
   <div class="container pt-2 pb-3 px-5">
     <div class="d-flex justify-content-between align-items-center">
       <div class="d-flex justify-content-between  flex-column">


### PR DESCRIPTION
Cette PR ajoute un warning à l'ajout d'un fichier lorsqu'il contient plus de 500 lignes.
J'ajoute aussi un badge précédemment oublié au clic sur le bouton Ajouter un fichier

<img width="366" alt="Screenshot 2025-04-03 at 21 09 23" src="https://github.com/user-attachments/assets/58fa4ec5-ab2a-484f-8b86-d1b98c4c7067" />
<img width="1264" alt="Screenshot 2025-04-03 at 21 03 01" src="https://github.com/user-attachments/assets/f5a8d156-c574-4274-98a0-8e676aa80127" />

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2733