### PR TITLE
fix(ft): handle ft error codes

### DIFF
--- a/app/jobs/outgoing_webhooks/france_travail/base_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/base_job.rb
@@ -3,7 +3,7 @@ module OutgoingWebhooks
     class BaseJob < ApplicationJob
       include LockedAndOrderedJobs
 
-      discard_on FranceTravailApi::RetrieveUserToken::UserNotFound
+      discard_on FranceTravailApi::RetrieveUserToken::NoMatchingUser
 
       def self.lock_key(participation_id:, **)
         "#{base_lock_key}:#{participation_id}"

--- a/app/models/concerns/participation/france_travail_payload.rb
+++ b/app/models/concerns/participation/france_travail_payload.rb
@@ -25,9 +25,9 @@ module Participation::FranceTravailPayload
       theme: motif.name,
       typeReception: france_travail_type_reception,
       interlocuteur: {
-        email: agents.first.email,
-        nom: agents.first.last_name,
-        prenom: agents.first.first_name
+        email: agents.first&.email,
+        nom: agents.first&.last_name,
+        prenom: agents.first&.first_name
       }
     }
   end

--- a/app/services/france_travail_api/retrieve_user_token.rb
+++ b/app/services/france_travail_api/retrieve_user_token.rb
@@ -1,6 +1,6 @@
 module FranceTravailApi
   class RetrieveUserToken < BaseService
-    class UserNotFound < StandardError; end
+    class NoMatchingUser < StandardError; end
     # https://francetravail.io/produits-partages/catalogue/rechercher-usager-v2/documentation#/api-reference/
 
     def initialize(user:, access_token:)
@@ -19,10 +19,10 @@ module FranceTravailApi
       response = FranceTravailClient.retrieve_user_token(payload: user_payload, headers: headers)
       @response_body = JSON.parse(response.body.force_encoding("UTF-8"))
 
-      if response.success? && !user_not_found?(response)
+      if response.success? && !no_matching_user?(response)
         @france_travail_user_token = @response_body["jetonUsager"]
-      elsif user_not_found?(response)
-        raise UserNotFound, "Aucun usager trouvé avec l'id #{@user.id}"
+      elsif no_matching_user?(response)
+        raise NoMatchingUser, "Aucun usager trouvé avec l'id #{@user.id}"
       else
         fail!(
           "Erreur lors de l'appel à l'api recherche-usager FT.\n" \
@@ -52,10 +52,11 @@ module FranceTravailApi
       }
     end
 
-    def user_not_found?(response)
+    def no_matching_user?(response)
       # Actuellement le code retour S002 est "Aucun approchant n'a été trouvé" mais c'est une 200
-      # Ca devrait être un 404, FT est au courant et va corriger, il faudra enlever cette condition.
-      @response_body["codeRetour"].include?("S002") || response.status == 404
+      # Aussi le code retour S003 est "Plusieurs approchants ont été trouvés" mais c'est une 200
+      # FT devrait corriger ça, auquel cas il faudra enlever cette condition.
+      @response_body["codeRetour"].in?(%w[S002 S003]) || response.status == 404
     end
   end
 end

--- a/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/update_participation_job_spec.rb
@@ -114,10 +114,10 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
       end
     end
 
-    context "when service fails with UserNotFound error" do
+    context "when service fails with NoMatchingUser error" do
       before do
         allow(service).to receive(:call)
-          .and_raise(FranceTravailApi::RetrieveUserToken::UserNotFound, "Aucun usager trouvé")
+          .and_raise(FranceTravailApi::RetrieveUserToken::NoMatchingUser, "Aucun usager trouvé")
       end
 
       it "discards the job without raising an error" do
@@ -128,7 +128,7 @@ describe OutgoingWebhooks::FranceTravail::UpdateParticipationJob do
               timestamp: timestamp
             )
           end
-        end.not_to raise_error # Le job est discard quand il y a une erreur UserNotFound
+        end.not_to raise_error # Le job est discard quand il y a une erreur NoMatchingUser
 
         assert_no_enqueued_jobs
       end

--- a/spec/services/france_travail_api/retrieve_user_token_spec.rb
+++ b/spec/services/france_travail_api/retrieve_user_token_spec.rb
@@ -43,6 +43,14 @@ describe FranceTravailApi::RetrieveUserToken do
         subject
         expect(subject.user_token).to eq(user_token)
       end
+
+      context "when no matching user is found" do
+        let(:response_body) { { "jetonUsager" => nil, "codeRetour" => "S003" }.to_json }
+
+        it "returns an error" do
+          expect { subject }.to raise_error(FranceTravailApi::RetrieveUserToken::NoMatchingUser)
+        end
+      end
     end
 
     context "when the API call fails" do


### PR DESCRIPTION
## Contexte 

Suite à l'ouverture de l'envoi de tous les rdvs vers France Travail, nous sommes tombés sur certains cas d'erreurs que l'on voudrait anticiper et mieux gérer.

## Cas où il n'y a pas d'agents

Nous avons certains cas où les rdvs n'ont pas d'agents associés, et donc `agents.first.email` raise une erreur dans le module `Participation::FranceTravailWebhooks`: https://www.rdv-insertion.fr/sidekiq/retries/1745510715.5825472-db32e50afa2bc339f95672dc . 

[Je fais en sorte d'utiliser un safe operator ](https://github.com/gip-inclusion/rdv-insertion/commit/89207f043259ec7dfba83134da5f91f8f9fab0dc) et de quand même envoyer le rdv puisque sur la documentation, j'ai l'impression  que l'interlocuteur n'est pas `required`. Qu'en penses-tu @Holist ?

## Cas où l'API recherche usager renvoi un code S003

Dans certains cas l'API recherche usager renvoie un code "S003" signifiant que plusieurs approchants ont été trouvés. En attendant des réponses (et des ajustements de FT), je fais en sorte qu'on gère ces cas-là pour [lever une erreur (qui est rescued) quand ça se produit
](https://github.com/gip-inclusion/rdv-insertion/commit/00dd4fc593c89032b843fddc51a236c4cdf4b834)
