### PR TITLE
FT(api): remove safir_code condition for FT webhooks

### DIFF
--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -10,14 +10,14 @@ module Participation::FranceTravailWebhooks
       )
     end
 
-    after_commit on: :update, if: -> { eligible_for_france_travail_webhook_update? } do
+    after_commit on: :update, if: -> { france_travail_webhook_updatable? } do
       OutgoingWebhooks::FranceTravail::UpdateParticipationJob.perform_later(
         participation_id: id, timestamp: updated_at
       )
     end
 
     around_destroy lambda { |participation, block|
-      if participation.eligible_for_france_travail_webhook?
+      if france_travail_webhook_updatable?
         OutgoingWebhooks::FranceTravail::DeleteParticipationJob.perform_later(
           participation_id: id,
           france_travail_id: participation.france_travail_id,
@@ -31,16 +31,20 @@ module Participation::FranceTravailWebhooks
   end
 
   def eligible_for_france_travail_webhook?
-    organisation.france_travail? && user.birth_date? && user.nir? && france_travail_active_department?
+    eligible_organisation? && user.birth_date? && user.nir? && france_travail_active_department?
   end
 
-  def eligible_for_france_travail_webhook_update?
+  def france_travail_webhook_updatable?
     eligible_for_france_travail_webhook? && france_travail_id?
   end
 
   def france_travail_active_department?
-    # C'est une condition temporaire, les autorisations des clés d'api de France Travail sont scopés au niveau des CD
-    # le temps que FT autorise notre clé d'API au niveau national on limitera à un département pour les tests
+    # C'est une condition temporaire, nous allons activer la fonctionnalité pour un département pour tester en production
     organisation.department.number.in?(ENV.fetch("FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS", "").split(","))
+  end
+
+  def eligible_organisation?
+    # francetravail organisations are not eligible for webhooks because they already have theses rdvs in their own system
+    organisation.delegataire_rsa? || organisation.conseil_departemental?
   end
 end

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -16,18 +16,16 @@ module Participation::FranceTravailWebhooks
       )
     end
 
-    around_destroy lambda { |participation, block|
+    before_destroy do
       if france_travail_webhook_updatable?
         OutgoingWebhooks::FranceTravail::DeleteParticipationJob.perform_later(
           participation_id: id,
-          france_travail_id: participation.france_travail_id,
-          user_id: participation.user.id,
+          france_travail_id: france_travail_id,
+          user_id: user.id,
           timestamp: Time.current
         )
       end
-
-      block.call
-    }
+    end
   end
 
   def eligible_for_france_travail_webhook?

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -39,12 +39,12 @@ module Participation::FranceTravailWebhooks
   end
 
   def france_travail_active_department?
-    # C'est une condition temporaire, nous allons activer la fonctionnalité pour un département pour tester en production
+    # C'est une condition temporaire le temps de tester la fonctionnalité en production sur un département
     organisation.department.number.in?(ENV.fetch("FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS", "").split(","))
   end
 
   def eligible_organisation?
-    # francetravail organisations are not eligible for webhooks because they already have theses rdvs in their own system
+    # francetravail organisations are not eligible for webhooks, they already have theses rdvs in their own system
     organisation.delegataire_rsa? || organisation.conseil_departemental?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -57,8 +57,6 @@ class Organisation < ApplicationRecord
     name
   end
 
-  def france_travail? = safir_code?
-
   def with_parcours_access?
     organisation_type.in?(ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
   end

--- a/spec/jobs/outgoing_webhooks/france_travail/delete_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/delete_participation_job_spec.rb
@@ -1,6 +1,6 @@
 describe OutgoingWebhooks::FranceTravail::DeleteParticipationJob do
   let!(:department) { create(:department, :ft_department) }
-  let!(:organisation) { create(:organisation, safir_code: "123456", department: department) }
+  let!(:organisation) { create(:organisation, department: department) }
   let!(:now) { Time.zone.parse("21/01/2023 23:42:11") }
 
   before do
@@ -9,53 +9,73 @@ describe OutgoingWebhooks::FranceTravail::DeleteParticipationJob do
   end
 
   describe "callbacks" do
-    context "when the organisation is france_travail and user is valid" do
-      let!(:user) { create(:user, :with_valid_nir) }
-      let!(:rdv) { build(:rdv) }
+    context "when the organisation is eligible for France Travail webhooks" do
+      context "when user has a valid nir" do
+        let!(:user) { create(:user, :with_valid_nir) }
+        let!(:rdv) { build(:rdv) }
 
-      context "on deletion" do
+        context "when participation has a france_travail_id" do
+          let!(:participation) do
+            create(:participation, rdv: rdv, user: user, organisation: organisation, france_travail_id: "123456")
+          end
+
+          context "on deletion" do
+            it "notifies on deletion" do
+              participation_id = participation.id
+              france_travail_id = participation.france_travail_id
+              user_id = user.id
+              expect(described_class).to receive(:perform_later)
+                .with(
+                  participation_id: participation_id,
+                  france_travail_id: france_travail_id,
+                  user_id: user_id,
+                  timestamp: now
+                )
+              participation.destroy
+            end
+          end
+        end
+
+        context "when participation has no france_travail_id" do
+          let!(:participation) do
+            create(:participation, rdv: rdv, user: user, organisation: organisation)
+          end
+
+          context "on deletion" do
+            it "does not send webhook" do
+              expect(described_class).not_to receive(:perform_later)
+              participation.destroy
+            end
+          end
+        end
+      end
+
+      context "when user has no nir" do
+        let!(:user) { create(:user) }
+        let!(:rdv) { build(:rdv) }
         let!(:participation) do
           create(:participation, rdv: rdv, user: user, organisation: organisation, france_travail_id: "123456")
         end
 
-        it "notifies on deletion" do
-          participation_id = participation.id
-          france_travail_id = participation.france_travail_id
-          user_id = user.id
-          expect(described_class).to receive(:perform_later)
-            .with(
-              participation_id: participation_id,
-              france_travail_id: france_travail_id,
-              user_id: user_id,
-              timestamp: now
-            )
-          participation.destroy
+        context "on deletion" do
+          it "does not send webhook" do
+            expect(described_class).not_to receive(:perform_later)
+            participation.destroy
+          end
         end
       end
     end
 
-    context "when organisation is not france_travail" do
-      let!(:organisation) { create(:organisation, safir_code: nil) }
-
-      context "on deletion" do
-        let!(:participation) { create(:participation, organisation: organisation) }
-
-        it "does not send webhook on deletion" do
-          expect(described_class).not_to receive(:perform_later)
-          participation.destroy
-        end
-      end
-    end
-
-    context "when organisation is france_travail but user has no nir" do
-      let!(:user) { create(:user) }
+    context "when organisation is not eligible for France Travail webhooks" do
+      let!(:organisation) { create(:organisation, organisation_type: "siae", department: department) }
+      let!(:user) { create(:user, :with_valid_nir) }
       let!(:rdv) { build(:rdv) }
       let!(:participation) do
-        create(:participation, rdv: rdv, user: user, organisation: organisation, france_travail_id: "123456")
+        create(:participation, rdv: rdv, user: user, organisation: organisation)
       end
 
       context "on deletion" do
-        it "does not send webhook" do
+        it "does not send webhook on deletion" do
           expect(described_class).not_to receive(:perform_later)
           participation.destroy
         end

--- a/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
@@ -1,6 +1,6 @@
 describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
   let!(:department) { create(:department, :ft_department) }
-  let!(:organisation) { create(:organisation, safir_code: "123456", department: department) }
+  let!(:organisation) { create(:organisation, department: department) }
   let!(:now) { Time.zone.parse("21/01/2023 23:42:11") }
 
   before do
@@ -9,43 +9,63 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
   end
 
   describe "callbacks" do
-    context "when the organisation is france_travail and user is valid" do
+    context "when the organisation is eligible for France Travail webhooks" do
+      context "when user has a valid nir" do
+        let!(:user) { create(:user, :with_valid_nir) }
+        let!(:rdv) { build(:rdv) }
+
+        context "when participation has a france_travail_id" do
+          let!(:participation) do
+            create(:participation, rdv: rdv, user: user, organisation: organisation, france_travail_id: "12345")
+          end
+
+          context "on update" do
+            it "notifies on update" do
+              expect(described_class).to receive(:perform_later)
+                .with(
+                  participation_id: participation.id,
+                  timestamp: participation.updated_at
+                )
+              participation.save
+            end
+          end
+        end
+
+        context "when participation has no france_travail_id" do
+          let!(:participation) do
+            create(:participation, rdv: rdv, user: user, organisation: organisation)
+          end
+
+          context "on update" do
+            it "does not send webhook" do
+              expect(described_class).not_to receive(:perform_later)
+              participation.save
+            end
+          end
+        end
+      end
+
+      context "when user has no nir" do
+        let!(:user) { create(:user) }
+        let!(:rdv) { build(:rdv) }
+        let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
+
+        context "on update" do
+          it "does not send webhook" do
+            expect(described_class).not_to receive(:perform_later)
+            participation.save
+          end
+        end
+      end
+    end
+
+    context "when organisation is not eligible for France Travail webhooks" do
+      let!(:organisation) { create(:organisation, organisation_type: "autre", department: department) }
       let!(:user) { create(:user, :with_valid_nir) }
       let!(:rdv) { build(:rdv) }
-
-      context "on update" do
-        let!(:participation) do
-          create(:participation, rdv: rdv, user: user, organisation: organisation, france_travail_id: "12345")
-        end
-
-        it "notifies on update" do
-          expect(described_class).to receive(:perform_later)
-            .with(
-              participation_id: participation.id,
-              timestamp: participation.updated_at
-            )
-          participation.save
-        end
+      let!(:participation) do
+        create(:participation, rdv: rdv, user: user, organisation: organisation)
       end
-    end
-
-    context "when organisation is not france_travail" do
-      let!(:organisation) { create(:organisation, safir_code: nil) }
-
-      context "on update" do
-        let!(:participation) { create(:participation, organisation: organisation) }
-
-        it "does not send webhook" do
-          expect(described_class).not_to receive(:perform_later)
-          participation.save
-        end
-      end
-    end
-
-    context "when organisation is france_travail but user has no nir" do
-      let!(:user) { create(:user) }
-      let!(:rdv) { build(:rdv) }
-      let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
 
       context "on update" do
         it "does not send webhook" do
@@ -108,7 +128,7 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
               timestamp: timestamp
             )
           end
-        end.not_to raise_error # Le job est discard quand il y a une erreur UserNotFound
+        end.not_to raise_error
 
         assert_no_enqueued_jobs
       end

--- a/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
@@ -128,7 +128,7 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
               timestamp: timestamp
             )
           end
-        end.not_to raise_error
+        end.not_to raise_error # Le job est discard quand il y a une erreur UserNotFound
 
         assert_no_enqueued_jobs
       end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2746

Cette PR :
- Enlève la condition des code safir pour le déclenchement des webhooks FT.
- Les organisations doivent être de type `conseil_departemental` ou `delegataire_rsa` pour que les webhooks se déclenchent.

J'ai amélioré les tests et j'ai résolu un bug éventuel (dans le cas d'une suppression de participation ou l'organisation est éligible aux webhooks FT mais que la participation n'a pas de `france_travail_id`)
