### PR TITLE
feat(ops): Deduplicate rdv solidarites webhooks

### DIFF
--- a/app/jobs/concerns/locked_jobs.rb
+++ b/app/jobs/concerns/locked_jobs.rb
@@ -13,6 +13,9 @@ module LockedJobs
     ActiveRecord::Base.with_advisory_lock!(
       self.class.lock_key(*arguments), timeout_seconds: 0, &
     )
+  rescue WithAdvisoryLock::FailedToAcquireLock
+    self.class.on_lock_failure(*arguments) if self.class.respond_to?(:on_lock_failure)
+    raise
   end
 
   class_methods do

--- a/app/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job.rb
+++ b/app/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job.rb
@@ -1,0 +1,23 @@
+class DeduplicateRdvSolidaritesWebhooksFromRetrySetJob < ApplicationJob
+  def perform(job_class_name, resource_id)
+    retry_set = Sidekiq::RetrySet.new
+
+    jobs_of_same_class = retry_set.map do |job|
+      next unless job.display_class == job_class_name
+
+      RdvSolidaritesWebhookJobWrapper.new(job)
+    end.compact
+
+    candidates = jobs_of_same_class.select do |job|
+      job.valid? && job.resource_id == resource_id
+    end
+
+    job_to_keep = candidates.max_by(&:timestamp)
+
+    return unless job_to_keep
+
+    candidates.each do |candidate|
+      candidate.sidekiq_job.delete unless candidate == job_to_keep
+    end
+  end
+end

--- a/app/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job.rb
+++ b/app/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job.rb
@@ -12,9 +12,9 @@ class DeduplicateRdvSolidaritesWebhooksFromRetrySetJob < ApplicationJob
       job.valid? && job.resource_id == resource_id
     end
 
-    job_to_keep = candidates.max_by(&:timestamp)
+    return if candidates.length < 2
 
-    return unless job_to_keep
+    job_to_keep = candidates.max_by(&:timestamp)
 
     candidates.each do |candidate|
       candidate.sidekiq_job.delete unless candidate == job_to_keep

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -8,6 +8,10 @@ module InboundWebhooks
         "#{base_lock_key}:#{data[:id]}"
       end
 
+      def self.on_lock_failure(data, _meta)
+        DeduplicateRdvSolidaritesWebhooksFromRetrySetJob.perform_later(name, data[:id])
+      end
+
       def perform(data, meta)
         @data = data.deep_symbolize_keys
         @meta = meta.deep_symbolize_keys

--- a/app/models/rdv_solidarites_webhook_job_wrapper.rb
+++ b/app/models/rdv_solidarites_webhook_job_wrapper.rb
@@ -24,9 +24,7 @@ class RdvSolidaritesWebhookJobWrapper
   end
 
   def timestamp
-    return unless meta["timestamp"]
-
-    Time.zone.parse(meta["timestamp"])
+    meta["timestamp"].is_a?(String) ? Time.zone.parse(meta["timestamp"]) : nil
   end
 
   def ==(other)

--- a/app/models/rdv_solidarites_webhook_job_wrapper.rb
+++ b/app/models/rdv_solidarites_webhook_job_wrapper.rb
@@ -1,0 +1,35 @@
+class RdvSolidaritesWebhookJobWrapper
+  attr_reader :sidekiq_job
+
+  delegate :jid, to: :sidekiq_job
+
+  def initialize(sidekiq_job)
+    @sidekiq_job = sidekiq_job
+  end
+
+  def valid?
+    sidekiq_job.display_args.count == 2 && data.is_a?(Hash) && meta.is_a?(Hash) && timestamp.present?
+  end
+
+  def data
+    sidekiq_job.display_args.first
+  end
+
+  def meta
+    sidekiq_job.display_args.last
+  end
+
+  def resource_id
+    data["id"]
+  end
+
+  def timestamp
+    return unless meta["timestamp"]
+
+    Time.zone.parse(meta["timestamp"])
+  end
+
+  def ==(other)
+    jid == other.jid
+  end
+end

