### PR TITLE
fix(invitations): Filter follow ups by status for periodic invites

### DIFF
--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -6,6 +6,7 @@ class SendPeriodicInvitesJob < ApplicationJob
       .joins(:invitations)
       .preload(invitations: [{ organisations: :category_configurations }, :user])
       .where(invitations: Invitation.candidates_for_periodic_invite)
+      .where.not(status: %w[rdv_pending closed])
       .distinct
       .find_each do |follow_up|
       send_invite(follow_up)

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -14,7 +14,7 @@ describe SendPeriodicInvitesJob do
     end
 
     let!(:motif_category) { create(:motif_category) }
-    let!(:follow_up) { create(:follow_up, motif_category: motif_category) }
+    let!(:follow_up) { create(:follow_up, motif_category: motif_category, status: "invitation_pending") }
     let!(:invitation) do
       create(
         :invitation,

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -138,5 +138,15 @@ describe SendPeriodicInvitesJob do
         subject
       end
     end
+
+    context "when the follow up is closed" do
+      let!(:follow_up) { create(:follow_up, closed_at: Time.zone.today) }
+
+      it "does not send periodic invites" do
+        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Maintenant que les jobs fail quand l'invitation périodique ne s'envoie pas on a plus de retours d'erreurs.
Ce fix corrige [cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/183834/?environment=production&project=16&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=2) sur sentry qui empêche l'envoi d'invitations que la personne a déjà un rdv à venir.
Je ne prends donc pas les suivis qui ont pour statut `rdv_pending` pour les suivis sur lesquels on itère. J'en profite pour enlever les suivis clôturés aussi.