### PR TITLE
NewUpload(bug): fix undefined method closed? for nil (NoMethodError)

### DIFF
--- a/app/services/user_list_upload/save_user.rb
+++ b/app/services/user_list_upload/save_user.rb
@@ -31,7 +31,7 @@ class UserListUpload::SaveUser < BaseService
   end
 
   def reopen_follow_up_if_closed
-    @follow_up.update!(closed_at: nil) if @follow_up.closed?
+    @follow_up.update!(closed_at: nil) if @follow_up&.closed?
   end
 
   def unarchive_user_if_archived

--- a/spec/services/user_list_upload/save_user_spec.rb
+++ b/spec/services/user_list_upload/save_user_spec.rb
@@ -109,6 +109,27 @@ describe UserListUpload::SaveUser, type: :service do
       end
     end
 
+    context "when no motif category is assigned" do
+      let(:user_row) do
+        instance_double(
+          "UserRow",
+          user: user,
+          referents: referents,
+          tags: tags,
+          motif_category_to_assign: nil,
+          organisation_to_assign: organisation_to_assign
+        )
+      end
+
+      it "does not create a follow up" do
+        expect { subject }.not_to change(FollowUp, :count)
+      end
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
     context "when user save fails" do
       before do
         allow(Users::Save).to receive(:call).and_return(OpenStruct.new(success?: false, errors: ["Some error"]))


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/165632/?project=16&referrer=webhooks_plugin

Suite à https://github.com/gip-inclusion/rdv-insertion/pull/2754 un bug a été introduit dans les cas ou aucune catégorie de motif n'est sélectionnée `@follow_up` n'existe pas et on obtient une erreur `NoMethodError`