### PR TITLE
feat(webhooks): Allow mutliple webhooks per organisation

### DIFF
--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,7 +1,8 @@
 class WebhookEndpoint < ApplicationRecord
   belongs_to :organisation
 
-  validates :organisation_id, uniqueness: true
+  validates :url, :secret, :signature_type, presence: true
+  validates :url, uniqueness: { scope: :organisation_id }
 
   enum :signature_type, { hmac: "hmac", jwt: "jwt" }
 


### PR DESCRIPTION
Suite à une demande du 78 je change les règles de validation des webhook endpoints pour pouvoir en configurer plusieurs (différentes) par organisations.
Cette évolution me semble logique et va dans le sens de l'architecture proposée par rdv-sp.