### PR TITLE
fix(webhooks): Ignore FT webhooks for rgpd destroys

### DIFF
--- a/app/jobs/destroy_old_ressources_job.rb
+++ b/app/jobs/destroy_old_ressources_job.rb
@@ -29,7 +29,10 @@ class DestroyOldRessourcesJob < ApplicationJob
                   WHERE users_organisations.user_id = users.id AND (users_organisations.created_at >= ?)
               )", date_limit)
           .distinct
-          .destroy_all
+
+    inactive_users.find_each(&:mark_for_rgpd_destruction)
+
+    inactive_users.destroy_all
 
     MattermostClient.send_to_notif_channel(
       "🚮 Les usagers suivants ont été supprimés pour inactivité : " \

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -29,15 +29,21 @@ module Participation::FranceTravailWebhooks
   end
 
   def eligible_for_france_travail_webhook?
-    eligible_organisation? && user.birth_date? && user.nir?
+    eligible_user_for_france_travail_webhook? && eligible_organisation_for_france_travail_webhook?
   end
 
   def france_travail_webhook_updatable?
     eligible_for_france_travail_webhook? && france_travail_id?
   end
 
-  def eligible_organisation?
+  private
+
+  def eligible_user_for_france_travail_webhook?
+    user_id? && user.birth_date? && user.nir? && !user.marked_for_rgpd_destruction?
+  end
+
+  def eligible_organisation_for_france_travail_webhook?
     # francetravail organisations are not eligible for webhooks, they already have theses rdvs in their own system
-    organisation.delegataire_rsa? || organisation.conseil_departemental?
+    organisation && (organisation.conseil_departemental? || organisation.delegataire_rsa?)
   end
 end

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -39,11 +39,11 @@ module Participation::FranceTravailWebhooks
   private
 
   def eligible_user_for_france_travail_webhook?
-    user_id? && user.birth_date? && user.nir? && !user.marked_for_rgpd_destruction?
+    user.birth_date? && user.nir? && !user.marked_for_rgpd_destruction?
   end
 
   def eligible_organisation_for_france_travail_webhook?
     # francetravail organisations are not eligible for webhooks, they already have theses rdvs in their own system
-    organisation && (organisation.conseil_departemental? || organisation.delegataire_rsa?)
+    organisation&.conseil_departemental? || organisation&.delegataire_rsa?
   end
 end

--- a/app/models/concerns/rgpd_destroyable.rb
+++ b/app/models/concerns/rgpd_destroyable.rb
@@ -1,0 +1,11 @@
+module RgpdDestroyable
+  extend ActiveSupport::Concern
+
+  def mark_for_rgpd_destruction
+    @marked_for_rgpd_destruction = true
+  end
+
+  def marked_for_rgpd_destruction?
+    @marked_for_rgpd_destruction == true
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   include Notificable
   include Invitable
   include HasParticipationsToRdvs
+  include RgpdDestroyable
   include User::TextHelper
   include User::Address
   include User::NirValidation

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -236,4 +236,34 @@ describe Participation do
       end
     end
   end
+
+  describe "#eligible_for_france_travail_webhook?" do
+    subject { participation.eligible_for_france_travail_webhook? }
+
+    let!(:participation) { create(:participation, user:, rdv: create(:rdv, organisation:)) }
+    let!(:organisation) { create(:organisation, organisation_type: "conseil_departemental") }
+    let!(:user) { create(:user, :with_valid_nir) }
+
+    context "when the user is not marked for rgpd destruction" do
+      it "is eligible" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when the user is marked for rgpd destruction" do
+      before { user.mark_for_rgpd_destruction }
+
+      it "is not eligible" do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "when the organisation is not a conseil departemental or delegataire" do
+      let!(:organisation) { create(:organisation, organisation_type: "siae") }
+
+      it "is not eligible" do
+        expect(subject).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Je fais un fix suite à cette erreur remontée sur sentry: https://sentry.incubateur.net/organizations/betagouv/issues/169065/?environment=production&project=16&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=5&utc=true


## Pas d'envoi de webhooks lorsqu'il n'y a pas d'organisations

Il se peut, dans de très rares cas (17 rdvs au total dans notre BDD) qu'il n'y ait pas d'organisation associé à un rdv. C'est certainement que l'organisation été supprimée sans supprimer les rdvs au préalable, or comme nous avions un `dependent: :nullify` sur l'association organisation -> rdvs, ces rdvs se retrouvent sans `organisation_id`. 

Pour régler le souci:

- Je fais en sorte de conditionner l'envoi de webhooks FT à la présence d'une orga associée pour ne plus lever cette erreur
- Je fais en sorte que ça ne se reproduise plus en changeant l'option sur  `dependent` pour `restrict_with_exception`
- Je supprimerais les  17 rdvs concernés (ça concerne des usagers tests de chez nous pour la  plupart) une fois cette PR mergée car en allant  sur la fiche d'un usager concerné par un de ces rdvs  je me rends compte  qu'on une 500: https://sentry.incubateur.net/organizations/betagouv/issues/169555/?project=16&referrer=webhooks_plugin

## Pas d'envoi de webhooks lors des destructions pour cause de RGPD

J'en profite pour faire en sorte de ne jamais envoyer  de webhooks à  FT lorsqu'un usager est supprimé pour cause de RGPD (ce qui a déclenché l'erreur).
Lorsqu'un usager était supprimé dans le `DestroyOldResourcesJob`, ses participations sont supprimés aussi. 
Or on ne veut pas envoyer de webhooks à FT dans ces cas-là. Du coup pour résoudre ça:
- je marque les usagers qui vont être détruits pour cause de rgpd
- je fais en sorte que l'envoi des webhooks à FT soit non éligible dans ce cas