### PR TITLE
fix(flaky): e2e notification center

### DIFF
--- a/app/controllers/concerns/notification_center_concern.rb
+++ b/app/controllers/concerns/notification_center_concern.rb
@@ -18,7 +18,7 @@ module NotificationCenterConcern
                                           .where(created_at: notifications_read_at...)
                                           # If organisation has 2 valid motif_categories it will receive 2 notifications
                                           # Any of the notifications created today may be important, not just the last
-                                          .where(created_at: Time.zone.today...)
+                                          .where(created_at: Time.zone.today.beginning_of_day...)
                                           .with_pending_invitations
                                           .order(created_at: :desc)
                                           .any?(&:low_availability?)


### PR DESCRIPTION
Je fix ce flaky qui me cass.. qui m'empêche de déployer depuis tout à l'heure.

En gros on est sensé prendre les CreneauxAvailability créés depuis minuit sauf que ceci `.where(created_at: Time.zone.today...)` ne prenait pas en compte l'ensemble. 

Donc c'est pas vraiment un flaky mais c'était un test dépendant de l'heure à laquelle il tourne