### PR TITLE
feat(upload): remove bg color when row is not selected

### DIFF
--- a/app/helpers/user_list_upload/invitation_attempts_helper.rb
+++ b/app/helpers/user_list_upload/invitation_attempts_helper.rb
@@ -1,4 +1,8 @@
 module UserListUpload::InvitationAttemptsHelper
+  def user_row_background_color_before_invitation(user_row)
+    "background-light" if user_row.selected_for_invitation?
+  end
+
   def user_row_before_invitation_badge_class(user_row)
     {
       already_invited: "background-very-light-grey text-very-dark-grey",

--- a/app/helpers/user_list_upload/user_list_upload_helper.rb
+++ b/app/helpers/user_list_upload/user_list_upload_helper.rb
@@ -17,7 +17,7 @@ module UserListUpload::UserListUploadHelper
   def user_row_background_color(user_row)
     if user_row.archived?
       "background-brown-light"
-    else
+    elsif user_row.selected_for_user_save?
       "background-light"
     end
   end

--- a/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
@@ -1,4 +1,4 @@
-<tr class="background-light">
+<tr class="<%= user_row_background_color_before_invitation(user_row) %>">
   <td class="border-light">
     <input type="checkbox"
             class="form-check-input user-checkbox"


### PR DESCRIPTION
closes #2793 .

Seules les lignes sélectionnées ont un fond bleuté, les lignes non sélectionnées sur fond blanc. La couleur change lorsqu'une ligne est sélectionnée ou déselectionnée (sauf si l'usager est  archivé).

<img width="1442" alt="image" src="https://github.com/user-attachments/assets/07c46d6c-1b38-41e7-bc0f-f6d4732e6d3a" />

J'en ai profité pour faire pareil sur la page d'invitation: 
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/4f61e915-247c-46fe-aa61-0cddc733788f" />

