### PR TITLE
fix(upload): Improve user_rows#update performance

### DIFF
--- a/app/models/concerns/user_list_upload/user_row/matching_user.rb
+++ b/app/models/concerns/user_list_upload/user_row/matching_user.rb
@@ -4,6 +4,7 @@ module UserListUpload::UserRow::MatchingUser
   def set_matching_user
     return if matching_user_id.present?
     return if user_save_succeeded?
+    return if persisted? && !matching_attribute_changed?
 
     matching_user = find_matching_user
     self.matching_user_id = matching_user.id if matching_user
@@ -104,5 +105,10 @@ module UserListUpload::UserRow::MatchingUser
         organisations: { department_id: department.id }
       )
     )
+  end
+
+  def matching_attribute_changed?
+    nir_changed? || phone_number_changed? || department_internal_id_changed? || affiliation_number_changed? ||
+      email_changed? || role_changed?
   end
 end

--- a/app/models/concerns/user_list_upload/user_row/matching_user.rb
+++ b/app/models/concerns/user_list_upload/user_row/matching_user.rb
@@ -103,7 +103,7 @@ module UserListUpload::UserRow::MatchingUser
 
   def retrieve_potential_matching_users_in_all_app
     base = User.active
-    scope = base.none
+    scope = User.none
 
     scope = scope.or(base.where(email: email)) if email.present?
     scope = scope.or(base.where(phone_number: phone_number)) if phone_number.present?
@@ -114,7 +114,7 @@ module UserListUpload::UserRow::MatchingUser
 
   def retrieve_potential_matching_users_in_department
     base = User.active.joins(:organisations).where(organisations: { department_id: department.id })
-    scope = base.none
+    scope = User.none
 
     scope = scope.or(base.where(affiliation_number: affiliation_number)) if affiliation_number.present?
     scope = scope.or(base.where(department_internal_id: department_internal_id)) if department_internal_id.present?

--- a/db/migrate/20250415134038_add_missing_indices_on_users.rb
+++ b/db/migrate/20250415134038_add_missing_indices_on_users.rb
@@ -1,0 +1,6 @@
+class AddMissingIndicesOnUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_index :users, :deleted_at
+    add_index :users, [:role, :affiliation_number]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_20_105629) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_15_134038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -617,11 +617,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_20_105629) do
     t.string "created_from_structure_type"
     t.bigint "created_from_structure_id"
     t.index ["created_from_structure_type", "created_from_structure_id"], name: "index_users_on_created_from_structure"
+    t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["department_internal_id"], name: "index_users_on_department_internal_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["nir"], name: "index_users_on_nir"
     t.index ["phone_number"], name: "index_users_on_phone_number"
     t.index ["rdv_solidarites_user_id"], name: "index_users_on_rdv_solidarites_user_id", unique: true
+    t.index ["role", "affiliation_number"], name: "index_users_on_role_and_affiliation_number"
     t.index ["uid"], name: "index_users_on_uid"
   end
 

--- a/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
+++ b/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
@@ -190,16 +190,28 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
     end
 
     describe "set matching user on update" do
-      context "when updating an existing record" do
+      context "when updating an existing record without changing matching attributes" do
+        let!(:user_row) { user_list_upload.user_rows.create!(user_row_attributes) }
+
+        it "does not retrieve the potential matching users" do
+          expect(user_row).not_to receive(:find_matching_user)
+          user_row.update!(title: "Mr.")
+        end
+      end
+
+      context "when updating an existing record with matching attribute changes" do
         let!(:user_row) { user_list_upload.user_rows.create!(user_row_attributes) }
 
         it "does not retrieve the potential matching users from the user_list_upload" do
           expect(user_list_upload).not_to receive(:potential_matching_users_in_all_app)
           expect(user_list_upload).not_to receive(:potential_matching_users_in_department)
-          user_row.save!
+          user_row.update!(email: "new-email@example.com")
         end
 
-        include_examples "matches user correctly"
+        it "attempts to find a matching user" do
+          expect(user_row).to receive(:find_matching_user).and_call_original
+          user_row.update!(email: "new-email@example.com")
+        end
       end
     end
   end


### PR DESCRIPTION
Skylight pointe un gros souci de performance sur l'endpoint `user_rows#update` (voir image).
Ce qui prend le plus de temps est la requête sur les users qui est trigger au moment de retrouver un `matching_user` à l'update d'un `user_row`.  
Je fais un fix ici qui: 
- Ajoute des index aux users là où il n'y en a pas pour améliorer la performance de ces requêtes
- Rajoute une condition pour ne pas faire cette requête lorsque c'est inutile

![image](https://github.com/user-attachments/assets/0bbd5820-c21c-495f-bdac-9a2af231c615)
