### PR TITLE
feat(convocations): Change by phone convocation text

### DIFF
--- a/app/services/concerns/notifications/sms_content.rb
+++ b/app/services/concerns/notifications/sms_content.rb
@@ -22,7 +22,7 @@ module Notifications
     def by_phone_participation_created_content
       "#{user.full_name},\nVous êtes #{user_designation} et êtes " \
         "#{user.conjugate('convoqué')} à un " \
-        "#{rdv_title_by_phone}. Un travailleur social vous appellera le #{formatted_start_date}" \
+        "#{rdv_title_by_phone}. Un conseiller d'insertion vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
@@ -42,7 +42,7 @@ module Notifications
 
     def by_phone_participation_updated_content
       "#{user.full_name},\nVotre #{rdv_title_by_phone} dans le cadre de votre #{rdv_subject} a été modifié. " \
-        "Un travailleur social vous appellera le #{formatted_start_date}" \
+        "Un conseiller d'insertion vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
@@ -64,7 +64,7 @@ module Notifications
     def by_phone_participation_reminder_content
       "RAPPEL: #{user.full_name},\nVous êtes #{user_designation} et avez été " \
         "#{user.conjugate('convoqué')} à un " \
-        "#{rdv_title_by_phone}. Un travailleur social vous appellera le #{formatted_start_date}" \
+        "#{rdv_title_by_phone}. Un conseiller d'insertion vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \

--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -8,7 +8,7 @@
 <div class="main-content">
   <p><%= user.title.capitalize %>,</p>
   <p>Vous êtes <%= user_designation %> et à ce titre <span class="bold-blue">vous êtes <%= user.conjugate("convoqué") %> à un <%= rdv_title %></span> afin de <%= rdv_purpose %>.</p>
