### PR TITLE
feat(participations): running created_by migration in a job

### DIFF
--- a/app/jobs/migrate_participations_created_by_job.rb
+++ b/app/jobs/migrate_participations_created_by_job.rb
@@ -1,0 +1,11 @@
+class MigrateParticipationsCreatedByJob < ApplicationJob
+  def perform
+    Participation.where(created_by_type: nil).where.not(created_by: nil).find_each do |participation|
+      participation.update!(
+        created_by_type: participation.attributes["created_by"]&.capitalize,
+        created_by_agent_prescripteur: participation.rdv_solidarites_agent_prescripteur_id.present?,
+        rdv_solidarites_created_by_id: participation.rdv_solidarites_agent_prescripteur_id
+      )
+    end
+  end
+end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -311,6 +311,8 @@ tables:
       - created_at
       - updated_at
       - follow_up_id
+      - created_by
+      - rdv_solidarites_agent_prescripteur_id
       - created_by_type
       - created_by_agent_prescripteur
       - rdv_solidarites_created_by_id

--- a/db/migrate/20250701140708_add_columns_to_participations.rb
+++ b/db/migrate/20250701140708_add_columns_to_participations.rb
@@ -3,16 +3,5 @@ class AddColumnsToParticipations < ActiveRecord::Migration[8.0]
     add_column :participations, :created_by_agent_prescripteur, :boolean, default: false
     add_column :participations, :created_by_type, :string
     add_column :participations, :rdv_solidarites_created_by_id, :bigint
-
-    Participation.where.not(created_by: nil).find_each do |participation|
-      participation.update!(
-        created_by_type: participation.attributes["created_by"]&.capitalize,
-        created_by_agent_prescripteur: participation.rdv_solidarites_agent_prescripteur_id.present?,
-        rdv_solidarites_created_by_id: participation.rdv_solidarites_agent_prescripteur_id
-      )
-    end
-
-    remove_column :participations, :rdv_solidarites_agent_prescripteur_id, :bigint
-    remove_column :participations, :created_by, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -415,6 +415,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_140708) do
     t.bigint "follow_up_id"
     t.boolean "convocable", default: false, null: false
     t.string "france_travail_id"
+    t.string "created_by"
+    t.bigint "rdv_solidarites_agent_prescripteur_id"
     t.boolean "created_by_agent_prescripteur", default: false
     t.string "created_by_type"
     t.bigint "rdv_solidarites_created_by_id"

--- a/lib/tasks/participations/migrate_created_by.rake
+++ b/lib/tasks/participations/migrate_created_by.rake
@@ -1,0 +1,5 @@
+namespace :participations do
+  task migrate_created_by: :environment do
+    MigrateParticipationsCreatedByJob.perform_later
+  end
+end


### PR DESCRIPTION
Cette PR permet d'extraire la gestion de la migration de la table participations dans un job dédié. 
De cette façon le job pourra s'executer tranquillement sans bloquer la table participations dans une transaction. 

Cela implique aussi de procéder à la suppression de la colonne created_by et rdv_solidarites_agent_prescripteur_id dans une future PR. 

## Pourquoi cette PR ? 

Durant la mise en production de [ceci ](https://github.com/gip-inclusion/rdv-insertion/commit/d1bc46c1daa41182572e4b8a9d849694a479657d) nous avons tenté d'effectuer le remplissage des nouvelles colonnes created_by_type, created_by_agent_prescripteur et rdv_solidarites_created_by_id de manière synchrone durant l'execution de `rails db:migrate`. 

Le problème est que les migrations rails sont executées (et tant mieux) à l'intérieur d'une transaction (afin de pouvoir gérer le rollback des modification de structure). 
Hors l'execution d'un nombre très important d'update à l'intérieur d'une transaction conduit inévitablement à l'incapacité de PG de process l'ensemble des updates tout en conservant la possibilité de faire ça dans un seul commit. 

## La timeline du problème 

La migration à engendré le blocage de la table participations durant plusieurs minutes pendant lesquelles la DB était à 100% de CPU mais l'application continuait de fonctionner. 

Au bout d'une quinzaine de minutes Scalingo a coupé le déploiement. Au lieu d'engendrer un rollback simple et clean de la DB, ceci a au contraire causé un effet boule de neige où toutes les requêtes en attente on commencer à se jouer sur la DB. 

J'ai d'abord essayé de couper manuellement les requêtes problématiques via l'interface de scalingo mais dès lors qu'une requête s'arrêtait d'autres venait s'accumuler par dessus. 

A ce moment l'application entière est devenue hors ligne. 

Pour faire repartir l'application j'ai downscale les conteneurs de `web` et `jobs` à 0 ce qui a eu pour effet d'arrêter d'empiler des requêtes sur la DB. 

A partir de là j'ai pu kill manuellement la dizaine de requêtes restantes bloquées sur la DB. 
La DB a donc pu repartir correctement, et j'ai alors rescale les conteneurs à 2, l'application est repartie. 

## Comment s'éviter le problème à l'avenir ?

Dès lors qu'une migration implique l'execution de requêtes synchrones pouvant bloquer une table (typiquement une itération sur un gros volume) nous devons la faire tourner de manière asynchrone ou bien en dehors de la transaction classique de Rails. 

Typiquement pour ce cas présent une façon de faire aurait pu être d'ajouter `disable_ddl_transaction!` en haut de la migration [comme expliqué ici ](https://github.com/ankane/strong_migrations?tab=readme-ov-file#good-7)

Pour notre cas, je pense qu'il est de toute façon plus safe d'extraire ça dans un job que l'on peut plus facilement monitorer et arrêter si besoin, d'où cette PR
