### PR TITLE
refactor(crisp): simplify crisp concern

### DIFF
--- a/app/controllers/concerns/crisp_concern.rb
+++ b/app/controllers/concerns/crisp_concern.rb
@@ -8,11 +8,6 @@ module CrispConcern
   private
 
   def should_display_crisp_chatbox
-    if current_agent.nil? || agent_impersonated? || ENV["ENABLE_CRISP"] != "true"
-      @should_display_crisp_chatbox = false
-      return
-    end
-
-    @should_display_crisp_chatbox = true
+    @should_display_crisp_chatbox = current_agent && !agent_impersonated? && ENV["ENABLE_CRISP"] == "true"
   end
 end

--- a/app/controllers/concerns/crisp_concern.rb
+++ b/app/controllers/concerns/crisp_concern.rb
@@ -2,12 +2,12 @@ module CrispConcern
   extend ActiveSupport::Concern
 
   included do
-    before_action :should_display_crisp_chatbox, if: -> { request.get? }
+    before_action :set_should_display_crisp_chatbox, if: -> { request.get? }
   end
 
   private
 
-  def should_display_crisp_chatbox
+  def set_should_display_crisp_chatbox
     @should_display_crisp_chatbox = current_agent && !agent_impersonated? && ENV["ENABLE_CRISP"] == "true"
   end
 end


### PR DESCRIPTION
Je suis tombé sur cette condition concernant   la variable `@should_display_crisp_chatbot` en relisant du code et j'ai remarqué qu'elle pouvait être simplifiée.
J'en profite  pour renommer la méthode qui set la variable.