### PR TITLE
fix(upload): Refactor follow up assignement in upload

### DIFF
--- a/app/helpers/user_list_upload/user_list_upload_helper.rb
+++ b/app/helpers/user_list_upload/user_list_upload_helper.rb
@@ -103,7 +103,7 @@ module UserListUpload::UserListUploadHelper
   def tooltip_content_for_user_row(user_row)
     tooltip_content_array = []
     tooltip_content_array << tooltip_content_for_user_row_archived(user_row) if user_row.archived?
-    tooltip_content_array << tooltip_content_for_user_row_follow_up_closed if user_row.matching_follow_up_closed?
+    tooltip_content_array << tooltip_content_for_user_row_follow_up_closed if user_row.matching_user_follow_up_closed?
     if tooltip_content_array.empty?
       tooltip_content_array << if user_row.matching_user_id
                                  "Ce dossier existe déjà. Si coché, les données seront mises à jour"

--- a/app/models/user_list_upload/collection.rb
+++ b/app/models/user_list_upload/collection.rb
@@ -49,7 +49,7 @@ class UserListUpload::Collection
   end
 
   def user_rows_with_closed_follow_up
-    user_rows.select(&:matching_follow_up_closed?)
+    user_rows.select(&:matching_user_follow_up_closed?)
   end
 
   def user_rows_selected_for_user_save

--- a/app/models/user_list_upload/user_row.rb
+++ b/app/models/user_list_upload/user_row.rb
@@ -128,15 +128,15 @@ class UserListUpload::UserRow < ApplicationRecord
     archives.map(&:archiving_reason)
   end
 
-  def matching_follow_up
+  def matching_user_follow_up
     return unless matching_user_id
     return unless motif_category_to_assign
 
     matching_user.follow_ups.find { |follow_up| follow_up.motif_category_id == motif_category_to_assign.id }
   end
 
-  def matching_follow_up_closed?
-    matching_follow_up&.closed?
+  def matching_user_follow_up_closed?
+    matching_user_follow_up&.closed?
   end
 
   def referent_to_assign
@@ -308,7 +308,7 @@ class UserListUpload::UserRow < ApplicationRecord
   end
 
   def selected_by_default_for_user_save?
-    user_valid? && !archived? && !matching_follow_up_closed?
+    user_valid? && !archived? && !matching_user_follow_up_closed?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/user_list_upload/save_user.rb
+++ b/app/services/user_list_upload/save_user.rb
@@ -8,10 +8,10 @@ class UserListUpload::SaveUser < BaseService
       assign_resources_to_user
       @organisation_to_assign = @user_row.organisation_to_assign || retrieve_organisation_to_assign!
       save_user!
-      reopen_follow_up_if_closed
-      unarchive_user_if_archived
       result.user = saved_user
     end
+    reopen_follow_up_if_closed
+    unarchive_user_if_archived
   end
 
   private
@@ -23,15 +23,15 @@ class UserListUpload::SaveUser < BaseService
   def assign_resources_to_user
     user.referents = @user_row.referents
     user.tags = @user_row.tags
-    find_or_create_follow_up if @user_row.motif_category_to_assign
-  end
-
-  def find_or_create_follow_up
-    @follow_up = FollowUp.find_or_create_by!(user: user, motif_category: @user_row.motif_category_to_assign)
+    user.assign_motif_category(@user_row.motif_category_to_assign.id) if @user_row.motif_category_to_assign
   end
 
   def reopen_follow_up_if_closed
-    @follow_up.update!(closed_at: nil) if @follow_up&.closed?
+    follow_up.update!(closed_at: nil) if follow_up&.closed?
+  end
+
+  def follow_up
+    user.follow_up_for(@user_row.motif_category_to_assign) if @user_row.motif_category_to_assign
   end
 
   def unarchive_user_if_archived

--- a/spec/services/user_list_upload/save_user_spec.rb
+++ b/spec/services/user_list_upload/save_user_spec.rb
@@ -31,11 +31,11 @@ describe UserListUpload::SaveUser, type: :service do
     it("is a success") { is_a_success }
 
     it "assigns resources to the user" do
+      expect(user).to receive(:assign_motif_category).with(motif_category.id)
       subject
 
       expect(user.referents).to eq(referents)
       expect(user.tags).to eq(tags)
-      expect(user.motif_categories).to include(motif_category)
     end
 
     context "when organisation is provided in user_row" do


### PR DESCRIPTION
## Explications 

Suite à #2754 , on a changé la façon dont on créait le suivi dans le service `UserListUpload::SaveUser` en utilisant `FollowUp.find_or_create_by!`. Seulement cette ligne était appelée avant la sauvegarde de l'usager (au sein du service `Users::Save`).  Cela avait pour conséquence de sauvegarder le record `user` lorsque celui-ci n'était pas persisté avant l'appel au service en charge de sauvegarder ce record.
Du coup pour changer cela:
- Je réutilise la méthode `user#assign_motif_category` qui permet de build un `follow_up` qui va être persisté en même temps l'usager

## Changements annexes

J'en profite pour: 
- enlever les méthodes `reopen_follow_up_if_closed` et `unarchive_user_if_archived` de la transaction car cela ne devrait empêcher la sauvegarde l'usager.
- renommer les méthodes lié au `follow_up` du `matching_user` dans le model `user_row` pour plus de clarté (https://github.com/gip-inclusion/rdv-insertion/commit/2fd890a7cd94e511dfba9ec21522922f6589904c)