### PR TITLE
feat(db): Allow agent and category_configuration destruction

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -11,6 +11,7 @@ class Agent < ApplicationRecord
   has_many :csv_exports, dependent: :destroy
   has_many :parcours_documents, dependent: :nullify
   has_many :dpa_agreements, dependent: :nullify
+  has_many :user_list_uploads, dependent: :destroy
 
   has_many :organisations, through: :agent_roles
   has_many :departments, -> { distinct }, through: :organisations

--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -6,6 +6,7 @@ class CategoryConfiguration < ApplicationRecord
   belongs_to :organisation
 
   has_many :creneau_availabilities, dependent: :destroy
+  has_many :user_list_uploads, dependent: :nullify
 
   validates :organisation, uniqueness: { scope: :motif_category,
                                          message: "a déjà une category_configuration pour cette catégorie de motif" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,7 @@ class User < ApplicationRecord
   has_many :orientations, dependent: :destroy
   has_many :diagnostics, dependent: :destroy
   has_many :contracts, dependent: :destroy
+  has_many :blocked_users, dependent: :destroy
 
   has_many :rdvs, through: :participations
   has_many :organisations, through: :users_organisations

--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -5,6 +5,7 @@ class UserListUpload < ApplicationRecord
 
   has_many :user_rows, class_name: "UserListUpload::UserRow", dependent: :destroy
   has_many :user_save_attempts, class_name: "UserListUpload::UserSaveAttempt", through: :user_rows
+  has_many :invitation_attempts, class_name: "UserListUpload::InvitationAttempt", through: :user_rows
 
   accepts_nested_attributes_for :user_rows
 


### PR DESCRIPTION
closes #2798 .
Je fais en sorte que les contrainte sur les foreign key sur la table `user_list_uploads` ne bloque pas la destruction d'agents ou de category configurations. Pour les agents supprimés je supprime leur upload parce qu'ils sont les seuls à éventuellement y avoir accès de toute façon.
J'en profite pour faire la même chose pour les `blocked_users`.