### PR TITLE
ui(letters): resize rdvsp logo on letters if its the only logo

### DIFF
--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -169,8 +169,9 @@ u {
   }
 
   // Ajustements en fonction du nombre de logos
+  &:has(div:first-child:nth-last-child(1)),
   &:has(div:first-child:nth-last-child(2)) {
-    // 2 logos
+    // 1 ou 2 logos
     div img {
       height: 50px;
     }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -296,12 +296,11 @@ CategoryConfiguration.create!(
   organisation: drome1_organisation
 )
 
-MessagesConfiguration.create!(
+drome1_organisation.messages_configuration.update!(
   direction_names:
     ["DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX",
     "DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI",
-    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"],
-  organisation: drome1_organisation
+    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"]
 )
 
 drome2_organisation = Organisation.create!(
@@ -331,12 +330,11 @@ CategoryConfiguration.create!(
   organisation: drome2_organisation
 )
 
-MessagesConfiguration.create!(
+drome2_organisation.messages_configuration.update!(
   direction_names:
     ["DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX",
     "DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI",
-    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"],
-  organisation: drome2_organisation
+    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"]
 )
 
 yonne_organisation = Organisation.create!(
@@ -357,12 +355,11 @@ CategoryConfiguration.create!(
   organisation: yonne_organisation
 )
 
-MessagesConfiguration.create!(
+yonne_organisation.messages_configuration.update!(
   direction_names:
     ["DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX",
     "DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI",
-    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"],
-  organisation: yonne_organisation
+    "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"]
 )
 
 OrientationType.create!(casf_category: "social", name: "Sociale")


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2941

Avant | Après
:- | -:
<img width="805" alt="Capture d’écran 2025-07-03 à 11 16 20" src="https://github.com/user-attachments/assets/884b8cc0-8c69-405b-a96c-45c023bd0b52" /> | <img width="805" alt="Capture d’écran 2025-07-03 à 11 16 14" src="https://github.com/user-attachments/assets/b99678ce-fe40-4bca-a86b-e4ecfc2fd75b" />


-------------------------------------------

J'en ai profité pour régler un bug dans les seeds, je peux faire une PR séparée pour ce sujet si besoin.
On créait de nouveaux `MessagesConfiguration` pour les orgas des seeds alors qu'ils existent déjà (dans le model `Organisation` grace à `before_create { build_messages_configuration }`)
Cela générait un comportement aléatoire lors de la génération de PDF d'invitations, les valeurs comme `display_department_logo` peuvent varier de manière imprévisible puisqu'il existe plusieurs `MessagesConfiguration`

On pourrait également ajouter une validation pour empêcher que cela ne se produise à l'avenir (des organisation avec plusieurs `MessagesConfiguration`. J'ai vérifié en production, nous n'avons pas de doublons de `MessagesConfiguration` pour les organisations. Je pense que ce serait bien de faire ca dans une autre PR.
