### PR TITLE
fix(tally): remove tally popup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,8 +54,6 @@ RDV_SOLIDARITES_OAUTH_APP_SECRET=development-EdtuETfEK5Lr_--kx6S_QlItIJov-iThILw
 CRISP_WEBSITE_ID=change_me
 ENABLE_CRISP=false
 
-TALLY_NEW_UPLOAD_FORM_ID=change_me
-
 # PDF Generator
 PDF_GENERATOR_URL=http://pdf-service.example.com
 PDF_GENERATOR_API_KEY=pdf_generator_api_key

--- a/app/views/user_list_uploads/invitation_attempts/index.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/index.html.erb
@@ -54,7 +54,7 @@
           </div>
           <div>
             <% if @all_invitations_attempted %>
-              <%= link_to "Terminer", @user_list_upload.structure_users_path, class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_end", data: { turbo_frame: "_top", controller: "tally", "tally-form-id": ENV["TALLY_NEW_UPLOAD_FORM_ID"], "tally-delay-in-ms": 1000, action: "click->tally#showPopup" } %>
+              <%= link_to "Terminer", @user_list_upload.structure_users_path, class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_end", data: { turbo_frame: "_top" } %>
             <% else %>
               <%= link_to "Terminer", "#", class: "btn btn-primary d-block mx-auto disabled" %>
             <% end %>

--- a/app/views/user_list_uploads/user_save_attempts/index.html.erb
+++ b/app/views/user_list_uploads/user_save_attempts/index.html.erb
@@ -61,13 +61,7 @@
                 @user_list_upload.structure_users_path,
                 class: "btn btn-blue-out #{'link-disabled' unless @all_saves_attempted}",
                 id: "rdvi_upload_users-data_end-course",
-                data: {
-                  turbo_frame: "_top",
-                  controller: "tally",
-                  "tally-form-id": ENV["TALLY_NEW_UPLOAD_FORM_ID"],
-                  "tally-delay-in-ms": 1000,
-                  action: "click->tally#showPopup"
-                }
+                data: { turbo_frame: "_top" }
               )
             %>
           </div>


### PR DESCRIPTION
Cette PR enlève les références à la popup Tally se trouvant à la fin du parcours d'upload. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2888