### PR TITLE
feat(upload): Add status to user rows before invitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ dump.rdb
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+.cursor/

--- a/app/helpers/user_list_upload/invitation_attempts_helper.rb
+++ b/app/helpers/user_list_upload/invitation_attempts_helper.rb
@@ -45,7 +45,7 @@ module UserListUpload::InvitationAttemptsHelper
   end
 
   def user_invitable_by_formats_sentence(user_row)
-    user_row.user_invitable_by_formats.map do |format|
+    user_row.invitable_by_formats.map do |format|
       I18n.t("activerecord.attributes.invitation.formats.#{format}")
     end.to_sentence(last_word_connector: " ou ", two_words_connector: " ou ")
   end
@@ -65,7 +65,7 @@ module UserListUpload::InvitationAttemptsHelper
   end
 
   def tooltip_content_for_user_row_before_invitation_not_invitable(user_row)
-    case user_row.user_invitable_by_formats
+    case user_row.invitable_by_formats
     when []
       safe_join(
         [
@@ -129,7 +129,7 @@ module UserListUpload::InvitationAttemptsHelper
 
   def disable_invitation_for_user_row?(user_row)
     !user_row.invitable? ||
-      selected_invitation_formats(user_row.user_list_upload_id).none? { |format| user_row.invitable_by?(format) }
+      selected_invitation_formats(user_row.user_list_upload_id).none? { |format| user_row.can_be_invited_through?(format) }
   end
 
   def invitation_format_checked?(format, user_list_upload_id)

--- a/app/helpers/user_list_upload/invitation_attempts_helper.rb
+++ b/app/helpers/user_list_upload/invitation_attempts_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module UserListUpload::InvitationAttemptsHelper
   def user_row_background_color_before_invitation(user_row)
     "background-light" if user_row.selected_for_invitation?
@@ -5,15 +6,86 @@ module UserListUpload::InvitationAttemptsHelper
 
   def user_row_before_invitation_badge_class(user_row)
     {
-      already_invited: "background-very-light-grey text-very-dark-grey",
-      not_invited: "background-blue-light text-mid-blue"
+      already_invited: "alert-success",
+      invitable: "background-blue-light text-mid-blue",
+      not_invitable: "alert-danger"
     }[user_row.before_invitation_status]
   end
 
   def user_row_before_invitation_status_text(user_row)
-    return "Non invité" if user_row.before_invitation_status == :not_invited
+    case user_row.before_invitation_status
+    when :already_invited
+      "Invité le #{user_row.previously_invited_at.strftime('%d/%m/%Y')}"
+    when :invitable
+      "Non invité"
+    when :not_invitable
+      "Ne peut être invité"
+    end
+  end
 
-    "Invité le #{user_row.previously_invited_at.strftime('%d/%m/%Y')}"
+  def tooltip_content_for_user_row_before_invitation(user_row)
+    case user_row.before_invitation_status
+    when :already_invited
+      tooltip_content_for_user_row_before_invitation_already_invited(user_row)
+    when :invitable
+      tooltip_content_for_user_row_before_invitation_invitable(user_row)
+    when :not_invitable
+      tooltip_content_for_user_row_before_invitation_not_invitable(user_row)
+    end
+  end
+
+  def tooltip_content_for_user_row_before_invitation_invitable(user_row)
+    safe_join(
+      [
+        tag.b("Cette usager n'a pas encore été invité sur cette catégorie de suivi."),
+        tag.br,
+        "Vous pouvez l'inviter par #{user_invitable_by_formats_sentence(user_row)}."
+      ]
+    )
+  end
+
+  def user_invitable_by_formats_sentence(user_row)
+    user_row.user_invitable_by_formats.map do |format|
+      I18n.t("activerecord.attributes.invitation.formats.#{format}")
+    end.to_sentence(last_word_connector: " ou ", two_words_connector: " ou ")
+  end
+
+  def tooltip_content_for_user_row_before_invitation_already_invited(user_row)
+    content_array = [
+      tag.b("Cette usager a déjà été invité sur cette catégorie" \
+            " le #{user_row.previously_invited_at.strftime('%d/%m/%Y')}.")
+    ]
+
+    if user_row.invited_less_than_24_hours_ago?
+      content_array << tag.br
+      content_array << "Attendez 24 heures pour pouvoir lui renvoyer une invitation."
+    end
+
+    safe_join(content_array)
+  end
+
+  def tooltip_content_for_user_row_before_invitation_not_invitable(user_row)
+    case user_row.user_invitable_by_formats
+    when []
+      safe_join(
+        [
+          tag.b("Cette usager ne peut pas être invité."),
+          tag.br,
+          "Il faut au moins une donnée de contact (téléphone, email ou adresse postale)."
+        ]
+      )
+    when %w[postal]
+      safe_join(
+        [
+          tag.b("Cette usager ne peut pas être invité numériquement."),
+          tag.br,
+          "Il faut au moins un numéro de téléphone ou une adresse email."
+        ]
+      )
+    # should never happen
+    else
+      "Cette usager ne peut pas être invité."
+    end
   end
 
   def user_row_status_after_invitation_text(after_invitation_status)
@@ -56,7 +128,8 @@ module UserListUpload::InvitationAttemptsHelper
   end
 
   def disable_invitation_for_user_row?(user_row)
-    selected_invitation_formats(user_row.user_list_upload_id).none? { |format| user_row.invitable_by?(format) }
+    !user_row.invitable? ||
+      selected_invitation_formats(user_row.user_list_upload_id).none? { |format| user_row.invitable_by?(format) }
   end
 
   def invitation_format_checked?(format, user_list_upload_id)
@@ -72,3 +145,4 @@ module UserListUpload::InvitationAttemptsHelper
     %w[sms email]
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/user_list_upload/user_list_upload_helper.rb
+++ b/app/helpers/user_list_upload/user_list_upload_helper.rb
@@ -91,18 +91,18 @@ module UserListUpload::UserListUploadHelper
     end
   end
 
-  def tooltip_for_user_row(user_row)
+  def tooltip_for_user_row_before_save(user_row)
     if user_row.user_errors.any?
       tooltip_errors(
         title: "Erreurs des données du dossier",
         errors: user_row.user_errors.full_messages
       )
     else
-      tooltip(content: tooltip_content_for_user_row(user_row))
+      tooltip(content: tooltip_content_for_user_row_before_save(user_row))
     end
   end
 
-  def tooltip_content_for_user_row(user_row)
+  def tooltip_content_for_user_row_before_save(user_row)
     tooltip_content_array = []
     tooltip_content_array << tooltip_content_for_user_row_archived(user_row) if user_row.archived?
     tooltip_content_array << tooltip_content_for_user_row_follow_up_closed if user_row.matching_user_follow_up_closed?

--- a/app/javascript/stylesheets/components/_button.scss
+++ b/app/javascript/stylesheets/components/_button.scss
@@ -119,3 +119,7 @@ button, input[type="button"] {
   font-size: 0.85em;
   font-weight: 600;
 }
+
+button:disabled {
+  cursor: not-allowed !important;
+}

--- a/app/jobs/user_list_upload/invite_users_job.rb
+++ b/app/jobs/user_list_upload/invite_users_job.rb
@@ -8,7 +8,7 @@ class UserListUpload::InviteUsersJob < ApplicationJob
 
     user_collection.user_rows_selected_for_invitation.each do |user_row|
       invitation_formats.each do |format|
-        user_row.invite_user_by(format) if user_row.invitable_by?(format)
+        user_row.invite_user_by(format) if user_row.can_be_invited_through?(format)
       end
     end
   end

--- a/app/models/concerns/user_list_upload/user_row/status.rb
+++ b/app/models/concerns/user_list_upload/user_row/status.rb
@@ -24,7 +24,7 @@ module UserListUpload::UserRow::Status
   def before_invitation_status
     return :already_invited if previously_invited?
 
-    :not_invited
+    invitable? ? :invitable : :not_invitable
   end
 
   def after_invitation_status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,10 @@ class User < ApplicationRecord
     can_be_invited_through?("sms") || can_be_invited_through?("email")
   end
 
+  def invitable_by_formats
+    %w[sms email postal].select { |format| can_be_invited_through?(format) }
+  end
+
   def soft_delete
     update_columns(
       last_name: "[Usager supprimé]",

--- a/app/models/user_list_upload/user_row.rb
+++ b/app/models/user_list_upload/user_row.rb
@@ -24,7 +24,7 @@ class UserListUpload::UserRow < ApplicationRecord
   delegate :motif_category, :organisations, to: :user_list_upload, prefix: true
   delegate :department, :department_number, :department_id, :restricted_user_attributes, :department_level?,
            to: :user_list_upload
-  delegate :valid?, :errors, to: :user, prefix: true
+  delegate :valid?, :errors, :invitable_by_formats, to: :user, prefix: true
   delegate :no_organisation_to_assign?, to: :last_user_save_attempt, allow_nil: true
 
   squishes :first_name, :last_name, :affiliation_number, :department_internal_id, :address
@@ -218,7 +218,7 @@ class UserListUpload::UserRow < ApplicationRecord
   end
 
   def invitable_by?(format)
-    invitable? && user.can_be_invited_through?(format)
+    user.can_be_invited_through?(format)
   end
 
   def invite_user_by(format)

--- a/app/models/user_list_upload/user_row.rb
+++ b/app/models/user_list_upload/user_row.rb
@@ -24,7 +24,9 @@ class UserListUpload::UserRow < ApplicationRecord
   delegate :motif_category, :organisations, to: :user_list_upload, prefix: true
   delegate :department, :department_number, :department_id, :restricted_user_attributes, :department_level?,
            to: :user_list_upload
-  delegate :valid?, :errors, :invitable_by_formats, to: :user, prefix: true
+  delegate :valid?, :errors, to: :user, prefix: true
+  # without prefix
+  delegate :can_be_invited_through?, :invitable_by_formats, to: :user
   delegate :no_organisation_to_assign?, to: :last_user_save_attempt, allow_nil: true
 
   squishes :first_name, :last_name, :affiliation_number, :department_internal_id, :address
@@ -217,17 +219,13 @@ class UserListUpload::UserRow < ApplicationRecord
     end
   end
 
-  def invitable_by?(format)
-    user.can_be_invited_through?(format)
-  end
-
   def invite_user_by(format)
     UserListUpload::InvitationAttempt.create_from_row(user_row: self, format:)
   end
 
   def invite_user
-    invite_user_by("email") if invitable_by?("email")
-    invite_user_by("sms") if invitable_by?("sms")
+    invite_user_by("email") if can_be_invited_through?("email")
+    invite_user_by("sms") if can_be_invited_through?("sms")
   end
 
   def invitation_attempted?

--- a/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
@@ -40,7 +40,7 @@
       <button type="submit"
               id="rdvi_upload_users-invit_user-download-<%= user_row.id %>"
               data-action="click->invitation-button#generatePostalInvitation"
-              <%= "disabled" unless user_row.invitable_by?("postal") %>>
+              <%= "disabled" unless user_row.can_be_invited_through?("postal") %>>
         <i class="ri-download-line"></i>
       </button>
   </td>

--- a/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_user_row_before_invitation.html.erb
@@ -22,7 +22,9 @@
 
   <td class="border-light">
     <div class="d-flex justify-content-between align-items-center">
-      <span class="badge rounded-pill <%= user_row_before_invitation_badge_class(user_row) %>">
+      <span class="badge rounded-pill <%= user_row_before_invitation_badge_class(user_row) %>"
+            <%= tooltip(content: tooltip_content_for_user_row_before_invitation(user_row)) %>
+      >
         <%= user_row_before_invitation_status_text(user_row) %>
       </span>
     </div>
@@ -37,7 +39,8 @@
   >
       <button type="submit"
               id="rdvi_upload_users-invit_user-download-<%= user_row.id %>"
-              data-action="click->invitation-button#generatePostalInvitation">
+              data-action="click->invitation-button#generatePostalInvitation"
+              <%= "disabled" unless user_row.invitable_by?("postal") %>>
         <i class="ri-download-line"></i>
       </button>
   </td>

--- a/app/views/user_list_uploads/user_list_uploads/_user_row.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_row.html.erb
@@ -28,7 +28,7 @@
   <td>
     <div class="d-flex justify-content-between align-items-center">
       <span class="badge rounded-pill <%= user_row_status_badge_class(user_row) %>"
-        <%= tooltip_for_user_row(user_row) %>
+        <%= tooltip_for_user_row_before_save(user_row) %>
       >
         <%= user_row_status_text(user_row.before_user_save_status) %>
         <%= user_row_icon_for_status(user_row.user_errors) %>

--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -981,7 +981,8 @@ describe "Agents can upload user list", :js do
       create(:user, first_name: "Hernan", last_name: "Crespo", email: "hernan@crespo.com", phone_number: "+33698943255")
     end
     let!(:christian) do
-      create(:user, first_name: "Christian", last_name: "Vieri", email: "christian@vieri.com", phone_number: nil)
+      create(:user, first_name: "Christian", last_name: "Vieri", email: "christian@vieri.com", phone_number: nil,
+                    address: nil)
     end
     let!(:user_list_upload) do
       create(
@@ -1009,6 +1010,23 @@ describe "Agents can upload user list", :js do
       # expect rows to be checked
       expect(find("input[type='checkbox'][data-user-row-id='#{hernan_row.id}']")).to be_checked
       expect(find("input[type='checkbox'][data-user-row-id='#{christian_row.id}']")).to be_checked
+
+      # status and tooltips
+      hernan_row_element = find("tr", text: "Crespo")
+      within(hernan_row_element) do
+        expect(page).to have_content("Non invité")
+        data_tooltip_content = hernan_row_element.find(".badge.rounded-pill")["data-tooltip-content"]
+        expect(data_tooltip_content).to include("Cette usager n'a pas encore été invité sur cette catégorie de suivi.")
+        expect(data_tooltip_content).to include("Vous pouvez l'inviter par SMS, email ou courrier.")
+      end
+
+      christian_row_element = find("tr", text: "Vieri")
+      within(christian_row_element) do
+        expect(page).to have_content("Non invité")
+        data_tooltip_content = christian_row_element.find(".badge.rounded-pill")["data-tooltip-content"]
+        expect(data_tooltip_content).to include("Cette usager n'a pas encore été invité sur cette catégorie de suivi.")
+        expect(data_tooltip_content).to include("Vous pouvez l'inviter par email.")
+      end
 
       expect(page).to have_button("Envoyer les invitations")
 
@@ -1103,6 +1121,13 @@ describe "Agents can upload user list", :js do
 
         # hernan
         expect(page).to have_content("Invité le 24/01/2025")
+        hernan_row_element = find("tr", text: "Crespo")
+        within(hernan_row_element) do
+          data_tooltip_content = hernan_row_element.find(".badge.rounded-pill")["data-tooltip-content"]
+          expect(data_tooltip_content).to include("Cette usager a déjà été invité sur cette catégorie le 24/01/2025.")
+          expect(data_tooltip_content).not_to include("Attendez 24 heures pour pouvoir lui renvoyer une invitation.")
+        end
+
         # christian
         expect(page).to have_content("Non invité")
 
@@ -1121,6 +1146,13 @@ describe "Agents can upload user list", :js do
 
           # hernan
           expect(page).to have_content("Invité le 29/01/2025")
+          hernan_row_element = find("tr", text: "Crespo")
+          within(hernan_row_element) do
+            data_tooltip_content = hernan_row_element.find(".badge.rounded-pill")["data-tooltip-content"]
+            expect(data_tooltip_content).to include("Cette usager a déjà été invité sur cette catégorie le 29/01/2025.")
+            expect(data_tooltip_content).to include("Attendez 24 heures pour pouvoir lui renvoyer une invitation.")
+          end
+
           # christian
           expect(page).to have_content("Non invité")
 

--- a/spec/models/user_list_upload/user_row_spec.rb
+++ b/spec/models/user_list_upload/user_row_spec.rb
@@ -422,9 +422,26 @@ describe UserListUpload::UserRow do
         expect(user_row.before_invitation_status).to eq(:already_invited)
       end
 
-      it "returns :not_invited when not previously invited" do
-        allow(user_row).to receive(:previously_invited?).and_return(false)
-        expect(user_row.before_invitation_status).to eq(:not_invited)
+      context "when not previously invited" do
+        context "when invitable" do
+          before do
+            allow(user_row).to receive(:invitable?).and_return(true)
+          end
+
+          it "returns :invitable" do
+            expect(user_row.before_invitation_status).to eq(:invitable)
+          end
+        end
+
+        context "when not invitable" do
+          before do
+            allow(user_row).to receive(:invitable?).and_return(false)
+          end
+
+          it "returns :not_invitable" do
+            expect(user_row.before_invitation_status).to eq(:not_invitable)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
closes #2917 

Pour m'adapter aux nouveaux [statuts](https://www.figma.com/design/I6oGJ4ZliyAhCIZ3Dkahym/02_Upload-de-fichiers-usagers?node-id=1966-33170&t=SjnAQ5uGEeth8ME6-0) et wording mentionnés dans le figma, j'ajoute un nouveau statut à la méthode `user_rows#before_invitation_status` et j'ajoute des méthods au helper `UserListUpload::InvitationAttemptsHelper` pour gérer les différents wording.