### PR TITLE
feat(notifs): make sure notifications_center isn't shown for categories with referents

### DIFF
--- a/app/controllers/concerns/notification_center_concern.rb
+++ b/app/controllers/concerns/notification_center_concern.rb
@@ -14,6 +14,7 @@ module NotificationCenterConcern
                                           .with_rsa_related_motif
                                           .joins(:category_configuration)
                                           .where(category_configuration: { organisation_id: current_organisation_id })
+                                          .where(category_configuration: { rdv_with_referents: false })
                                           .where(created_at: notifications_read_at...)
                                           # If organisation has 2 valid motif_categories it will receive 2 notifications
                                           # Any of the notifications created today may be important, not just the last
@@ -46,7 +47,9 @@ module NotificationCenterConcern
 
   def organisation_has_expected_motifs_for_notification_center?
     current_organisation
-      .motif_categories
-      .exists?(motif_category_type: MotifCategory::RSA_RELATED_TYPES)
+      .category_configurations
+      .where(rdv_with_referents: false)
+      .joins(:motif_category)
+      .exists?(motif_categories: { motif_category_type: MotifCategory::RSA_RELATED_TYPES })
   end
 end

--- a/app/controllers/notification_center_controller.rb
+++ b/app/controllers/notification_center_controller.rb
@@ -32,6 +32,7 @@ class NotificationCenterController < ApplicationController
                                  .joins(:category_configuration)
                                  .preload(category_configuration: :motif_category)
                                  .where(category_configuration: { organisation_id: current_organisation_id })
+                                 .where(category_configuration: { rdv_with_referents: false })
                                  .with_rsa_related_motif
                                  .with_pending_invitations
                                  .order(created_at: :desc)

--- a/app/jobs/creneaux/store_all_number_of_creneaux_available_job.rb
+++ b/app/jobs/creneaux/store_all_number_of_creneaux_available_job.rb
@@ -3,7 +3,7 @@ module Creneaux
     def perform
       CategoryConfiguration
         .joins(:organisation)
-        .where(organisations: { archived_at: nil })
+        .where(rdv_with_referents: false, organisations: { archived_at: nil })
         .find_each do |category_configuration|
         Creneaux::StoreNumberOfCreneauxAvailableJob.perform_later(category_configuration.id)
       end

--- a/spec/features/agent_can_read_notifications_spec.rb
+++ b/spec/features/agent_can_read_notifications_spec.rb
@@ -74,6 +74,21 @@ describe "Agents can read notifications", :js do
     end
   end
 
+  context "category configuration has rdv_with_referents set to true" do
+    let!(:category_configuration) do
+      create(:category_configuration, organisation: organisation, motif_category: motif_category, rdv_with_referents: true)
+    end
+
+    before do
+      setup_agent_session(agent)
+      visit organisation_users_path(organisation)
+    end
+
+    it "doesn't show notification center" do
+      expect(page).to have_no_css("#btn-notification-center")
+    end
+  end
+
   context "agent has notifications but the last one is not important" do
     let!(:creneau_availability) do
       create(:creneau_availability,

--- a/spec/features/agent_can_read_notifications_spec.rb
+++ b/spec/features/agent_can_read_notifications_spec.rb
@@ -76,7 +76,8 @@ describe "Agents can read notifications", :js do
 
   context "category configuration has rdv_with_referents set to true" do
     let!(:category_configuration) do
-      create(:category_configuration, organisation: organisation, motif_category: motif_category, rdv_with_referents: true)
+      create(:category_configuration, organisation: organisation, motif_category: motif_category,
+                                      rdv_with_referents: true)
     end
 
     before do


### PR DESCRIPTION
Cette PR fait en sorte de limiter l'accès au centre de notifications aux seules organisations qui traite de motifs categories valides et dont les configurations sont sans référents

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2875