### PR TITLE
fix(csp): Add flourish csp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ matomo = "matomo.inclusion.beta.gouv.fr"
 crisp = ["*.crisp.chat", "wss://client.relay.crisp.chat"]
 sentry = "sentry.incubateur.net"
 tally = "tally.so"
-flourish = ["flo.uri.sh", "https://public.flourish.studio/resources/embed.js"] # for deployment map
+flourish = ["flo.uri.sh", "public.flourish.studio"] # for deployment map
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src     :self


### PR DESCRIPTION
Nous avons encore eu des reports  de violation de csp sur la page `/deployment_map` : https://sentry.incubateur.net/organizations/betagouv/issues/165520/?environment=production&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0&utc=true

Je tente de les résoudre ici en autorisant les uri commencant par `public.flourish.studio`  sur les images et les scripts