### PR TITLE
ux(header): add search filter in organisations list

### DIFF
--- a/app/javascript/controllers/dropdown_menu_controller.js
+++ b/app/javascript/controllers/dropdown_menu_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
 
   connect() {
     window.addEventListener("click", (e) => {
-      if (e.target !== this.buttonTarget && this.isOpen()){
+      if (e.target !== this.buttonTarget && !this.dropdownTarget.contains(e.target) && this.isOpen()){
         this.toggle()
       }
     })

--- a/app/javascript/controllers/organisation_filter_controller.js
+++ b/app/javascript/controllers/organisation_filter_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input", "item", "noResults"]
+
+  connect() {
+    // filter is optional in case of low number of organisations so input target is optional
+    if (this.hasInputTarget) {
+      document.addEventListener("click", (event) => {
+        // reset input value and show all items when clicking outside the dropdown
+        if (!this.element.contains(event.target) && this.hasInputTarget) {
+          this.inputTarget.value = "";
+          this.#showAllItems();
+        }
+      });
+    }
+  }
+
+  filter() {
+    if (!this.hasInputTarget) return;
+
+    const searchText = this.inputTarget.value.toLowerCase().trim();
+
+    if (searchText === "") {
+      this.#showAllItems();
+      return;
+    }
+
+    let visibleCount = 0;
+    this.itemTargets.forEach(item => {
+      const itemText = item.textContent.toLowerCase();
+      if (itemText.includes(searchText)) {
+        item.classList.remove("d-none");
+        visibleCount += 1;
+      } else {
+        item.classList.add("d-none");
+      }
+    });
+
+    this.noResultsTarget.style.display = visibleCount === 0 ? "block" : "none";
+  }
+
+  #showAllItems() {
+    this.itemTargets.forEach(item => {
+      item.classList.remove("d-none");
+    });
+
+    this.noResultsTarget.style.display = "none";
+  }
+}

--- a/app/javascript/stylesheets/components/_dropdown.scss
+++ b/app/javascript/stylesheets/components/_dropdown.scss
@@ -3,7 +3,6 @@
     width: 260px;
   }
   &#organisation-navigation-dropdown {
-    right: -165px;
     max-width: 515px;
     min-width: 300px;
     max-height: 500px;

--- a/app/views/common/_header_organisation_navigation_button.html.erb
+++ b/app/views/common/_header_organisation_navigation_button.html.erb
@@ -2,7 +2,20 @@
   <button id="btn-organisation-navigation" class="dropdown-toggle accessible text-truncate" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">
     <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
   </button>
-  <div id="organisation-navigation-dropdown" data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2">
+  <div id="organisation-navigation-dropdown" data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2" data-controller="organisation-filter">
+    <% if current_agent_department_organisations.count > 1 %>
+      <div class="px-3 pt-2 pb-2 border-bottom">
+        <div class="position-relative">
+          <input type="text"
+                 class="form-control form-control-sm pe-4"
+                 placeholder="Nom de l'organisation recherchée..."
+                 data-organisation-filter-target="input"
+                 data-action="input->organisation-filter#filter"
+                 autocomplete="off">
+        </div>
+      </div>
+    <% end %>
+
     <%= link_to department_users_path(current_department), title: "#{current_department_name} - Toutes les organisations" do %>
       <div class="dropdown-item py-3 text-truncate <%= "navigation-selected-item" if department_level? %>">
         <i class="ri-building-line me-3 <%= department_level? ? "text-white" : "text-dark-blue" %>"></i><%= current_department_name %> - Toutes les organisations
@@ -10,8 +23,12 @@
     <% end %>
     <% current_agent_department_organisations.sort_by(&:name).each do |organisation| %>
       <%= link_to organisation_users_path(organisation), title: "#{organisation.name}" do %>
-        <div class="dropdown-item py-3 text-truncate <%= "navigation-selected-item" if current_structure == organisation %>"><i class="ri-building-4-line me-3 <%= current_structure == organisation ? "text-white" : "text-dark-blue" %>"></i><%= organisation.name %></div>
+        <div class="dropdown-item py-3 text-truncate <%= "navigation-selected-item" if current_structure == organisation %>" data-organisation-filter-target="item"><i class="ri-building-4-line me-3 <%= current_structure == organisation ? "text-white" : "text-dark-blue" %>"></i><%= organisation.name %></div>
       <% end %>
     <% end %>
+
+    <div class="dropdown-item py-3 text-muted text-center" style="display: none;" data-organisation-filter-target="noResults">
+      Aucun résultat
+    </div>
   </div>
 </div>

--- a/app/views/common/_header_organisation_navigation_button.html.erb
+++ b/app/views/common/_header_organisation_navigation_button.html.erb
@@ -3,7 +3,7 @@
     <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
   </button>
   <div id="organisation-navigation-dropdown" data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2" data-controller="organisation-filter">
-    <% if current_agent_department_organisations.count > 1 %>
+    <% if current_agent_department_organisations.count > 10 %>
       <div class="px-3 pt-2 pb-2 border-bottom">
         <div class="position-relative">
           <input type="text"


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2693

Ce n'était pas précisé dans l'issue mais je reinitialise le filtre de recherche lorsqu'on clic en dehors de la dropdown. On le voit dans la démo. Ca évitera je pense des pbl d'interface ou les agents ne retrouvent pas leur organisation dans la liste parce qu'il restait une lettre dans le filtre.


https://github.com/user-attachments/assets/2cdbec1c-49b0-41f6-bcd8-c312f930e977

