### PR TITLE
tech(gem): update stringio to 3.1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,7 +575,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    stringio (3.1.5)
+    stringio (3.1.7)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)


### PR DESCRIPTION
J'ai constamment cette erreur en local quand j'ouvre une console ou je lance un serveur. Il faut mettre à jour le `gemfile.lock` pour s'en débarasser. 
`'Bundler::Runtime#check_for_activated_spec!': You have already activated stringio 3.1.7, but your Gemfile requires stringio 3.1.5. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)`