-  <p>Un travailleur social vous appellera <span class="bold-blue">le <%= I18n.l(rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="bold-blue"><%= user.phone_number %></span>.</p>
+  <p>Un conseiller d'insertion vous appellera <span class="bold-blue">le <%= I18n.l(rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="bold-blue"><%= user.phone_number %></span>.</p>
   <%= tag.p tag.span(mandatory_warning, class: "bold-blue") if mandatory_warning %>
   <%= tag.p tag.span(instruction_for_rdv, class: "bold-blue") if instruction_for_rdv.present? %>
   <%= tag.p tag.span("En cas d'absence, #{punishable_warning}.", class: "bold-blue") if punishable_warning.present? %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
 <p>Vous êtes <%= @user_designation %> et à ce titre vous êtes <%= @user.conjugate("convoqué") %> à un <%= @rdv_title_by_phone %> afin de <%= @rdv_purpose %>.</p>
-<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
+<p>Un conseiller d'insertion vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
 <% if @instruction_for_rdv.present? %>
   <p>

--- a/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
 <p>Vous êtes <%= @user_designation %> et à ce titre vous avez été <%= @user.conjugate("convoqué") %> à un <%= @rdv_title_by_phone %> afin de <%= @rdv_purpose %>.</p>
-<p>Nous vous rappelons qu'un travailleur social vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
+<p>Nous vous rappelons qu'un conseiller d'insertion vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
 <% if @instruction_for_rdv.present? %>
   <p>

--- a/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
 <p>Votre <%= @rdv_title_by_phone %> dans le cadre de votre <%= @rdv_subject %> a été modifié.</p>
-<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
+<p>Un conseiller d'insertion vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @user.phone_number %></span>.</p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
 <% if @instruction_for_rdv.present? %>
   <p>

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à un rendez-vous d'orientation" \
           " téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -457,7 +457,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué " \
           "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -485,7 +485,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué " \
           "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -513,7 +513,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué " \
           "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -541,7 +541,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à un rendez-vous téléphonique" \
           " de signature de CER afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -569,7 +569,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à un rendez-vous de suivi " \
           "téléphonique afin de faire un point avec votre référent de parcours" \
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -619,7 +619,7 @@ RSpec.describe NotificationMailer do
         expect(body_string).to include(
           "Votre rendez-vous d'orientation téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -646,7 +646,7 @@ RSpec.describe NotificationMailer do
         expect(body_string).to include(
           "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -673,7 +673,7 @@ RSpec.describe NotificationMailer do
         expect(body_string).to include(
           "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -700,7 +700,7 @@ RSpec.describe NotificationMailer do
         expect(body_string).to include(
           "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -728,7 +728,7 @@ RSpec.describe NotificationMailer do
           "Votre rendez-vous téléphonique de signature de CER" \
           " dans le cadre de votre RSA a été modifié"
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -756,7 +756,7 @@ RSpec.describe NotificationMailer do
           "Votre rendez-vous de suivi " \
           "téléphonique dans le cadre de votre RSA a été modifié" \
         )
-        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("Un conseiller d'insertion vous appellera")
         expect(body_string).to include("le lundi 20 décembre 2021 à 12h00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")
@@ -978,7 +978,7 @@ RSpec.describe NotificationMailer do
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué à un rendez-vous d'orientation" \
           " téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(body_string).to include("Nous vous rappelons qu'un travailleur social vous appellera")
+        expect(body_string).to include("Nous vous rappelons qu'un conseiller d'insertion vous appellera")
         expect(body_string).to include("le 20/12/2021 à 12:00")
         expect(body_string).to include("sur votre numéro de téléphone:")
         expect(body_string).to include("+33607070707")

--- a/spec/services/notifications/generate_letter_spec.rb
+++ b/spec/services/notifications/generate_letter_spec.rb
@@ -77,8 +77,8 @@ describe Notifications::GenerateLetter, type: :service do
         expect(content).to include("DIRECTION DÉPARTEMENTAL")
         expect(content).to include("Convocation à un rendez-vous d'orientation téléphonique dans le cadre de votre RSA")
         expect(content).to include(
-          "Un conseiller d'insertion vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 à 09h30</span>" \
-          " sur votre numéro de téléphone: <span class=\"bold-blue\">+33607070707</span>"
+          "Un conseiller d'insertion vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 à 09h30" \
+          "</span> sur votre numéro de téléphone: <span class=\"bold-blue\">+33607070707</span>"
         )
         expect(content).not_to include("Merci de venir au RDV avec un justificatif de domicile et une pièce")
       end

--- a/spec/services/notifications/generate_letter_spec.rb
+++ b/spec/services/notifications/generate_letter_spec.rb
@@ -77,7 +77,7 @@ describe Notifications::GenerateLetter, type: :service do
         expect(content).to include("DIRECTION DÉPARTEMENTAL")
         expect(content).to include("Convocation à un rendez-vous d'orientation téléphonique dans le cadre de votre RSA")
         expect(content).to include(
-          "Un travailleur social vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 à 09h30</span>" \
+          "Un conseiller d'insertion vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 à 09h30</span>" \
           " sur votre numéro de téléphone: <span class=\"bold-blue\">+33607070707</span>"
         )
         expect(content).not_to include("Merci de venir au RDV avec un justificatif de domicile et une pièce")
@@ -119,7 +119,7 @@ describe Notifications::GenerateLetter, type: :service do
             "Convocation à un nouveau type de rendez-vous téléphonique dans le cadre de votre RSA"
           )
           expect(content).to include(
-            "Un travailleur social vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 " \
+            "Un conseiller d'insertion vous appellera <span class=\"bold-blue\">le dimanche 25 décembre 2022 " \
             "à 09h30</span> sur votre numéro de téléphone: <span class=\"bold-blue\">+33607070707</span>"
           )
         end

--- a/spec/services/notifications/send_sms_spec.rb
+++ b/spec/services/notifications/send_sms_spec.rb
@@ -256,7 +256,7 @@ describe Notifications::SendSms, type: :service do
         let!(:content) do
           "M. John DOE,\nVous êtes bénéficiaire du RSA et êtes convoqué à un " \
             "rendez-vous d'orientation téléphonique." \
-            " Un travailleur social vous appellera le 20/12/2021 à " \
+            " Un conseiller d'insertion vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "Ce RDV est obligatoire. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -279,7 +279,7 @@ describe Notifications::SendSms, type: :service do
           let!(:content) do
             "M. John DOE,\nVotre rendez-vous d'orientation téléphonique " \
               "dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
+              "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -303,7 +303,7 @@ describe Notifications::SendSms, type: :service do
           let!(:content) do
             "RAPPEL: M. John DOE,\nVous êtes bénéficiaire du RSA et avez été convoqué à un " \
               "rendez-vous d'orientation téléphonique." \
-              " Un travailleur social vous appellera le 20/12/2021 à " \
+              " Un conseiller d'insertion vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -393,7 +393,7 @@ describe Notifications::SendSms, type: :service do
 
           let!(:content) do
             "M. John DOE,\nVous êtes bénéficiaire du RSA et êtes convoqué à un " \
-              "rendez-vous d'accompagnement téléphonique. Un travailleur social " \
+              "rendez-vous d'accompagnement téléphonique. Un conseiller d'insertion " \
               "vous appellera le 20/12/2021 à partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. " \
               "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
@@ -417,7 +417,7 @@ describe Notifications::SendSms, type: :service do
             let!(:content) do
               "M. John DOE,\nVotre rendez-vous d'accompagnement téléphonique " \
                 "dans le cadre de votre RSA a été modifié. " \
-                "Un travailleur social vous appellera le 20/12/2021 à " \
+                "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
                 "partir de 10:00 sur ce numéro. " \
                 "Ce RDV est obligatoire. " \
                 "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
@@ -510,7 +510,7 @@ describe Notifications::SendSms, type: :service do
         let!(:content) do
           "M. John DOE,\nVous êtes bénéficiaire du RSA et êtes convoqué à un " \
             "rendez-vous téléphonique de signature de CER. " \
-            "Un travailleur social vous appellera le 20/12/2021 à " \
+            "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "Ce RDV est obligatoire. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -533,7 +533,7 @@ describe Notifications::SendSms, type: :service do
           let!(:content) do
             "M. John DOE,\nVotre rendez-vous téléphonique de signature de CER" \
               " dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
+              "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -621,7 +621,7 @@ describe Notifications::SendSms, type: :service do
         let!(:content) do
           "M. John DOE,\nVous êtes bénéficiaire du RSA et êtes convoqué à un " \
             "rendez-vous de suivi téléphonique. " \
-            "Un travailleur social vous appellera le 20/12/2021 à " \
+            "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
@@ -643,7 +643,7 @@ describe Notifications::SendSms, type: :service do
           let!(:content) do
             "M. John DOE,\nVotre rendez-vous de suivi téléphonique" \
               " dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
+              "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
           end
@@ -733,7 +733,7 @@ describe Notifications::SendSms, type: :service do
 
         let!(:content) do
           "M. John DOE,\nVous êtes demandeur d'emploi et êtes convoqué à un " \
-            "rendez-vous d'accompagnement téléphonique. Un travailleur social " \
+            "rendez-vous d'accompagnement téléphonique. Un conseiller d'insertion " \
             "vous appellera le 20/12/2021 à partir de 10:00 sur ce numéro. " \
             "Ce RDV est obligatoire. " \
             "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
@@ -757,7 +757,7 @@ describe Notifications::SendSms, type: :service do
           let!(:content) do
             "M. John DOE,\nVotre rendez-vous d'accompagnement téléphonique dans le cadre de votre " \
               "demande d'emploi a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
+              "Un conseiller d'insertion vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. " \
               "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \


### PR DESCRIPTION
Closes #2788 

J'ai remplacé le terme "travailleur social" par "conseiller d'insertion" sur tous les messages de convocation à des rdvs téléphoniques.
@amaurydubot on pourra éventuellement rendre ce terme configuration si on commence à avoir des cas d'usages avec moins de liens directs avec l'écosystème de l'insertion.