### PR TITLE
feat(participation): display agent creator info in tooltip

### DIFF
--- a/app/blueprints/participation_blueprint.rb
+++ b/app/blueprints/participation_blueprint.rb
@@ -1,5 +1,11 @@
 class ParticipationBlueprint < ApplicationBlueprint
   identifier :id
-  fields :status, :created_by, :created_at, :starts_at
+  fields :status, :created_at, :starts_at, :created_by_type, :created_by_agent_prescripteur,
+         :rdv_solidarites_created_by_id
   association :user, blueprint: UserBlueprint
+
+  # Retrocompatibility with the old API format for created_by
+  field :created_by do |participation, _|
+    participation.created_by_type.downcase
+  end
 end

--- a/app/blueprints/participation_blueprint.rb
+++ b/app/blueprints/participation_blueprint.rb
@@ -1,7 +1,6 @@
 class ParticipationBlueprint < ApplicationBlueprint
   identifier :id
-  fields :status, :created_at, :starts_at, :created_by_type, :created_by_agent_prescripteur,
-         :rdv_solidarites_created_by_id
+  fields :status, :created_at, :starts_at
   association :user, blueprint: UserBlueprint
 
   # Retrocompatibility with the old API format for created_by

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -58,8 +58,14 @@ module ParticipationsHelper
       "prescripteur" => "un prescripteur",
       "agent" => "un agent",
       "user" => "l'usager"
-    }[participation.created_by]
+    }[participation.created_by_type]
 
-    "Rendez-vous pris par #{author} le #{participation.created_at.strftime('%d/%m/%Y à %H:%M')}"
+    author_info = if participation.created_by_agent_prescripteur?
+                    " (#{participation.created_by.full_name})"
+                  else
+                    ""
+                  end
+
+    "Rendez-vous pris par #{author}#{author_info} le #{participation.created_at.strftime('%d/%m/%Y à %H:%M')}"
   end
 end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -56,12 +56,12 @@ module ParticipationsHelper
   def participation_created_by_tooltip_content(participation)
     author = {
       "prescripteur" => "un prescripteur",
-      "agent" => "un agent",
+      "agent" => "l'agent",
       "user" => "l'usager"
     }[participation.created_by_type]
 
     author_info = if participation.created_by_agent?
-                    " (#{participation.created_by})"
+                    " #{participation.created_by} (#{participation.created_by.email})"
                   else
                     ""
                   end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -60,8 +60,8 @@ module ParticipationsHelper
       "user" => "l'usager"
     }[participation.created_by_type]
 
-    author_info = if participation.created_by_agent_prescripteur?
-                    " (#{participation.created_by.full_name})"
+    author_info = if participation.created_by_agent?
+                    " (#{participation.created_by})"
                   else
                     ""
                   end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -54,18 +54,18 @@ module ParticipationsHelper
   end
 
   def participation_created_by_tooltip_content(participation)
