### PR TITLE
fix(upload): Set matching user priority criterias

### DIFF
--- a/app/models/concerns/user_list_upload/user_row/matching_user.rb
+++ b/app/models/concerns/user_list_upload/user_row/matching_user.rb
@@ -10,22 +10,34 @@ module UserListUpload::UserRow::MatchingUser
   end
 
   def find_matching_user
-    find_matching_user_in_all_app || find_matching_user_in_department
+    all_app_users = potential_matching_users_in_all_app
+    department_users = potential_matching_users_in_department
+
+    find_user_by_nir(all_app_users) ||
+      find_user_by_department_internal_id(department_users) ||
+      find_user_by_email(all_app_users) ||
+      find_user_by_phone_number(all_app_users) ||
+      find_user_by_affiliation_number_and_role(department_users)
   end
 
-  def find_matching_user_in_all_app
-    potential_matching_users_in_all_app.find do |matching_user|
-      user_matches_nir?(matching_user.nir) ||
-        user_matches_phone_number?(matching_user) ||
-        user_matches_email?(matching_user)
-    end
+  def find_user_by_nir(users)
+    users.find { |user| user_matches_nir?(user.nir) }
   end
 
-  def find_matching_user_in_department
-    potential_matching_users_in_department.find do |matching_user|
-      user_matches_department_internal_id?(matching_user) ||
-        user_matches_affiliation_number_and_role?(matching_user)
-    end
+  def find_user_by_department_internal_id(users)
+    users.find { |user| user_matches_department_internal_id?(user) }
+  end
+
+  def find_user_by_email(users)
+    users.find { |user| user_matches_email?(user) }
+  end
+
+  def find_user_by_phone_number(users)
+    users.find { |user| user_matches_phone_number?(user) }
+  end
+
+  def find_user_by_affiliation_number_and_role(users)
+    users.find { |user| user_matches_affiliation_number_and_role?(user) }
   end
 
   def user_matches_nir?(matching_user_nir)

--- a/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
+++ b/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
 
     describe "matching priority order" do
       subject { user_row.save! }
+
       let(:user_row) { user_list_upload.user_rows.build(user_row_attributes) }
 
       context "when multiple matching criteria are satisfied" do


### PR DESCRIPTION
Lorsqu'on récupère un matching user sur le nouvel upload, on avait pas d'ordre de priorité sur les critères de matching.
Je répare ça ici pour que les matchings  se fassent dans cet ordre: 
- sur le NIR
- sur l'id interne
- sur l'email + prénom
- sur le téléphone + prénom
- sur le num d'allocataire/rôle