### PR TITLE
NewUpload(matomo): add ids on elements for matomo tracking

### DIFF
--- a/app/javascript/controllers/user_list_upload_controller.js
+++ b/app/javascript/controllers/user_list_upload_controller.js
@@ -28,6 +28,7 @@ export default class extends Controller {
 
     const file = event.dataTransfer.files[0]
     if (file) {
+      this.dropZoneTarget.setAttribute("data-matomo-event", "rdvi_upload_select-file_drag-drop");
       await this.#processFile(file)
     }
   }
@@ -195,7 +196,7 @@ export default class extends Controller {
   #setFileSelected(file) {
     this.#updateFileName(file.name)
     this.#updateUserCount(this.rows.length)
-    
+
     this.#toggleTooManyLinesWarning()
     this.fileInputInstructionTarget.classList.add("d-none")
     this.uploadedFileInfoTarget.classList.remove("d-none")

--- a/app/views/user_list_uploads/_search_form.html.erb
+++ b/app/views/user_list_uploads/_search_form.html.erb
@@ -9,6 +9,7 @@
   <div class="position-relative">
     <%= f.search_field :search_query,
                         class: "form-control ms-2 pe-4",
+                        id: "rdvi_upload_users-data_user-search",
                         placeholder: "Rechercher un usager",
                         value: params[:search_query],
                         data: {

--- a/app/views/user_list_uploads/category_selections/new.html.erb
+++ b/app/views/user_list_uploads/category_selections/new.html.erb
@@ -5,7 +5,7 @@
   <div class="row text-dark-blue col-md-10 mx-auto">
     <div class="d-flex justify-content-between align-items-center my-1">
       <div>
-        <%= link_to structure_users_path, class: "text-dark-blue fw-bold" do %>
+        <%= link_to structure_users_path, class: "text-dark-blue fw-bold", id: "rdvi_upload_select-category_back" do %>
           <i class="ri-arrow-left-s-line"></i><span> Retour</span>
         <% end %>
       </div>
@@ -48,7 +48,7 @@
           </div>
         </div>
         <div class="text-end mt-5 me-5">
-          <%= f.submit "Valider la sélection", name: nil, class: "btn btn-primary", data: { radio_submit_target: "submit" } %>
+          <%= f.submit "Valider la sélection", name: nil, class: "btn btn-primary", id: "rdvi_upload_select-category_validate", data: { radio_submit_target: "submit" } %>
         </div>
       </div>
     <% end %>

--- a/app/views/user_list_uploads/invitation_attempts/_all_invitations_sent_status.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_all_invitations_sent_status.html.erb
@@ -4,11 +4,11 @@
   <h2 class="h2-title">Invitations envoyées.</h2>
   <% if params[:search_query].blank? %>
     <% if user_rows_with_invitation_errors.empty? %>
-      <div class="flash-expanded">
+      <div class="flash-expanded" id="rdvi_upload_users-invit_success-alert">
         <%= render "common/flash_banner", type: :success, description: "Toutes les invitations ont été envoyées." %>
       </div>
     <% else %>
-      <div class="flash-expanded">
+      <div class="flash-expanded" id="rdvi_upload_users-invit_warning-alert">
         <%= render(
           "common/flash_banner",
           type: :alert,

--- a/app/views/user_list_uploads/invitation_attempts/_user_row_after_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_row_after_invitation.html.erb
@@ -9,7 +9,7 @@
     <div class="d-flex justify-content-between align-items-center">
       <% if user_row.all_invitations_failed? %>
         <%= link_to new_user_list_upload_user_row_invitation_attempts_retry_path(user_list_upload_id: user_row.user_list_upload.id, user_row_id: user_row.id), data: { turbo_frame: "remote_modal" } do %>
-          <span class="badge rounded-pill alert-danger" <%= tooltip_for_invitation_errors(user_row) %>>
+          <span class="badge rounded-pill alert-danger" id="rdvi_upload_users-invit_statut-<%= user_row.id %>-tag-error" <%= tooltip_for_invitation_errors(user_row) %>>
             Erreur
             <i class="ri-alert-line text-end"></i>
           </span>

--- a/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
@@ -2,6 +2,7 @@
   <td class="border-light">
     <input type="checkbox"
             class="form-check-input user-checkbox"
+            id="rdvi_upload_users-invit_user-<%= user_row.id %>-select"
             data-select-user-rows-target="checkbox"
             data-action="click->select-user-rows#toggleSelect"
             data-user-email="<%= user_row.user.email %>"
@@ -35,6 +36,7 @@
       data-motif-category-id="<%= @user_list_upload.motif_category_id %>"
   >
       <button type="submit"
+              id="rdvi_upload_users-invit_user-<%= user_row.id %>-download"
               data-action="click->invitation-button#generatePostalInvitation">
         <i class="ri-download-line"></i>
       </button>

--- a/app/views/user_list_uploads/invitation_attempts/_user_rows_after_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_rows_after_invitation.html.erb
@@ -4,17 +4,17 @@
       <tr>
         <th scope="col">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_last-name_sort" role="button"></i>
         </th>
         <th scope="col">Numéro CAF</th>
         <th scope="col">Téléphone</th>
         <th scope="col">Email</th>
         <th scope="col">Code postal</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="after_invitation_status">
-          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
+          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_statut-sort" role="button"></i>
         </th>
       </tr>
     </thead>

--- a/app/views/user_list_uploads/invitation_attempts/_user_rows_after_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_rows_after_invitation.html.erb
@@ -4,17 +4,17 @@
       <tr>
         <th scope="col">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
         </th>
         <th scope="col">Numéro CAF</th>
         <th scope="col">Téléphone</th>
         <th scope="col">Email</th>
         <th scope="col">Code postal</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="after_invitation_status">
-          Statut des invitations <i class="ri-arrow-up-down-line" role="button"></i>
+          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
         </th>
       </tr>
     </thead>

--- a/app/views/user_list_uploads/invitation_attempts/_user_rows_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_rows_before_invitation.html.erb
@@ -6,22 +6,23 @@
           <input
             type="checkbox"
             class="form-check-input"
+            id="rdvi_upload_users-invit_all-select"
             data-action="click->select-user-rows#toggleAll"
             <%= "checked" if checkbox_to_select_all_checked?("selected_for_invitation", @user_list_upload.id) %>
           >
         </th>
         <th scope="col" class="border-light">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
         </th>
         <th scope="col" class="border-light">Numéro CAF</th>
         <th scope="col" class="border-light">Téléphone</th>
         <th scope="col" class="border-light">Email</th>
         <th scope="col" class="border-light" data-action="click->sort-list#changeUrlParams" data-sort-by="before_invitation_status">
-          Statut des invitations <i class="ri-arrow-up-down-line" role="button"></i>
+          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
         </th>
         <th scope="col" class="border-light">Courrier</th>
       </tr>

--- a/app/views/user_list_uploads/invitation_attempts/_user_rows_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_rows_before_invitation.html.erb
@@ -13,16 +13,16 @@
         </th>
         <th scope="col" class="border-light">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_last-name_sort" role="button"></i>
         </th>
         <th scope="col" class="border-light">Numéro CAF</th>
         <th scope="col" class="border-light">Téléphone</th>
         <th scope="col" class="border-light">Email</th>
         <th scope="col" class="border-light" data-action="click->sort-list#changeUrlParams" data-sort-by="before_invitation_status">
-          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
+          Statut des invitations <i class="ri-arrow-up-down-line" id="rdvi_upload_users-invit_statut-sort" role="button"></i>
         </th>
         <th scope="col" class="border-light">Courrier</th>
       </tr>

--- a/app/views/user_list_uploads/invitation_attempts/index.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/index.html.erb
@@ -22,13 +22,13 @@
         <div class="d-flex border-bottom align-items-center">
           <ul class="nav nav-tabs flex-grow-1 border-bottom-0 align-self-end">
             <li class="nav-item">
-              <%= link_to user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'text-light-blue' : 'active text-dark-blue fw-bold' }", data: { turbo_frame: "user_collection" } do %>
+              <%= link_to user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'text-light-blue' : 'active text-dark-blue fw-bold' }", id: "rdvi_upload_users-invit_all-folder",data: { turbo_frame: "user_collection" } do %>
                 Tous les dossiers
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows.count, active: !rows_with_errors? %>
               <% end %>
             </li>
             <li class="nav-item">
-              <%= link_to user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id, rows_with_errors: true, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'active text-dark-blue fw-bold' : 'text-light-blue' }", data: { turbo_frame: "user_collection" } do %>
+              <%= link_to user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id, rows_with_errors: true, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'active text-dark-blue fw-bold' : 'text-light-blue' }", id: "rdvi_upload_users-invit_folder-error", data: { turbo_frame: "user_collection" } do %>
                 Dossiers avec erreurs
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows_with_invitation_errors.count, active: rows_with_errors? %>
               <% end %>