-    author = {
+    author_description = {
       "prescripteur" => "un prescripteur",
       "agent" => "l'agent",
       "user" => "l'usager"
     }[participation.created_by_type]
 
-    author_info = if participation.created_by_agent?
-                    " #{participation.created_by} (#{participation.created_by.email})"
-                  else
-                    ""
-                  end
+    author_details = if participation.created_by_agent?
+                       author = participation.created_by
+                       " #{author} (#{author.email})" if author.present?
+                     end
 
-    "Rendez-vous pris par #{author}#{author_info} le #{participation.created_at.strftime('%d/%m/%Y à %H:%M')}"
+    "Rendez-vous pris par #{author_description}#{author_details || ''}" \
+      " le #{participation.created_at.strftime('%d/%m/%Y à %H:%M')}"
   end
 end

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -169,12 +169,12 @@ module InboundWebhooks
         attributes = {
           id: existing_participation&.id,
           status: rdv_solidarites_participation.status,
-          created_by: rdv_solidarites_participation.created_by,
+          created_by_type: rdv_solidarites_participation.created_by_type,
+          rdv_solidarites_created_by_id: rdv_solidarites_participation.created_by_id,
+          created_by_agent_prescripteur: rdv_solidarites_participation.created_by_agent_prescripteur,
           user_id: user.id,
           rdv_solidarites_participation_id: rdv_solidarites_participation.id,
-          follow_up_id: follow_up_for(user).id,
-          rdv_solidarites_agent_prescripteur_id:
-            retrieve_rdv_solidarites_agent_prescripteur_id(rdv_solidarites_participation)
+          follow_up_id: follow_up_for(user).id
         }
 
         # convocable attribute can be set only once
@@ -183,16 +183,6 @@ module InboundWebhooks
         end
 
         attributes
-      end
-
-      def retrieve_rdv_solidarites_agent_prescripteur_id(rdv_solidarites_participation)
-        # Nous avons choisi de ne pas implémenter le polymorphisme des created_by de rdvs tant qu'on en a pas besoin
-        # - created_by_agent_prescripteur est un boolean qui indique
-        # si la participation a été créée par un agent prescripteur
-        # - created_by_id est l'id de l'agent qui a prescrit la participation
-        return unless rdv_solidarites_participation.created_by_agent_prescripteur
-
-        rdv_solidarites_participation.created_by_id
       end
 
       def follow_up_for(user)

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -37,6 +37,9 @@ class Participation < ApplicationRecord
   alias_method :created_by_prescripteur?, :created_by_type_prescripteur?
   alias_method :created_by_user?, :created_by_type_user?
 
+  # rdv_solidarites_created_by_id are not entirely synced
+  # with rdv-solidarités as we added them later without backfilling
+  # the data.
   def created_by
     if created_by_agent?
       Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_created_by_id)
@@ -46,7 +49,7 @@ class Participation < ApplicationRecord
   end
 
   def agent_prescripteur
-    created_by if created_by_agent_prescripteur?
+    Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_created_by_id) if created_by_agent_prescripteur?
   end
 
   def notifiable?

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -45,6 +45,10 @@ class Participation < ApplicationRecord
     end
   end
 
+  def agent_prescripteur
+    created_by if created_by_agent_prescripteur?
+  end
+
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])
   end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -8,11 +8,6 @@ class Participation < ApplicationRecord
   belongs_to :rdv
   belongs_to :follow_up
   belongs_to :user
-  belongs_to :agent_prescripteur,
-             class_name: "Agent",
-             primary_key: "rdv_solidarites_agent_id",
-             foreign_key: "rdv_solidarites_agent_prescripteur_id",
-             optional: true
 
   has_many :notifications, dependent: :destroy
   has_many :follow_up_invitations, through: :follow_up, source: :invitations
@@ -29,7 +24,7 @@ class Participation < ApplicationRecord
   after_commit :notify_user, if: :should_notify_user?, on: [:create, :update]
   after_commit :notify_external, if: :should_notify_external?, on: [:create, :update]
 
-  enum :created_by, { agent: "agent", user: "user", prescripteur: "prescripteur" }, prefix: true
+  enum :created_by_type, { agent: "Agent", user: "User", prescripteur: "Prescripteur" }, prefix: true
 
   delegate :starts_at, :motif, :lieu, :collectif?, :by_phone?, :duration_in_min,
            :rdv_solidarites_url, :rdv_solidarites_rdv_id, :instruction_for_rdv, :address,
@@ -37,6 +32,18 @@ class Participation < ApplicationRecord
   delegate :department, :department_id, to: :organisation
   delegate :phone_number_is_mobile?, :email?, to: :user
   delegate :motif_category, :orientation?, to: :follow_up
