### PR TITLE
api(tags): tags are not applied when api is called for user creation

### DIFF
--- a/app/services/users/upsert.rb
+++ b/app/services/users/upsert.rb
@@ -9,6 +9,10 @@ module Users
       @user = find_or_initialize_user.user
       result.user = @user
       filter_origin_attributes if @user.persisted?
+
+      # Assign organisation first to ensure dependent attributes can access organisation context (tags)
+      assign_organisation_if_new_user
+
       @user.assign_attributes(@user_attributes.except(*restricted_user_attributes))
       save_user!
     end
@@ -31,6 +35,12 @@ module Users
 
     def filter_origin_attributes
       @user_attributes.except!(*User::ORIGIN_ATTRIBUTES)
+    end
+
+    def assign_organisation_if_new_user
+      return if @user.persisted?
+
+      @user.organisations = [@organisation]
     end
 
     def save_user!


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2932

On a besoin d'avoir accès à l'organisation **avant** l'assignation des attributs.
Sans cela la méthode `find_tag_in_organisations` du concern `User::Tags` ne peut pas trouver les tags dans l'organisation.
On a pas eu de problèmes pour les référents car il n'y a pas de vérification de ce type pour les référents (à mettre en place ?)
J'ajoute un test de non regression.