--- a/app/views/user_list_uploads/invitation_attempts/index.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/index.html.erb
@@ -54,7 +54,7 @@
           </div>
           <div>
             <% if @all_invitations_attempted %>
-              <%= link_to "Terminer", @user_list_upload.structure_users_path, class: "btn btn-primary d-block mx-auto", data: { turbo_frame: "_top", controller: "tally", "tally-form-id": ENV["TALLY_NEW_UPLOAD_FORM_ID"], "tally-delay-in-ms": 1000, action: "click->tally#showPopup" } %>
+              <%= link_to "Terminer", @user_list_upload.structure_users_path, class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_end", data: { turbo_frame: "_top", controller: "tally", "tally-form-id": ENV["TALLY_NEW_UPLOAD_FORM_ID"], "tally-delay-in-ms": 1000, action: "click->tally#showPopup" } %>
             <% else %>
               <%= link_to "Terminer", "#", class: "btn btn-primary d-block mx-auto disabled" %>
             <% end %>

--- a/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
@@ -48,14 +48,14 @@
               <div class="d-flex justify-content-around align-items-center">
                 <div class="align-middle">Inviter la sélection par:</div>
                 <div class="form-check mx-3">
-                  <%= check_box_tag "format_email", "Email", checked: invitation_format_checked?("email", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "email" } %>
+                  <%= check_box_tag "format_email", "Email", checked: invitation_format_checked?("email", @user_list_upload.id), class: "form-check-input text-dark-blue", id: "rdvi_upload_users-invit_email-option", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "email" } %>
                   <%= label_tag "format_email", "Email", class: "form-check-label" %>
                 </div>
                 <div class="form-check mx-3">