+
+  alias_method :created_by_agent?, :created_by_type_agent?
+  alias_method :created_by_prescripteur?, :created_by_type_prescripteur?
+  alias_method :created_by_user?, :created_by_type_user?
+
+  def created_by
+    if created_by_agent?
+      Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_created_by_id)
+    elsif created_by_user?
+      User.find_by(rdv_solidarites_user_id: rdv_solidarites_created_by_id)
+    end
+  end
 
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])

--- a/app/models/rdv_solidarites/participation.rb
+++ b/app/models/rdv_solidarites/participation.rb
@@ -1,7 +1,7 @@
 module RdvSolidarites
   class Participation < Base
     RECORD_ATTRIBUTES = [
-      :id, :status, :created_by, :created_by_agent_prescripteur, :created_by_id
+      :id, :status, :created_by_type, :created_by, :created_by_agent_prescripteur, :created_by_id
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 

--- a/app/services/stats/compute_rate_of_autonomous_users.rb
+++ b/app/services/stats/compute_rate_of_autonomous_users.rb
@@ -18,7 +18,7 @@ module Stats
     end
 
     def autonomous_users
-      @autonomous_users ||= @users.joins(:participations).where(participations: { created_by: "user" })
+      @autonomous_users ||= @users.joins(:participations).where(participations: { created_by_type: "User" })
     end
   end
 end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -308,11 +308,12 @@ tables:
       - rdv_id
       - status
       - rdv_solidarites_participation_id
-      - rdv_solidarites_agent_prescripteur_id
       - created_at
       - updated_at
       - follow_up_id
-      - created_by
+      - created_by_type
+      - created_by_agent_prescripteur
+      - rdv_solidarites_created_by_id
       - convocable
 
   - table_name: follow_ups

--- a/db/migrate/20250701140708_add_columns_to_participations.rb
+++ b/db/migrate/20250701140708_add_columns_to_participations.rb
@@ -1,0 +1,18 @@
+class AddColumnsToParticipations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :participations, :created_by_agent_prescripteur, :boolean, default: false
+    add_column :participations, :created_by_type, :string
+    add_column :participations, :rdv_solidarites_created_by_id, :bigint
+
+    Participation.where.not(created_by: nil).find_each do |participation|
+      participation.update!(
+        created_by_type: participation.attributes["created_by"]&.capitalize,
+        created_by_agent_prescripteur: participation.rdv_solidarites_agent_prescripteur_id.present?,
+        rdv_solidarites_created_by_id: participation.rdv_solidarites_agent_prescripteur_id
+      )
+    end
+
+    remove_column :participations, :rdv_solidarites_agent_prescripteur_id, :bigint
+    remove_column :participations, :created_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_17_131753) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_01_140708) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -413,10 +413,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_17_131753) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "follow_up_id"
-    t.string "created_by", null: false
     t.boolean "convocable", default: false, null: false
-    t.bigint "rdv_solidarites_agent_prescripteur_id"
     t.string "france_travail_id"
+    t.boolean "created_by_agent_prescripteur", default: false
+    t.string "created_by_type"
+    t.bigint "rdv_solidarites_created_by_id"
     t.index ["follow_up_id"], name: "index_participations_on_follow_up_id"
     t.index ["status"], name: "index_participations_on_status"
     t.index ["user_id", "rdv_id"], name: "index_participations_on_user_id_and_rdv_id", unique: true

--- a/docs/api/description.md
+++ b/docs/api/description.md
@@ -405,6 +405,9 @@ Ci-dessous un exemple de payload envoyé lorsqu'un rdv est créé:
         "id": 291,
         "status": "unknown",
         "created_by": "agent",
