### PR TITLE
fix(demo): make reminders work on demo env

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,22 +1,25 @@
-<% if ENV["ENVIRONMENT_NAME"] == "production" || ENV["ENVIRONMENT_NAME"] == "demo" %>
+<% if ENV["ENVIRONMENT_NAME"] == "production" %>
 monitor_webhook_activity_job:
   cron: "0 0-1,6-23 * * 1-5" # Monitor webhooks activity every hour from Monday to Friday except between 1:00 and 6:00
   class: "MonitorWebhookActivityJob"
-send_periodic_invites_job:
-  cron: "0 14 * * *" # we send recurrent invitations X days after the previous one, at 14:00
-  class: "SendPeriodicInvitesJob"
-send_invitation_reminders_job:
-  cron: "0 11 * * *" # we send reminders once a day, at 11:00
-  class: "SendInvitationRemindersJob"
-send_convocation_reminders_job:
-  cron: "0 10 * * *" # we send reminders once a day, at 10:00
-  class: "SendConvocationRemindersJob"
 notify_jobs_to_retry_on_mattermost_job:
   cron: "30 10 * * *" # we send jobs in the retry_set once a day, at 10:30
   class: "NotifyJobsToRetryOnMattermostJob"
 retrieve_and_notify_all_unavailable_creneaux_job:
   cron: "0 01 * * *" # we verify organisations creneaux availability once a day, at 01:00
   class: "Creneaux::RetrieveAndNotifyAllUnavailableCreneauxJob"
+send_periodic_invites_job:
+  cron: "0 14 * * *" # we send recurrent invitations X days after the previous one, at 14:00
+  class: "SendPeriodicInvitesJob"
+<% end %>
+
+<% if ENV["ENVIRONMENT_NAME"] == "production" || ENV["ENVIRONMENT_NAME"] == "demo" %>
+send_invitation_reminders_job:
+  cron: "0 11 * * *" # we send reminders once a day, at 11:00
+  class: "SendInvitationRemindersJob"
+send_convocation_reminders_job:
+  cron: "0 10 * * *" # we send reminders once a day, at 10:00
+  class: "SendConvocationRemindersJob"
 <% end %>
 
 upsert_global_stats_job:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,4 +1,4 @@
-<% if ENV["ENVIRONMENT_NAME"] == "production" %>
+<% if ENV["ENVIRONMENT_NAME"] == "production" || ENV["ENVIRONMENT_NAME"] == "demo" %>
 monitor_webhook_activity_job:
   cron: "0 0-1,6-23 * * 1-5" # Monitor webhooks activity every hour from Monday to Friday except between 1:00 and 6:00
   class: "MonitorWebhookActivityJob"


### PR DESCRIPTION
Cette PR fait en sorte d'activer les reminders sur l'environnement de démo conformément à ce que l'on s'est dit ici : 
https://mattermost.incubateur.net/betagouv/pl/8ykxmzw97t8giq6njd4qwtbsia
