### PR TITLE
fix(ft): Enqueue ft webhooks on rdv updates

### DIFF
--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -8,6 +8,10 @@ module Participation::FranceTravailWebhooks
     before_destroy :send_france_travail_delete_webhook, if: :france_travail_webhook_updatable?
   end
 
+  def send_update_to_france_travail_if_eligible(timestamp)
+    send_france_travail_upsert_webhook(timestamp) if eligible_for_france_travail_webhook?
+  end
+
   def eligible_for_france_travail_webhook?
     eligible_user_for_france_travail_webhook? &&
       eligible_organisation_for_france_travail_webhook? &&
@@ -20,10 +24,10 @@ module Participation::FranceTravailWebhooks
 
   private
 
-  def send_france_travail_upsert_webhook
+  def send_france_travail_upsert_webhook(timestamp = updated_at)
     OutgoingWebhooks::FranceTravail::UpsertParticipationJob.perform_later(
       participation_id: id,
-      timestamp: updated_at
+      timestamp: timestamp
     )
   end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -188,4 +188,22 @@ describe Rdv do
       end
     end
   end
+
+  describe "france travail webhooks" do
+    let!(:rdv) { create(:rdv) }
+    let!(:participation) { rdv.participations.first }
+    let!(:updated_at) { 2.minutes.from_now }
+
+    before do
+      allow(participation).to receive(:eligible_for_france_travail_webhook?).and_return(true)
+    end
+
+    it "enqueues a job to notify france travail" do
+      expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later).with(
+        participation_id: participation.id,
+        timestamp: updated_at
+      )
+      rdv.update!(starts_at: 1.day.from_now, updated_at:)
+    end
+  end
 end


### PR DESCRIPTION
closes #2956 .

On envoie maintenant des update à France Travail lorsque les `rdvs` changent et pas juste quand les `participations`changent. C'est nécessaire parce que lorsqu'on envoie une participation  à FT on envoie plusieurs attributs sauvegardés au niveau du `rdv`. Du coup si ces attributs changent il faut faire l'update sur FT.

**Note**: j'ai fait en sorte d'envoyer  à FT tous les updates (à partir du moment où la participation est éligible) parce que la plupart des attributs du rdv sont envoyés à FT, donc la plupart des updates doivent trigger un envoi de webhook. J'aurais pu faire que l'on envoie le webhook seulement s'il y avait changement sur un ces attributs mais ça nous aurait fait maintenir un système plus complexe à maintenir et prône à de nouveaux oublis d'envoi, alors que le peu de webhook qu'on enverra pour "rien" dans cette implem ne coûtera pas grand chose.