+        "created_by_type": "Agent",
+        "created_by_agent_prescripteur": false,
+        "rdv_solidarites_created_by_id": 7,
         "created_at": "2023-11-09T09:25:05.356+01:00",
         "starts_at": "2023-11-14T09:00:00.000+01:00",
         "user": {

--- a/spec/factories/participation.rb
+++ b/spec/factories/participation.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     after(:build) do |participation|
       participation.status = participation.rdv.status if participation.status.blank?
-      participation.created_by = (participation.rdv.created_by || "user") if participation.created_by.blank?
+      participation.created_by_type = (participation.rdv.created_by || "user") if participation.created_by_type.blank?
     end
   end
 end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
       if rdv.participations.blank?
         rdv.users = [create(:user)]
         rdv.participations.first.follow_up = create(:follow_up)
-        rdv.participations.first.created_by = "user"
+        rdv.participations.first.created_by_type = "User"
       end
     end
   end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -13,8 +13,10 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
   let!(:rdv_solidarites_motif_id) { 53 }
   let!(:participations_attributes) do
     [
-      { id: 998, status: "unknown", created_by: "user", user: { id: user_id1 } },
-      { id: 999, status: "unknown", created_by: "user", user: { id: user_id2 } }
+      { id: 998, status: "unknown", created_by: "user", created_by_type: "User", created_by_agent_prescripteur: false,
+        created_by_id: user_id1, user: { id: user_id1 } },
+      { id: 999, status: "unknown", created_by: "user", created_by_type: "User", created_by_agent_prescripteur: false,
+        created_by_id: user_id2, user: { id: user_id2 } }
     ]
   end
   let!(:lieu_attributes) { { id: rdv_solidarites_lieu_id, name: "DINUM", address: "20 avenue de Ségur" } }
@@ -146,22 +148,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
           {
             id: nil,
             status: "unknown",
-            created_by: "user",
+            created_by_type: "User",
+            created_by_agent_prescripteur: false,
+            rdv_solidarites_created_by_id: user_id1,
             user_id: user.id,
             rdv_solidarites_participation_id: 998,
             follow_up_id: follow_up.id,
-            convocable: false,
-            rdv_solidarites_agent_prescripteur_id: nil
+            convocable: false
           },
           {
             id: nil,
             status: "unknown",
-            created_by: "user",
+            created_by_type: "User",
+            created_by_agent_prescripteur: false,
+            rdv_solidarites_created_by_id: user_id2,
             user_id: user2.id,
             rdv_solidarites_participation_id: 999,
             follow_up_id: follow_up2.id,
-            convocable: false,
-            rdv_solidarites_agent_prescripteur_id: nil
+            convocable: false
           }
         ]
       end
@@ -323,22 +327,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                       {
                         id: nil,
                         status: "unknown",
-                        created_by: "user",
+                        created_by_type: "User",
+                        created_by_agent_prescripteur: false,
+                        rdv_solidarites_created_by_id: user_id2,
                         user_id: user2.id,
                         rdv_solidarites_participation_id: 999,
                         follow_up_id: follow_up2.id,
-                        convocable: false,
-                        rdv_solidarites_agent_prescripteur_id: nil
+                        convocable: false
                       },
                       {
                         id: nil,
                         status: "unknown",
-                        created_by: "user",
+                        created_by_type: "User",
+                        created_by_agent_prescripteur: false,
+                        rdv_solidarites_created_by_id: user_id1,
                         user_id: new_user.id,
                         rdv_solidarites_participation_id: 998,
                         follow_up_id: new_follow_up.id,
-                        convocable: false,
-                        rdv_solidarites_agent_prescripteur_id: nil
+                        convocable: false
                       }
                     ],
                     organisation_id: organisation.id,
@@ -374,12 +380,13 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   participations_attributes: [{
                     id: nil,
                     status: "unknown",
-                    created_by: "user",
+                    created_by_type: "User",
+                    created_by_agent_prescripteur: false,
+                    rdv_solidarites_created_by_id: user_id2,
                     user_id: user2.id,
                     rdv_solidarites_participation_id: 999,
                     follow_up_id: follow_up2.id,
-                    convocable: false,
-                    rdv_solidarites_agent_prescripteur_id: nil
+                    convocable: false
                   }],
                   agent_ids: [agent.id],
                   organisation_id: organisation.id,
