### PR TITLE
FT(api): remove department restrictive condition for france travail webhooks

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,7 +13,6 @@ FRANCE_TRAVAIL_AUTH_URL=https://somefakeauthurl.fr
 FRANCE_TRAVAIL_API_URL=https://francetravailfakerdvurl.fr
 FRANCE_TRAVAIL_CLIENT_ID=client_id
 FRANCE_TRAVAIL_CLIENT_SECRET=client_secret
-FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS=83
 
 AGENT_SIGNATURE_KEY=bc995863-5c80-43a3-a31d-0da216e814a4
 HOST=http://www.rdv-insertion-test.fake

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -29,16 +29,11 @@ module Participation::FranceTravailWebhooks
   end
 
   def eligible_for_france_travail_webhook?
-    eligible_organisation? && user.birth_date? && user.nir? && france_travail_active_department?
+    eligible_organisation? && user.birth_date? && user.nir?
   end
 
   def france_travail_webhook_updatable?
     eligible_for_france_travail_webhook? && france_travail_id?
-  end
-
-  def france_travail_active_department?
-    # C'est une condition temporaire le temps de tester la fonctionnalité en production sur un département
-    organisation.department.number.in?(ENV.fetch("FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS", "").split(","))
   end
 
   def eligible_organisation?


### PR DESCRIPTION
Les tests étant concluants pour le Loiret, on active pour tout le monde en enlevant la condition qui permettait de filtrer sur les numéros des départements. FT est prévenu, à merge en prod le mardi 22 avril.
