### PR TITLE
feat(org): Raise when deleting an org with rdvs

### DIFF
--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -46,7 +46,7 @@ module Participation::FranceTravailWebhooks
 
   def eligible_organisation_for_france_travail_webhook?
     # francetravail organisations are not eligible for webhooks, they already have theses rdvs in their own system
-    organisation&.conseil_departemental? || organisation&.delegataire_rsa?
+    organisation.conseil_departemental? || organisation.delegataire_rsa?
   end
 
   def eligible_department_for_france_travail_webhook?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -19,10 +19,10 @@ class Organisation < ApplicationRecord
   has_one :dpa_agreement, dependent: :destroy
 
   has_many :category_configurations, dependent: :destroy
-  has_many :rdvs, dependent: :nullify
+  has_many :rdvs, dependent: :restrict_with_exception
   has_many :participations, through: :rdvs
-  has_many :lieux, dependent: :nullify
-  has_many :motifs, dependent: :nullify
+  has_many :lieux, dependent: :restrict_with_exception
+  has_many :motifs, dependent: :restrict_with_exception
   has_many :agent_roles, dependent: :destroy
   has_many :users_organisations, dependent: :destroy
   has_many :tag_organisations, dependent: :destroy


### PR DESCRIPTION
Comme je le disais dans #2810 on a quelques rdvs qui n'ont pas d'organisation lorsque l'organisation a été supprimée sans les rdvs. 
Je fais en sorte que ce ne soit pas possible en levant une exception lorsque l'on essaie de supprimer une organisation qui a des rdvs associés. 
J'en profite pour faire de même avec les lieux et les motifs.

Aussi, ayant supprimé les 17 rdvs en db qui étaient dans cet état, je fais en sorte d'enlever le safe operator ici:  https://github.com/gip-inclusion/rdv-insertion/pull/2821/commits/43fa2b248220d8c9caeb5523e58e301d8a5f8292