@@ -424,12 +431,13 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   participations_attributes: [{
                     id: nil,
                     status: "unknown",
-                    created_by: "user",
+                    created_by_type: "User",
+                    created_by_agent_prescripteur: false,
+                    rdv_solidarites_created_by_id: user_id2,
                     user_id: user2.id,
                     rdv_solidarites_participation_id: 999,
                     follow_up_id: follow_up2.id,
-                    convocable: false,
-                    rdv_solidarites_agent_prescripteur_id: nil
+                    convocable: false
                   }],
                   agent_ids: [agent.id],
                   organisation_id: organisation.id,
@@ -468,11 +476,12 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
             {
               id: 2,
               status: "seen",
-              created_by: "user",
+              created_by_type: nil,
+              created_by_agent_prescripteur: nil,
+              rdv_solidarites_created_by_id: nil,
               user_id: user2.id,
               rdv_solidarites_participation_id: 999,
-              follow_up_id: follow_up2.id,
-              rdv_solidarites_agent_prescripteur_id: nil
+              follow_up_id: follow_up2.id
             },
             {
               _destroy: true,
@@ -574,22 +583,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: "User",
+                  created_by_agent_prescripteur: false,
+                  rdv_solidarites_created_by_id: user_id1,
                   user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
-                  convocable: true,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: true
                 },
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: "User",
+                  created_by_agent_prescripteur: false,
+                  rdv_solidarites_created_by_id: user_id2,
                   user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
-                  convocable: true,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: true
                 }
               ],
               organisation_id: organisation.id,
@@ -611,22 +622,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: "User",
+                  created_by_agent_prescripteur: false,
+                  rdv_solidarites_created_by_id: user_id1,
                   user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
-                  convocable: false,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: false
                 },
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: "User",
+                  created_by_agent_prescripteur: false,
+                  rdv_solidarites_created_by_id: user_id2,
                   user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
-                  convocable: false,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: false
                 }
               ]
               # Here we sort the participations by user_id to ensure the test doesn't get flaky and matches
@@ -695,22 +708,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "agent",
+                  created_by_type: nil,
+                  created_by_agent_prescripteur: nil,
+                  rdv_solidarites_created_by_id: nil,
                   user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
-                  convocable: true,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: true
                 },
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: nil,
+                  created_by_agent_prescripteur: nil,
+                  rdv_solidarites_created_by_id: nil,
                   user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
-                  convocable: false,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: false
                 }
               ],
               organisation_id: organisation.id,
@@ -735,22 +750,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                   {
                     id: nil,
                     status: "unknown",
-                    created_by: "agent",
                     user_id: user.id,
                     rdv_solidarites_participation_id: 998,
+                    created_by_type: nil,
+                    created_by_agent_prescripteur: nil,
+                    rdv_solidarites_created_by_id: nil,
                     follow_up_id: follow_up.id,
-                    convocable: false,
-                    rdv_solidarites_agent_prescripteur_id: nil
+                    convocable: false
                   },
                   {
                     id: nil,
                     status: "unknown",
-                    created_by: "user",
                     user_id: user2.id,
                     rdv_solidarites_participation_id: 999,
+                    created_by_type: nil,
+                    created_by_agent_prescripteur: nil,
+                    rdv_solidarites_created_by_id: nil,
                     follow_up_id: follow_up2.id,
-                    convocable: false,
-                    rdv_solidarites_agent_prescripteur_id: nil
+                    convocable: false
                   }
                 ],
                 organisation_id: organisation.id,
