### PR TITLE
fix(stats): change monthly stat schedule

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -22,12 +22,18 @@ send_convocation_reminders_job:
   class: "SendConvocationRemindersJob"
 <% end %>
 
+# We compute global stats once a week, the saturday at 22:00
 upsert_global_stats_job:
-  cron: "0 22 * * 6" # we compute global stats once a week, the saturday at 22:00
+  cron: "0 22 * * 6" 
   class: "Stats::GlobalStats::UpsertStatsJob"
+
+# We compute monthly stats once a week on Friday at 22:00
+# This task takes several hours to run, so we schedule it for the start of the weekend
+# to avoid overlapping with the week load
 upsert_monthly_stats_job:
-  cron: "0 22 * * 7" # we compute monthly stats once a week, the sunday at 22:00
+  cron: "0 22 * * 5" 
   class: "Stats::MonthlyStats::UpsertStatsJob"
+
 refresh_out_of_date_follow_up_statuses_job:
   cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "RefreshOutOfDateFollowUpStatusesJob"


### PR DESCRIPTION
Cette PR déplace l'horaire de traitement des stats mensuelles en début de weekend plutôt que le dimanche à 22h. 

Ce changement a été fait car nous avons remarqué que les stats lancée à 22h le dimanche soir se terminent désormais vers 11h le lundi matin (soit un temps de traitement de 13h et un overlap sur des horaires d'activité). 

En déplaçant ce job au Vendredi soir on se donne une marge plus que suffisante qui laissera encore plusieurs années de traitement avant d'overlap à nouveau sur les heures de semaines (la durée de traitement est malheureusement encore fonction du volume de données).

Pour information l'impact sur la DB est assez majeur, d'où la nécessité de déplacer ce job en dehors des heures de traffic : 
<img width="700" alt="db" src="https://github.com/user-attachments/assets/64cb8495-3379-48be-b579-697bf0e47df4" />