### PR TITLE
ui(mails): use html_escape on instruction_for_rdv for notifications

### DIFF
--- a/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
@@ -2,7 +2,12 @@
 <p>Vous êtes <%= @user_designation %> et à ce titre vous êtes <%= @user.conjugate("convoqué") %> à un <%= @rdv_title_by_phone %> afin de <%= @rdv_purpose %>.</p>
 <p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
@@ -2,7 +2,12 @@
 <p>Vous êtes <%= @user_designation %> et à ce titre vous avez été <%= @user.conjugate("convoqué") %> à un <%= @rdv_title_by_phone %> afin de <%= @rdv_purpose %>.</p>
 <p>Nous vous rappelons qu'un travailleur social vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
@@ -2,7 +2,12 @@
 <p>Votre <%= @rdv_title_by_phone %> dans le cadre de votre <%= @rdv_subject %> a été modifié.</p>
 <p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/notification_mailer/presential_participation_created.html.erb
+++ b/app/views/mailers/notification_mailer/presential_participation_created.html.erb
@@ -5,7 +5,12 @@
 <p><h4><%= @rdv.lieu.address %></h4></p>
 <br/>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/notification_mailer/presential_participation_reminder.html.erb
+++ b/app/views/mailers/notification_mailer/presential_participation_reminder.html.erb
@@ -5,7 +5,12 @@
 <p><h4><%= @rdv.lieu.address %></h4></p>
 <br/>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/notification_mailer/presential_participation_updated.html.erb
+++ b/app/views/mailers/notification_mailer/presential_participation_updated.html.erb
@@ -5,7 +5,12 @@
 <p><h4><%= @rdv.lieu.address %></h4></p>
 <br/>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
-<%= tag.p tag.strong(@instruction_for_rdv, class: "bold-blue") if @instruction_for_rdv.present? %>
+<% if @instruction_for_rdv.present? %>
+  <p>
+    <%= tag.strong("Informations importantes :") %><br>
+    <%= simple_format(h(@instruction_for_rdv)) %>
+  </p>
+<% end %>
 <%= tag.p tag.strong("En cas d'absence, #{@punishable_warning}.") if @punishable_warning.present? %>
 <p>En cas d'empêchement, merci d'appeler rapidement le <%= @rdv.phone_number %>.</p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2796

Pour reprendre l'exemple de l'issue ca donne ca. J'ai repris la valeur de la pté `instruction_for_rdv` du motif de l'issue de production. On voit qu'il y a eu un retour à la ligne au milieu d'une phrase ! Il faudra être attentif au paramètrage avec le nouveau fonctionnement @amaurydubot .

<img width="889" alt="Capture d’écran 2025-04-25 à 11 32 32" src="https://github.com/user-attachments/assets/ac77dddd-fb65-4786-a38a-0f9c31e4a704" />

Avec les bons retours à la ligne ca donnera ca : 

<img width="889" alt="Capture d’écran 2025-04-25 à 11 41 27" src="https://github.com/user-attachments/assets/4471b2cb-d0bb-48da-8ad7-81a61ee4739e" />