@@ -800,9 +817,11 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
         end
         let!(:participations_attributes) do
           [
-            { id: 998, status: "unknown", created_by: "agent", user: { id: user_id1 },
-              created_by_agent_prescripteur: true, created_by_id: agent.rdv_solidarites_agent_id },
-            { id: 999, status: "unknown", created_by: "user", user: { id: user_id2 } }
+            { id: 998, status: "unknown", created_by: "agent", created_by_type: "Agent",
+              created_by_agent_prescripteur: true, created_by_id: agent.rdv_solidarites_agent_id,
+              user: { id: user_id1 } },
+            { id: 999, status: "unknown", created_by: "user", created_by_type: "User",
+              created_by_agent_prescripteur: false, created_by_id: user_id2, user: { id: user_id2 } }
           ]
         end
 
@@ -815,22 +834,24 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "agent",
+                  created_by_type: "Agent",
+                  created_by_agent_prescripteur: true,
+                  rdv_solidarites_created_by_id: agent.rdv_solidarites_agent_id,
                   user_id: user.id,
                   rdv_solidarites_participation_id: 998,
                   follow_up_id: follow_up.id,
-                  convocable: true,
-                  rdv_solidarites_agent_prescripteur_id: agent.rdv_solidarites_agent_id
+                  convocable: true
                 },
                 {
                   id: nil,
                   status: "unknown",
-                  created_by: "user",
+                  created_by_type: "User",
+                  created_by_agent_prescripteur: false,
+                  rdv_solidarites_created_by_id: user_id2,
                   user_id: user2.id,
                   rdv_solidarites_participation_id: 999,
                   follow_up_id: follow_up2.id,
-                  convocable: false,
-                  rdv_solidarites_agent_prescripteur_id: nil
+                  convocable: false
                 }
               ],
               organisation_id: organisation.id,

--- a/spec/mailers/organisation_mailer_spec.rb
+++ b/spec/mailers/organisation_mailer_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe OrganisationMailer do
     end
     let(:follow_up) { create(:follow_up, motif_category_id: category_configuration.motif_category_id) }
     let(:agent_prescripteur) { create(:agent, first_name: "Jean", last_name: "Pierre") }
-    let(:participation) { create(:participation, organisation:, follow_up:, agent_prescripteur:) }
+    let(:participation) do
+      create(:participation,
+             organisation:, follow_up:, created_by_agent_prescripteur: true, created_by_id: agent_prescripteur.id)
+    end
     let!(:rdv) { create(:rdv, participations: [participation], organisation:) }
 
     it "sends the email" do

--- a/spec/mailers/organisation_mailer_spec.rb
+++ b/spec/mailers/organisation_mailer_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe OrganisationMailer do
     let(:agent_prescripteur) { create(:agent, first_name: "Jean", last_name: "Pierre") }
     let(:participation) do
       create(:participation,
-             organisation:, follow_up:, created_by_agent_prescripteur: true, created_by_id: agent_prescripteur.id)
+             organisation:, follow_up:,
+             created_by_agent_prescripteur: true,
+             rdv_solidarites_created_by_id: agent_prescripteur.rdv_solidarites_agent_id,
+             created_by_type: "agent")
     end
     let!(:rdv) { create(:rdv, participations: [participation], organisation:) }
 

--- a/spec/models/concerns/participation/france_travail_payload_spec.rb
+++ b/spec/models/concerns/participation/france_travail_payload_spec.rb
@@ -43,7 +43,7 @@ describe Participation::FranceTravailPayload, type: :concern do
     end
 
     context "when participation is not created by user" do
-      before { participation.update(created_by: "agent") }
+      before { participation.update(created_by_type: "agent") }
 
       it "returns PARTENAIRE" do
         expect(payload[:initiateur]).to eq("PARTENAIRE")

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -123,7 +123,7 @@ describe Rdv do
       let!(:participation_attributes) do
         {
           id: nil, user: user, follow_up: follow_up,
-          created_by: "agent", rdv_solidarites_participation_id: 17
+          created_by_type: "agent", rdv_solidarites_participation_id: 17
         }
       end
       let!(:rdv) { create(:rdv, participations_attributes: participation_attributes) }
