### PR TITLE
fix(crisp): fix crisp refacto for displaying for logged_in agents only

### DIFF
--- a/app/controllers/concerns/crisp_concern.rb
+++ b/app/controllers/concerns/crisp_concern.rb
@@ -8,6 +8,6 @@ module CrispConcern
   private
 
   def set_should_display_crisp_chatbox
-    @should_display_crisp_chatbox = current_agent && !agent_impersonated? && ENV["ENABLE_CRISP"] == "true"
+    @should_display_crisp_chatbox = current_agent.present? && !agent_impersonated? && ENV["ENABLE_CRISP"] == "true"
   end
 end

--- a/spec/features/crisp_chatbox_visibility_spec.rb
+++ b/spec/features/crisp_chatbox_visibility_spec.rb
@@ -1,0 +1,38 @@
+describe "Crisp chatbox visibility", :js do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+
+  context "when user is not logged in" do
+    it "does not display the crisp chatbox" do
+      visit root_path
+      expect(page).to have_css('div[data-controller="crisp"][data-crisp-display-crisp-value="false"]')
+      expect(page).to have_no_css('script[src="https://client.crisp.chat/l.js"]', visible: :hidden)
+    end
+  end
+
+  context "when agent is logged in" do
+    before do
+      ENV["ENABLE_CRISP"] = "true"
+      setup_agent_session(agent)
+    end
+
+    it "displays the crisp chatbox" do
+      visit organisation_users_path(organisation)
+      expect(page).to have_css('div[data-controller="crisp"][data-crisp-display-crisp-value="true"]')
+      expect(page).to have_css('script[src="https://client.crisp.chat/l.js"]', visible: :hidden)
+    end
+  end
+
+  context "when agent is logged in but ENABLE_CRISP is false" do
+    before do
+      ENV["ENABLE_CRISP"] = "false"
+      setup_agent_session(agent)
+    end
+
+    it "does not display the crisp chatbox" do
+      visit organisation_users_path(organisation)
+      expect(page).to have_css('div[data-controller="crisp"][data-crisp-display-crisp-value="false"]')
+      expect(page).to have_no_css('script[src="https://client.crisp.chat/l.js"]', visible: :hidden)
+    end
+  end
+end


### PR DESCRIPTION
suite à https://github.com/gip-inclusion/rdv-insertion/pull/2843
Cela a introduit un bug qui affiche la fenêtre Crisp pour tout le monde.
J'ai ajouté un test de non regression.
C'est potentiellement une bonne idée pour les prospects et les usagers bloqués mais ca fera l'objet d'un travail dédié.