-                  <%= check_box_tag "format_sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "sms" } %>
+                  <%= check_box_tag "format_sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", id: "rdvi_upload_users-invit_SMS-option", data: { select_user_rows_target: "invitationFormatOption", action: "change->select-user-rows#handleFormatOptionChange", format: "sms" } %>
                   <%= label_tag "format_sms", "SMS", class: "form-check-label" %>
                 </div>
-                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", disabled: @number_of_user_rows_selected.zero? %>
+                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_send-invit", disabled: @number_of_user_rows_selected.zero? %>
               </div>
             <% end %>
           </div>

--- a/app/views/user_list_uploads/user_list_uploads/_enrich_with_cnaf_button.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_enrich_with_cnaf_button.html.erb
@@ -8,7 +8,7 @@
     },
     accept: ".csv, .txt"
   %>
-  <%= label_tag :enrich_with_cnaf_data_file_input, "Enrichir avec les données CNAF", class: "btn btn-blue-out mb-2" %>
+  <%= label_tag :enrich_with_cnaf_data_file_input, "Enrichir avec les données CNAF", class: "btn btn-blue-out mb-2", id: "rdvi_upload_users-data_data-complete" %>
 
   <%= form_with(url: user_list_upload_enrich_with_cnaf_data_path(user_list_upload_id: @user_list_upload.id), local: true, data: { enrich_with_cnaf_file_target: "form", target: "_top" }) do |f| %>
     <%= f.hidden_field :rows_cnaf_data %>

--- a/app/views/user_list_uploads/user_list_uploads/_user_row.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_row.html.erb
@@ -2,6 +2,7 @@
   <td>
     <input type="checkbox"
            class="form-check-input user-checkbox"
+           id="rdvi_upload_users-data_user-<%= user_row.id %>-select"
            data-select-user-rows-target="checkbox"
            data-action="click->select-user-rows#toggleSelect"
            data-user-row-id="<%= user_row.id %>"

--- a/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <% if user_row.matching_user_accessible? %>
-          <%= link_to @user_list_upload.structure_user_path(user_row.matching_user_id), target: "_blank", class: "text-dark-blue" do %>
+          <%= link_to @user_list_upload.structure_user_path(user_row.matching_user_id), target: "_blank", class: "text-dark-blue", id: "rdvi_upload_users-data_open-folder-user" do %>
             <span class="text-underline">Ouvrir le dossier usager</span> <i class="ri-external-link-line"></i>
           <% end %>
         <% end %>

