### PR TITLE
fix(migration): Override statement timeout for sms providers migration

### DIFF
--- a/db/migrate/20250512150409_add_sms_providers_to_sendables.rb
+++ b/db/migrate/20250512150409_add_sms_providers_to_sendables.rb
@@ -1,4 +1,7 @@
 class AddSmsProvidersToSendables < ActiveRecord::Migration[8.0]
+  set_lock_timeout(60_000)
+  set_statement_timeout(120_000)
+
   def change
     add_column :invitations, :sms_provider, :string
     add_column :notifications, :sms_provider, :string


### PR DESCRIPTION
La migration qui ajoute les `sms_provider` a fail en prod à cause d'un statement timeout.
Je set un statement timeout plus long sur cette migration pour la faire passer.
⚠️ **Il faudra donc merger en prod en période creuse en soirée**.