@@ -141,7 +141,7 @@ describe Rdv do
       let!(:participation_attributes) do
         {
           id: nil, user: user, follow_up: follow_up,
-          created_by: "agent", rdv_solidarites_participation_id: 18
+          created_by_type: "agent", rdv_solidarites_participation_id: 18
         }
       end
       let!(:rdv_count_before) { described_class.count }
@@ -160,7 +160,7 @@ describe Rdv do
     context "when participation id is present" do
       let!(:rdv) { create(:rdv) }
       let!(:participation) { rdv.participations.first }
-      let!(:participation_attributes) { { id: participation.id, created_by: "agent" } }
+      let!(:participation_attributes) { { id: participation.id, created_by_type: "agent" } }
       let!(:participation_count_before) { Participation.count }
 
       before do
@@ -169,7 +169,7 @@ describe Rdv do
 
       it "updates the existing participation" do
         expect(Participation.count).to eq(participation_count_before)
-        expect(participation.reload.created_by).to eq("agent")
+        expect(participation.reload.created_by_type).to eq("agent")
       end
     end
 

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -78,12 +78,11 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
   end
   let!(:participation_rdv_prescrit) do
     create(:participation,
-      user: user2,
-      status: "seen",
-      rdv_solidarites_created_by_id: 123,
-      created_by_type: "Agent",
-      created_by_agent_prescripteur: true
-    )
+           user: user2,
+           status: "seen",
+           rdv_solidarites_created_by_id: 123,
+           created_by_type: "Agent",
+           created_by_agent_prescripteur: true)
   end
   let!(:first_invitation) do
     create(:invitation, user: user1, format: "email", created_at: Time.zone.parse("2022-05-21"))

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -77,7 +77,13 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
                  participations: [participation_rdv_prescrit])
   end
   let!(:participation_rdv_prescrit) do
-    create(:participation, user: user2, status: "seen", rdv_solidarites_agent_prescripteur_id: 123)
+    create(:participation,
+      user: user2,
+      status: "seen",
+      rdv_solidarites_created_by_id: 123,
+      created_by_type: "Agent",
+      created_by_agent_prescripteur: true
+    )
   end
   let!(:first_invitation) do
     create(:invitation, user: user1, format: "email", created_at: Time.zone.parse("2022-05-21"))

--- a/spec/services/stats/compute_rate_of_autonomous_users_spec.rb
+++ b/spec/services/stats/compute_rate_of_autonomous_users_spec.rb
@@ -37,7 +37,7 @@ describe Stats::ComputeRateOfAutonomousUsers, type: :service do
   let!(:rdv3) { create(:rdv, created_at: date, created_by: "agent") }
   let!(:participation3) do
     create(:participation, follow_up: follow_up3, user: user3,
-                           rdv: rdv3, created_at: date, created_by: "user")
+                           rdv: rdv3, created_at: date, created_by_type: "user")
   end
 
   # Fourth user : created 1 month ago, has been invited but has not take any rdv

--- a/spec/services/upsert_record_spec.rb
+++ b/spec/services/upsert_record_spec.rb
@@ -14,7 +14,7 @@ describe UpsertRecord, type: :service do
           {
             id: nil,
             status: "unknown",
-            created_by: created_by,
+            created_by_type: created_by_type,
             user_id: user_id,
             rdv_solidarites_participation_id: 998,
             follow_up_id: follow_up.id
@@ -31,7 +31,7 @@ describe UpsertRecord, type: :service do
     let!(:rdv_solidarites_rdv_id) { 12 }
     let!(:rdv_solidarites_attributes) do
       { id: 12, starts_at: starts_at, duration_in_min: duration_in_min,
-        status: status, created_by: created_by }
+        status: status, created_by_type: created_by_type }
     end
     let!(:user) { create(:user, id: user_id) }
     let!(:follow_up) { create(:follow_up) }
