### PR TITLE
Rgpd(user): anonymize `Users` `last_name` and `first_name` when soft_deleted

### DIFF
--- a/app/controllers/super_admins/users_controller.rb
+++ b/app/controllers/super_admins/users_controller.rb
@@ -33,6 +33,10 @@ module SuperAdmins
       :last_name
     end
 
+    def scoped_resource
+      resource_class.active
+    end
+
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,8 +131,8 @@ class User < ApplicationRecord
 
   def soft_delete
     update_columns(
-      last_name: "Usager supprimé",
-      first_name: "Usager supprimé",
+      last_name: "[Usager supprimé]",
+      first_name: "[Usager supprimé]",
       deleted_at: Time.zone.now,
       affiliation_number: nil,
       role: nil,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,8 @@ class User < ApplicationRecord
 
   def soft_delete
     update_columns(
+      last_name: "Usager supprimé",
+      first_name: "Usager supprimé",
       deleted_at: Time.zone.now,
       affiliation_number: nil,
       role: nil,

--- a/spec/services/users/remove_from_organisation_spec.rb
+++ b/spec/services/users/remove_from_organisation_spec.rb
@@ -27,6 +27,8 @@ describe Users::RemoveFromOrganisation, type: :service do
     it "deletes the user when there is no org attached" do
       subject
       expect(user.deleted?).to eq(true)
+      expect(user.first_name).to eq("Usager supprimé")
+      expect(user.last_name).to eq("Usager supprimé")
     end
 
     context "when user does not have a rdv_solidarites_user_id" do

--- a/spec/services/users/remove_from_organisation_spec.rb
+++ b/spec/services/users/remove_from_organisation_spec.rb
@@ -27,8 +27,8 @@ describe Users::RemoveFromOrganisation, type: :service do
     it "deletes the user when there is no org attached" do
       subject
       expect(user.deleted?).to eq(true)
-      expect(user.first_name).to eq("Usager supprimé")
-      expect(user.last_name).to eq("Usager supprimé")
+      expect(user.first_name).to eq("[Usager supprimé]")
+      expect(user.last_name).to eq("[Usager supprimé]")
     end
 
     context "when user does not have a rdv_solidarites_user_id" do


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2757
J'en ai profité pour enlever les usagers supprimés du scope du `super_admin`.