--- a/app/views/user_list_uploads/user_list_uploads/_user_rows.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_rows.html.erb
@@ -11,22 +11,23 @@
           <input
             type="checkbox"
             class="form-check-input"
+            id="rdvi_upload_users-data_all-select"
             data-action="click->select-user-rows#toggleAll"
             <%= "checked" if checkbox_to_select_all_checked?("selected_for_user_save", @user_list_upload.id) %>
           >
         </th>
         <th scope="col">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
         </th>
         <th scope="col">Numéro CAF</th>
         <th scope="col">Téléphone</th>
         <th scope="col">Email</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="before_user_save_status">
-          Statut du dossier <i class="ri-arrow-up-down-line" role="button"></i>
+          Statut du dossier <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
         </th>
         <th scope="col"></th>
       </tr>

--- a/app/views/user_list_uploads/user_list_uploads/new.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/new.html.erb
@@ -48,7 +48,7 @@
             <p class="mb-0">Glisser/déposer votre fichier ici</p>
             <p class="text-muted small">OU</p>
             <div class="mt-2">
-              <label for="user_list_upload_file" class="btn btn-primary">
+              <label for="user_list_upload_file" class="btn btn-primary" id="rdvi_upload_select-file_file-choice">
                 Charger un fichier
               </label>
             </div>
@@ -66,18 +66,18 @@
                   <div class="d-flex">
                     <i class="ri-information-line me-1 fs-4"></i>
                     <p class="w-50">
-                      Votre fichier contient plus de 500 lignes. Cela risque de ralentir les importations. 
-                      Nous vous conseillons de découper votre fichier et d’effectuer plusieurs imports. 
+                      Votre fichier contient plus de 500 lignes. Cela risque de ralentir les importations.
+                      Nous vous conseillons de découper votre fichier et d’effectuer plusieurs imports.
                     </p>
                   </div>
                 </div>
               </div>
               <div class="px-2">
-                <i class="ri-close-line ri-2x btn btn-link text-decoration-none" data-action="click->user-list-upload#handleFileRemove"></i>
+                <i class="ri-close-line ri-2x btn btn-link text-decoration-none" data-action="click->user-list-upload#handleFileRemove" id="rdvi_upload_select-file_delete"></i>
               </div>
             </div>
             <div>
-              <label for="user_list_upload_file" class="btn btn-link p-0 text-decoration-underline">
+              <label for="user_list_upload_file" class="btn btn-link p-0 text-decoration-underline" id="rdvi_upload_select-file_change-file">
                 Changer de fichier
               </label>
             </div>
@@ -87,11 +87,12 @@
         <div class="d-flex justify-content-between my-5">
           <div>
             <i class="ri-arrow-left-s-line"></i>
-            <%= link_to "Revenir à l'étape précédente", new_structure_user_list_uploads_category_selection_path, class: "btn btn-link" %>
+            <%= link_to "Revenir à l'étape précédente", new_structure_user_list_uploads_category_selection_path, class: "btn btn-link", id: "rdvi_upload_select-file_back" %>
           </div>
           <div>
             <%= f.submit "Charger les données usagers",
                         class: "btn btn-primary d-block mx-auto disabled",
+                        id: "rdvi_upload_select-file_validate",
                         data: {
                           action: "click->user-list-upload#handleSubmit",
                           user_list_upload_target: "submitButton"

--- a/app/views/user_list_uploads/user_list_uploads/show.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/show.html.erb
@@ -39,6 +39,7 @@
                     search_query: params[:search_query]
                   ),
                   class: "nav-link #{rows_with_errors? ? 'text-light-blue' : 'active text-dark-blue fw-bold' }",
+                  id: "rdvi_upload_users-data_all-data-user",
                   data: { turbo_frame: "user_collection" } do %>
                 Tous les usagers chargés
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows.count, active: !rows_with_errors? %>
@@ -51,6 +52,7 @@
                     search_query: params[:search_query]
                   ),
                   class: "nav-link #{rows_with_errors? ? 'active text-dark-blue fw-bold' : 'text-light-blue' }",
+                  id: "rdvi_upload_users-data_data-user-error",
                   data: { turbo_frame: "user_collection" } do %>
                 Usagers avec erreurs
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows_with_errors.count, active: rows_with_errors? %>
@@ -80,7 +82,7 @@
                 data: { controller: "confirmation-modal" }
               ) do
             %>
