### PR TITLE
FT(api): add an env variable for departments to disable ft webhooks

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,6 +13,7 @@ FRANCE_TRAVAIL_AUTH_URL=https://somefakeauthurl.fr
 FRANCE_TRAVAIL_API_URL=https://francetravailfakerdvurl.fr
 FRANCE_TRAVAIL_CLIENT_ID=client_id
 FRANCE_TRAVAIL_CLIENT_SECRET=client_secret
+FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS_DISABLED=84,86
 
 AGENT_SIGNATURE_KEY=bc995863-5c80-43a3-a31d-0da216e814a4
 HOST=http://www.rdv-insertion-test.fake

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -29,7 +29,9 @@ module Participation::FranceTravailWebhooks
   end
 
   def eligible_for_france_travail_webhook?
-    eligible_user_for_france_travail_webhook? && eligible_organisation_for_france_travail_webhook?
+    eligible_user_for_france_travail_webhook? &&
+      eligible_organisation_for_france_travail_webhook? &&
+      eligible_department_for_france_travail_webhook?
   end
 
   def france_travail_webhook_updatable?
@@ -45,5 +47,9 @@ module Participation::FranceTravailWebhooks
   def eligible_organisation_for_france_travail_webhook?
     # francetravail organisations are not eligible for webhooks, they already have theses rdvs in their own system
     organisation&.conseil_departemental? || organisation&.delegataire_rsa?
+  end
+
+  def eligible_department_for_france_travail_webhook?
+    ENV.fetch("FRANCE_TRAVAIL_WEBHOOKS_DEPARTMENTS_DISABLED", "").split(",").exclude?(organisation.department.number)
   end
 end

--- a/spec/jobs/outgoing_webhooks/france_travail/create_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/create_participation_job_spec.rb
@@ -49,6 +49,21 @@ describe OutgoingWebhooks::FranceTravail::CreateParticipationJob do
         end
       end
     end
+
+    context "when the department is not eligible for France Travail webhooks" do
+      let!(:department) { create(:department, number: 84) }
+      let!(:organisation) { create(:organisation, organisation_type: "delegataire_rsa", department: department) }
+      let!(:user) { create(:user, :with_valid_nir) }
+      let!(:rdv) { build(:rdv) }
+      let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
+
+      context "on creation" do
+        it "does not send webhook" do
+          expect(described_class).not_to receive(:perform_later)
+          participation.save
+        end
+      end
+    end
   end
 
   describe "#perform" do


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2817

TODO une fois merge, désactiver pour la Manche en production.