### PR TITLE
security(seed): remove password comment in seeds for staging account

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,7 @@
 
 # Les seeds de rdv-solidarités permettent de créer ces différents éléments
 # L'agent à utiliser est alors "Alain Sertion"
-  # email: "alain.sertion@rdv-insertion-demo.fr",
-  # password: "Rdvservicepublictest1!",
+  # email: "alain.sertion@rdv-insertion-demo.fr"
 # Les rdv_solidarites_organisation_id sont configurées pour match ces seeds, mais il est préférable de les vérifier
 
 if Agent.exists?(email: "alain.sertion@rdv-insertion-demo.fr")


### PR DESCRIPTION
https://github.com/gip-inclusion/rdv-insertion/issues/2694
Ce n'est pas suffisant pour variabiliser le mot de passe du compte agent de staging.
L'essentiel des changements doit se faire dans rdvsp. 
En cours [dans cette PR](https://github.com/betagouv/rdv-service-public/pull/5351).