-              <button class="btn btn-link" data-action="click->confirmation-modal#show">Revenir à l'étape précédente</button>
+              <button class="btn btn-link" id="rdvi_upload_users-data_return" data-action="click->confirmation-modal#show">Revenir à l'étape précédente</button>
               <%= render "back_to_file_upload_warning_modal" %>
             <% end %>
           </div>
@@ -97,7 +99,7 @@
             <%= form_tag create_many_user_list_upload_user_save_attempts_path(user_list_upload_id: @user_list_upload.id),
                   method: :post,
                   data: { turbo: false } do %>
-              <%= submit_tag "Créer et mettre à jour les dossiers", class: "btn btn-primary d-block mx-auto", disabled: @number_of_user_rows_selected.zero? %>
+              <%= submit_tag "Créer et mettre à jour les dossiers", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-data_create-folder", disabled: @number_of_user_rows_selected.zero? %>
             <% end %>
           </div>
         </div>

--- a/app/views/user_list_uploads/user_save_attempts/_all_saves_attempted_status.html.erb
+++ b/app/views/user_list_uploads/user_save_attempts/_all_saves_attempted_status.html.erb
@@ -4,11 +4,11 @@
   <h2 class="h2-title">Création et mise à jour des dossiers terminées.</h2>
   <% if params[:search_query].blank? %>
     <% if user_rows_with_user_save_errors.empty? %>
-      <div class="flash-expanded">
+      <div class="flash-expanded" id="rdvi_upload_users-data_success-alert">
         <%= render "common/flash_banner", type: :success, description: "Tous les dossiers ont été créés ou mis à jour." %>
       </div>
     <% else %>
