### PR TITLE
fix(policy): ensure correct parcours access

### DIFF
--- a/app/controllers/users/parcours_controller.rb
+++ b/app/controllers/users/parcours_controller.rb
@@ -22,7 +22,7 @@ module Users
       return if DepartmentPolicy.new(pundit_user, current_structure).parcours?(user: @user)
 
       flash[:error] = "Votre compte ne vous permet pas d'effectuer cette action"
-      redirect_to structure_user_path(@user.id)
+      redirect_to structure_users_path
     end
 
     def set_user

--- a/app/controllers/users/parcours_controller.rb
+++ b/app/controllers/users/parcours_controller.rb
@@ -18,7 +18,11 @@ module Users
     private
 
     def ensure_has_access_to_parcours
-      authorize(current_structure, :parcours?)
+      return authorize(current_structure, :parcours?) if current_structure.is_a?(Organisation)
+      return if DepartmentPolicy.new(pundit_user, current_structure).parcours?(user: @user)
+
+      flash[:error] = "Votre compte ne vous permet pas d'effectuer cette action"
+      redirect_to structure_user_path(@user.id)
     end
 
     def set_user

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,8 +62,12 @@ module UsersHelper
     end
   end
 
-  def show_parcours?
-    policy(current_structure).parcours?
+  def show_parcours?(user:)
+    if current_structure.is_a?(Organisation)
+      policy(current_structure).parcours?
+    else
+      policy(current_structure).parcours?(user:)
+    end
   end
 
   def show_rdv_organisation_selection_for?(user, agent, department)

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -9,13 +9,12 @@ class DepartmentPolicy < ApplicationPolicy
 
   def batch_actions? = access?
 
-  def parcours?
+  def parcours?(user:)
     return false unless record.with_parcours_access?
 
-    pundit_user
-      .organisations
-      .pluck(:organisation_type)
-      .intersect?(Organisation::ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
+    user.organisations.any? do |organisation|
+      OrganisationPolicy.new(pundit_user, organisation).parcours?
+    end
   end
 
   class Scope < Scope

--- a/app/views/users/_user_tabs.html.erb
+++ b/app/views/users/_user_tabs.html.erb
@@ -9,7 +9,7 @@
       Rendez-vous
     <% end %>
   </li>
-  <% if show_parcours? %>
+  <% if show_parcours?(user:) %>
     <li class="nav-item">
       <%= link_to structure_user_parcours_path(user_id: user.id), class: "nav-link d-flex align-items-center #{tab == "parcours" ? "active" : ""}" do %>
         Parcours

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -33,7 +33,7 @@ describe "Agents can upload documents for users", :js do
 
       it "redirects right away" do
         visit department_user_parcours_path(user_id: user.id, department_id: department.id)
-        expect(page).to have_current_path(organisation_users_path(organisation))
+        expect(page).to have_current_path(department_users_path(department))
       end
     end
 
@@ -42,7 +42,7 @@ describe "Agents can upload documents for users", :js do
 
       it "redirects right away" do
         visit department_user_parcours_path(user_id: user.id, department_id: department.id)
-        expect(page).to have_current_path(organisation_users_path(organisation))
+        expect(page).to have_current_path(department_users_path(department))
       end
     end
 

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -74,6 +74,36 @@ describe "Agents can upload documents for users", :js do
       end
     end
 
+    context "on a user that only belongs to organisations without parcours access" do
+      let!(:organisation) do
+        create(:organisation, organisation_type: "siae", name: "Asso1", agents: organisation_agents,
+                              department: department)
+      end
+
+      let(:other_organisation) do
+        create(:organisation, organisation_type: "siae", name: "Asso2", agents: organisation_agents,
+                              department: department)
+      end
+
+      # User doesn't belong to this org, but agent does
+      let!(:yet_another_organisation) do
+        create(:organisation, organisation_type: "france_travail", name: "FT", agents: organisation_agents,
+                              department: department)
+      end
+
+      let(:department) { create(:department, number: "26", parcours_enabled: true) }
+
+      it "cannot see the parcours tab" do
+        visit department_user_path(id: user.id, department_id: department.id)
+        expect(page).to have_no_content("Parcours")
+      end
+
+      it "cannot access parcours tab manually" do
+        visit department_user_parcours_path(user_id: user.id, department_id: department.id)
+        expect(page).to have_content("Votre compte ne vous permet pas d'effectuer cette action")
+      end
+    end
+
     it "can upload a file" do
       visit organisation_user_path(organisation_id: organisation.id, id: user.id)
       expect(page).to have_content("Parcours")


### PR DESCRIPTION
Cette PR fait en sorte de pouvoir faire varier les droits d'accès à l'onglet parcours en y accédant depuis la page d'un département et ce en fonction de l'usager pour lequel on souhaite afficher le parcours.

## La règle

Plus concrètement, pour afficher l'onglet parcours, il faut réunir les conditions suivantes :  
- Que le parcours soit activé sur le département
- Qu'au moins une orga associée à l'usager soit : 
  - de type valide (france_travail, cd, délégataire, etc)
  - et que l'agent y ait accès
  
## Qu'est ce que ça change 

Avant il fallait seulement que : l'agent fasse partie d'une organisation pour laquelle le parcours était autorisé, et que le département ait le parcours activé

Désormais, il faut que : l'agent fasse partie d'une des organisations de l'usager dans laquelle le parcours est autorisé, et que le département ait le parcours activé

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2892