### PR TITLE
fix(brevo): Fix the way to call Sentry.capture_message

### DIFF
--- a/app/controllers/brevo/ip_whitelist_concern.rb
+++ b/app/controllers/brevo/ip_whitelist_concern.rb
@@ -23,11 +23,12 @@ module Brevo::IpWhitelistConcern
 
     return if IP_WHITELIST_RANGES.any? { |range| IPAddr.new(range).include?(request.remote_ip) }
 
-    Sentry.capture_message("Brevo Webhook received with following non whitelisted IP", {
-                             extra: {
-                               ip: request.remote_ip
-                             }
-                           })
+    Sentry.capture_message(
+      "Brevo Webhook received with following non whitelisted IP",
+      extra: {
+        ip: request.remote_ip
+      }
+    )
     head :forbidden
   end
 end


### PR DESCRIPTION
Répare [cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/180561/?project=16&referrer=webhooks_plugin) en changeant la nature des arguments passés à la méthodes `capture_message` de Sentry sur ce concern.