### PR TITLE
fix(template): force csv encoding

### DIFF
--- a/app/controllers/file_configurations_controller.rb
+++ b/app/controllers/file_configurations_controller.rb
@@ -20,9 +20,12 @@ class FileConfigurationsController < ApplicationController
   def edit; end
 
   def download_template
-    send_data @file_configuration.column_attributes.values.to_csv,
-              filename: "template_file_configuration.csv",
-              type: "text/csv",
+    # This line ensures the CSV is read as UTF-8
+    bom = "\uFEFF"
+    csv_data = bom + @file_configuration.column_attributes.values.to_csv
+    send_data csv_data,
+              filename: "modele-#{@file_configuration.sheet_name.parameterize}.csv",
+              type: "text/csv; charset=utf-8",
               disposition: "attachment"
   end
 


### PR DESCRIPTION
Cette PR corrige l'encodage de fichiers CSV pour que les accents soient reconnus une fois uploadé sur rdv-insertion. 

Fix https://mattermost.incubateur.net/betagouv/pl/f8ddynyibbgpzedtx5383os87a