--- a/spec/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job_spec.rb
+++ b/spec/jobs/deduplicate_rdv_solidarites_webhooks_from_retry_set_job_spec.rb
@@ -1,0 +1,59 @@
+describe DeduplicateRdvSolidaritesWebhooksFromRetrySetJob do
+  subject { described_class.new.perform(class_name, resource_id) }
+
+  let(:class_name) { "InboundWebhooks::RdvSolidarites::ProcessRdvJob" }
+  let(:resource_id) { 123 }
+  let(:older_sidekiq_job_from_same_class_and_resource_id) do
+    instance_double(
+      Sidekiq::JobRecord,
+      display_class: class_name,
+      display_args: [{ "id" => resource_id }, { "timestamp" => "2024-05-01T12:00:00Z" }],
+      jid: SecureRandom.uuid
+    )
+  end
+  let(:newer_sidekiq_job_from_same_class_and_resource_id) do
+    instance_double(
+      Sidekiq::JobRecord,
+      display_class: class_name,
+      display_args: [{ "id" => resource_id }, { "timestamp" => "2024-05-01T12:00:01Z" }],
+      jid: SecureRandom.uuid
+    )
+  end
+  let(:sidekiq_job_from_same_class_and_different_resource_id) do
+    instance_double(
+      Sidekiq::JobRecord,
+      display_class: class_name,
+      display_args: [{ "id" => 456 }, { "timestamp" => "2024-05-01T12:00:00Z" }],
+      jid: SecureRandom.uuid
+    )
+  end
+  let(:sidekiq_job_from_other_class) do
+    instance_double(
+      Sidekiq::JobRecord,
+      display_class: "SomeOtherJob",
+      jid: SecureRandom.uuid
+    )
+  end
+
+  before do
+    allow(Sidekiq::RetrySet).to receive(:new).and_return(
+      [
+        older_sidekiq_job_from_same_class_and_resource_id,
+        sidekiq_job_from_same_class_and_different_resource_id,
+        sidekiq_job_from_other_class,
+        newer_sidekiq_job_from_same_class_and_resource_id
+      ]
+    )
+  end
+
+  describe "#perform" do
+    it "deduplicates the webhooks" do
+      expect(older_sidekiq_job_from_same_class_and_resource_id).to receive(:delete)
+      expect(newer_sidekiq_job_from_same_class_and_resource_id).not_to receive(:delete)
+      expect(sidekiq_job_from_same_class_and_different_resource_id).not_to receive(:delete)
+      expect(sidekiq_job_from_other_class).not_to receive(:delete)
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
closes #2844 

## Contexte

Lorsqu'on fait un changement sur un rdv collectif - par exemple si on change son statut - on reçoit autant de webhooks qu'il y a de participants pour ce rdv. Or pour certains rdvs, comme par exemple pour certaines ALI du 93, il peut y avoir une centaine de participants aux rdvs. 
Le traitement de ces webhooks via la classe `InboundWebhooks::RdvSolidarites::ProcessRdvJob` va en plus être assez long puisqu'on va chercher à retrouver chaque participation aux rdvs: https://github.com/gip-inclusion/rdv-insertion/blob/115c8176052d217cc2ba976e2f3dbaed8903a3df/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb#L155

Du coup, comme ces jobs sont [lockés](https://github.com/gip-inclusion/rdv-insertion/blob/staging/app/jobs/concerns/locked_jobs.rb) pour qu'il ne puisse y avoir qu'un job à la fois pour un même rdv, on va se retrouver avec 99 jobs (on prend un cas où il y a 100 participants) qui auront levé une erreur `WithAdvisoryLock::FailedToAcquireLock` et qui se retrouveront dans le retry set de Sidekiq. Comme un job prend du temps à s'exécuter, les retry vont encore lever une erreur et on se retrouver avec un retry set inondé de ces jobs;

## Précédente amélioration

Dans #2463 j'avais fait en sorte de ne pas exécuter les jobs qui process des webhooks antérieurs à ceux déjà processés. Seulement cela n'est pas suffisant, puisque si jamais les jobs s'exécutent dans l'ordre où on les a reçu, ils s'exécuteront quand même tous.

## Nouvelle solution

### Nouveau `on_lock_failure` hook 

J'introduis la possibilité d'implémenter un hook `on_lock_failure` pour les classes lockés qui incluent le concern `LockedJobs`. Cette méthode implémenté au niveau de la classe en question est appelé lorsque l'erreur `WithAdvisoryLock::FailedToAcquireLock` est levé. 
J'implémente donc une méthode `on_lock_failure` au niveau du `InboundWebhooks::RdvSolidarites::ProcessRdvJob`. 
Cette méthode - qui prend en arguments les arguments d'entrée du job - va enqueue un nouveau job `DeduplicateRdvSolidaritesWebhooksFromRetrySetJob` qui prend en entrée le nom de la classe et l'id de la ressource.

## `DeduplicateRdvSolidaritesWebhooksFromRetrySetJob` 

Ce job va itérer sur tous les jobs dans le retry set et recupérer tous ceux qui corresponde à la classe en question pour l'id en question. On va alors récupérer le dernier job qui a été enqueued (en regardant le timestamp), garder celui-là et supprimer les autres. Ces jobs étant idempotent, processer le dernier seulement suffit pour être synchro avec rdv-sp.

### `RdvSolidaritesWebhookJobWrapper`

Il est un peu complexe de manipuler directement les hash des arguments des jobs sidekiq, du coup j'introduis un PORO `RdvSolidaritesWebhookJobWrapper`, qui prend en entrée une instance de `Sidekiq::Job` et permet de récupérer facilement le timestamp et l'id de la ressource en question.

