### PR TITLE
fix(participations): allow nil for created_by

### DIFF
--- a/db/migrate/20250717214918_allow_null_for_created_by_in_participations.rb
+++ b/db/migrate/20250717214918_allow_null_for_created_by_in_participations.rb
@@ -1,0 +1,5 @@
+class AllowNullForCreatedByInParticipations < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :participations, :created_by, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_140708) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_17_214918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -415,11 +415,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_140708) do
     t.bigint "follow_up_id"
     t.boolean "convocable", default: false, null: false
     t.string "france_travail_id"
-    t.string "created_by"
-    t.bigint "rdv_solidarites_agent_prescripteur_id"
     t.boolean "created_by_agent_prescripteur", default: false
     t.string "created_by_type"
     t.bigint "rdv_solidarites_created_by_id"
+    t.string "created_by"
+    t.bigint "rdv_solidarites_agent_prescripteur_id"
     t.index ["follow_up_id"], name: "index_participations_on_follow_up_id"
     t.index ["status"], name: "index_participations_on_status"
     t.index ["user_id", "rdv_id"], name: "index_participations_on_user_id_and_rdv_id", unique: true


### PR DESCRIPTION
La migration des données de participations prend finalement beaucoup plus de temps que prévu (8h environ). 

Le problème est qu'en attendant certains jobs échoue car la colonne created_by est toujours présente mais n'est pas remplie. 
https://www.rdv-insertion.fr/sidekiq/retries/1752789179.6757653-89ca434cfb4dcd001d958f6a
https://sentry.incubateur.net/organizations/betagouv/issues/188314/?project=16&referrer=webhooks_plugin

On a déjà eu une vingtaine d'occurrences du problèmes en 2 heures. 

Dans la mesure où sa seule utilité est désormais de permettre de remplir les nouvelles colonnes, on peut se permettre d'enlever la contrainte sur le null en attendant que l'on ai fini de migrer les données. 