-      <div class="flash-expanded">
+      <div class="flash-expanded" id="rdvi_upload_users-data_warning-alert">
         <%= render(
           "common/flash_banner",
           type: :alert,

--- a/app/views/user_list_uploads/user_save_attempts/_user_row.html.erb
+++ b/app/views/user_list_uploads/user_save_attempts/_user_row.html.erb
@@ -26,6 +26,7 @@
       <% if user_row.no_organisation_to_assign? %>
         <%= link_to(new_user_list_upload_user_row_organisation_assignation_path(user_list_upload_id: @user_list_upload.id, user_row_id: user_row.id),
                     class: "badge rounded-pill alert-warning #{'link-disabled' unless @all_saves_attempted}",
+                    id: "rdvi_upload_users-date_select-orga",
                     data: { turbo_frame: "remote_modal" }
         ) do %>
           Assigner une organisation

--- a/app/views/user_list_uploads/user_save_attempts/_user_rows.html.erb
+++ b/app/views/user_list_uploads/user_save_attempts/_user_rows.html.erb
@@ -4,17 +4,17 @@
       <tr>
         <th scope="col">Civilité</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
-          Prénom <i class="ri-arrow-up-down-line" role="button"></i>
+          Prénom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
         </th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
-          Nom <i class="ri-arrow-up-down-line" role="button"></i>
+          Nom <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
         </th>
         <th scope="col">Numéro CAF</th>
         <th scope="col">Téléphone</th>
         <th scope="col">Email</th>
         <th scope="col">Code postal</th>
         <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="after_user_save_status">
-          Statut du dossier <i class="ri-arrow-up-down-line" role="button"></i>
+          Statut du dossier <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_folder-statut_sort" role="button"></i>
         </th>
       </tr>
     </thead>

--- a/app/views/user_list_uploads/user_save_attempts/index.html.erb
+++ b/app/views/user_list_uploads/user_save_attempts/index.html.erb
@@ -26,13 +26,13 @@
         <div class="d-flex border-bottom align-items-center">
           <ul class="nav nav-tabs flex-grow-1 border-bottom-0 align-self-end">
             <li class="nav-item">
-              <%= link_to user_list_upload_user_save_attempts_path(user_list_upload_id: @user_list_upload.id, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'text-light-blue' : 'active text-dark-blue fw-bold' }", data: { turbo_frame: "user_collection" } do %>
+              <%= link_to user_list_upload_user_save_attempts_path(user_list_upload_id: @user_list_upload.id, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'text-light-blue' : 'active text-dark-blue fw-bold' }", id: "rdvi_upload_users-data_all-folder", data: { turbo_frame: "user_collection" } do %>
                 Tous les dossiers
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows.count, active: !rows_with_errors? %>
               <% end %>
             </li>
             <li class="nav-item">
-              <%= link_to user_list_upload_user_save_attempts_path(user_list_upload_id: @user_list_upload.id, rows_with_errors: true, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'active text-dark-blue fw-bold' : 'text-light-blue' }", data: { turbo_frame: "user_collection" } do %>
+              <%= link_to user_list_upload_user_save_attempts_path(user_list_upload_id: @user_list_upload.id, rows_with_errors: true, search_query: params[:search_query]), class: "nav-link #{rows_with_errors? ? 'active text-dark-blue fw-bold' : 'text-light-blue' }", id: "rdvi_upload_users-data_folder-error", data: { turbo_frame: "user_collection" } do %>
                 Dossiers avec erreurs
                 <%= render "user_list_uploads/user_count_badge", user_count: @user_rows_with_user_save_errors.count, active: rows_with_errors? %>
               <% end %>
@@ -57,10 +57,11 @@
           <div>
             <%=
               link_to(
-                "Terminer et revenir à l'accueil", 
-                @user_list_upload.structure_users_path, 
-                class: "btn btn-blue-out #{'link-disabled' unless @all_saves_attempted}", 
-                data: { 
+                "Terminer et revenir à l'accueil",
+                @user_list_upload.structure_users_path,
+                class: "btn btn-blue-out #{'link-disabled' unless @all_saves_attempted}",
+                id: "rdvi_upload_users-data_end-course",
+                data: {
                   turbo_frame: "_top",
                   controller: "tally",
                   "tally-form-id": ENV["TALLY_NEW_UPLOAD_FORM_ID"],
@@ -73,7 +74,7 @@
           <div class="ms-3">
             <% if @user_list_upload.invitations_enabled? %>
               <% if @all_saves_attempted && @user_rows_with_user_save_errors.count != @user_rows.count %>
-                <%= link_to @user_rows_with_user_save_errors.any? ? "Ignorer et passer aux invitations" : "Passer aux invitations", select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id), class: "btn btn-primary d-block mx-auto", data: { turbo_frame: "_top" } %>
+                <%= link_to @user_rows_with_user_save_errors.any? ? "Ignorer et passer aux invitations" : "Passer aux invitations", select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: @user_list_upload.id), class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-data_pass-invit", data: { turbo_frame: "_top" } %>
               <% else %>
                 <%= link_to "Passer aux invitations", "#", class: "btn btn-primary d-block mx-auto disabled" %>
               <% end %>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -4,11 +4,11 @@
   <thead class="text-dark-blue" data-controller="sort-list">
     <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
       Nom
-      <i class="ri-arrow-up-down-line" role="button"></i>
+      <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
     </th>
     <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
       Prénom
-      <i class="ri-arrow-up-down-line" role="button"></i>
+      <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
     </th>
     <th scope="col">Date de création</th>
     <% @all_configurations.each do |category_configuration| %>
@@ -41,8 +41,8 @@
           <% end %>
         <% end %>
         <td class="padding-left-15">
-          <%= link_to structure_user_path(user.id) do %>
-            <button class="btn btn-blue">Gérer</button>
+          <%= link_to structure_user_path(user.id), class: "btn btn-blue" do %>
+            Gérer
           <% end %>
         </td>
       </tr>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -4,11 +4,11 @@
   <thead class="text-dark-blue" data-controller="sort-list">
     <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="last_name">
       Nom
-      <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_last-name_sort" role="button"></i>
+      <i class="ri-arrow-up-down-line" role="button"></i>
     </th>
     <th scope="col" data-action="click->sort-list#changeUrlParams" data-sort-by="first_name">
       Prénom
-      <i class="ri-arrow-up-down-line" id="rdvi_upload_users-data_first-name_sort" role="button"></i>
+      <i class="ri-arrow-up-down-line" role="button"></i>
     </th>
     <th scope="col">Date de création</th>
     <% @all_configurations.each do |category_configuration| %>


### PR DESCRIPTION
https://github.com/gip-inclusion/rdv-insertion/issues/2710

Je propose dans cette PR la mise en place des ids sur le parcours du nouvel upload.
Matomo est actuellement assez peu utilisé et pas vraiment paramétré pour un tracking précis des éléments.
Avant d'ajouter plus d'id dans l'application, je pense qu'il est préférable d'itérer sur ce sujet en fonction des premiers retours de la configuration Matomo. Les ids mis en place sur le nouvel upload dans cette PR vont nous permettre de nous faire la main sur ce sujet.