### PR TITLE
feat(geocoding): Update Api Adresse Url

### DIFF
--- a/app/clients/api_adresse_client.rb
+++ b/app/clients/api_adresse_client.rb
@@ -1,5 +1,5 @@
 class ApiAdresseClient
-  URL = "https://api-adresse.data.gouv.fr/search/".freeze
+  URL = "https://data.geopf.fr/geocodage/search/".freeze
 
   def self.get_geocoding(address, **params)
     Faraday.get(URL, { q: address }.merge(params), { "Content-Type" => "application/json" })

--- a/spec/services/retrieve_address_geocoding_params_spec.rb
+++ b/spec/services/retrieve_address_geocoding_params_spec.rb
@@ -42,7 +42,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
     before do
       allow(Faraday).to receive(:get)
         .with(
-          "https://api-adresse.data.gouv.fr/search/",
+          ApiAdresseClient::URL,
           { q: address }, { "Content-Type" => "application/json" }
         )
         .and_return(OpenStruct.new(success?: true, body: response_body.to_json))
@@ -85,7 +85,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
       before do
         allow(Faraday).to receive(:get)
           .with(
-            "https://api-adresse.data.gouv.fr/search/",
+            ApiAdresseClient::URL,
             { q: address }, { "Content-Type" => "application/json" }
           )
           .and_return(OpenStruct.new(success?: false, body: { "error" => "something" }.to_json))
@@ -105,7 +105,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
         [address, parsed_post_code_and_city, parsed_city].each do |query|
           allow(Faraday).to receive(:get)
             .with(
-              "https://api-adresse.data.gouv.fr/search/",
+              ApiAdresseClient::URL,
               { q: query }, { "Content-Type" => "application/json" }
             )
             .and_return(OpenStruct.new(success?: true, body: response_body.to_json))
@@ -149,7 +149,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
         [address, parsed_post_code_and_city, parsed_city].each do |query|
           expect(Faraday).to receive(:get)
             .with(
-              "https://api-adresse.data.gouv.fr/search/",
+              ApiAdresseClient::URL,
               { q: query }, { "Content-Type" => "application/json" }
             )
         end
@@ -169,7 +169,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
         [address, parsed_post_code_and_city].each do |query|
           allow(Faraday).to receive(:get)
             .with(
-              "https://api-adresse.data.gouv.fr/search/",
+              ApiAdresseClient::URL,
               { q: query }, { "Content-Type" => "application/json" }
             )
             .and_return(OpenStruct.new(success?: true, body: response_body.to_json))
@@ -181,7 +181,7 @@ describe RetrieveAddressGeocodingParams, type: :service do
         [address, parsed_post_code_and_city].each do |query|
           expect(Faraday).to receive(:get)
             .with(
-              "https://api-adresse.data.gouv.fr/search/",
+              ApiAdresseClient::URL,
               { q: query }, { "Content-Type" => "application/json" }
             )
         end


### PR DESCRIPTION
Closes #2799 

Je change l'url de search de l'API adresse pour utiliser la nouvelle adresse liée à l'IGN.