@@ -40,7 +40,7 @@ describe UpsertRecord, type: :service do
     let!(:starts_at) { Time.zone.parse("2021-09-08 12:00:00") }
     let!(:duration_in_min) { 45 }
     let!(:status) { "unknown" }
-    let!(:created_by) { "user" }
+    let!(:created_by_type) { "user" }
 
     describe "#call" do
       context "when the record exists" do
@@ -60,7 +60,7 @@ describe UpsertRecord, type: :service do
           participation = Participation.order(:created_at).last
           expect(participation.user_id).to eq(user.id)
           expect(participation.rdv_id).to eq(rdv.id)
-          expect(participation.created_by).to eq("user")
+          expect(participation.created_by_type).to eq("user")
           expect(participation.follow_up_id).to eq(follow_up.id)
         end
 


### PR DESCRIPTION
Cette PR permet d'afficher l'information de l'agent créateur de la participation (nom + prénom + email) dans la tooltip de date de création de rdv : 

<img width="558" alt="image" src="https://github.com/user-attachments/assets/25277a68-5e0e-4c5c-979a-9e650379dda8" />

### Choix techniques 

Comme évoqué ensemble, l'idée est de se rapprocher de la solution proposée par Rdv-solidarités. 

En revanche, étant donné que nous ne souhaitons pas pour le moment stocker la donnée de `Prescripteur` -- seulement des `User` et `Agent` simples -- nous ne mettons pas en place le même polymorphisme que Rdvs. 

Du coup le changement est le suivant, nous passons du simple `enum :created_by` à 3 champs : 
- `created_by_type` -> Correspondance parfaite de rdvs (Agent, Prescripteur, User)
- `rdv_solidarites_created_by_id` -> Comme évoqué, nous stockons directement les ids rdvs, pour être explicite on préfixe ce champ
- `created_by_agent_prescripteur` -> Copie conforme de la solution mise en place par rdvs

### Implications non évoquée pendant notre call

#### Rétrocompatibilité 

Afin de rendre ce changement effectif j'ai été contraint (comme rdvs d'ailleurs) de conserver une rétrocompatibilité sur le champ `created_by` dans les blueprint destinés aux APIs. 

#### Migration de données safe

La migration de données impose de basculer la donnée provenant du champ `created_by` ayant pour valeurs `user`, `agent`, ou `prescripteur` vers le champ `created_by_type` où cette donnée est désormais stockée à la façon polymorphisme Rails (capitalize). 

Cette migration va donc :
- Créer la colonne `created_by_agent_prescripteur` - booléen équivalent à rdvs
- Créer la colonne `created_by_type` - nouvelle colonne de réception du "type"
- Créer la colonne `rdv_solidarites_created_by_id` - afin de retrouver le réel auteur et l'afficher

Puis elle va itérer sur les 500 000 participations que nous avons afin de : 
- Migrer la donnée de `created_by` vers `created_by_type`
- Utiliser la donnée de `rdv_solidarites_agent_prescripteur_id` afin de compléter les champs 
  - `created_by_agent_prescripteur` qui passe à true si la l'id est présent
  - `rdv_solidarites_created_by_id` que l'on rempli
  
Enfin, une fois complétée la migration va supprimer les 2 colonnes qui ne sont plus nécessaires : `rdv_solidarites_agent_prescripteur_id` (que l'on retrouve grace à rdv_solidarites_created_by_id) et `created_by`
  
⚠️ Sachant que la migration supprime 2 colonnes, il est possible que les requêtes qui utilisent ces champs en production soient en erreur le temps que le conteneur termine la migration (et rollout les nouveaux).

Je pense que l'impact sera relativement mitigé sachant que la suppression intervient à la toute fin de la migration. 
Pour autant, ce n'est pas une migration "safe". 
 
Ainsi si vous pensez que c'est risqué, on peut tout à fait déplacer ça dans une migration que l'on fera dans un second temps une fois que tous les conteneurs de prod auront été déployé et ne dépendront plus des colonnes supprimées. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2576