### PR TITLE
ux(user_table): improve no user table message with links

### DIFF
--- a/app/javascript/stylesheets/components/_color.scss
+++ b/app/javascript/stylesheets/components/_color.scss
@@ -105,6 +105,14 @@
   }
 }
 
+.link-blue-underlined {
+  text-decoration: underline;
+  color: $dark-blue;
+  &:hover {
+    color: $alt-grey;
+  }
+}
+
 .blue-out {
   background-color: white;
   color: $dark-blue;

--- a/app/views/users/_users_list_table.html.erb
+++ b/app/views/users/_users_list_table.html.erb
@@ -10,7 +10,13 @@
       <p class="mb-0 pb-2">Aucun dossier usager ne correspond à votre recherche</p>
       <p class="mb-0 pb-3">Vous pouvez essayer de lancer une nouvelle recherche ou utiliser les filtres</p>
     <% else %>
-      <h4 class="mb-0 pb-2">Il n'y a pas encore d'usagers</h4>
+      <% if archived_scope?(@users_scope) %>
+        <h5 class="mb-0 pb-2"><strong>Il n'y a pas encore d'usagers archivés</strong></h5>
+      <% else %>
+        <h5 class="mb-0 pb-2"><strong>Il n'y a pas encore d'usagers</strong></h5>
+        <p class="mb-0 pb-2">Vous pouvez <%= link_to("importer des usagers", new_structure_user_list_uploads_category_selection_path, class: "link-blue-underlined") %>
+         ou <%= link_to("ajouter un usager manuellement", new_structure_user_path, class: "link-blue-underlined") %> pour compléter cette liste</p>
+      <% end %>
     <% end %>
   <% elsif archived_scope?(@users_scope) %>
     <%= render "archived_users_table" %>


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2918

Le résultat correspond à ce qui est demandé dans la maquette : 

Avant | Après
:- | -:
<img width="1528" height="447" alt="Capture d’écran 2025-07-18 à 10 14 51" src="https://github.com/user-attachments/assets/119bd5ab-0507-4dbe-b2b1-3590f0dbc7cb" /> |<img width="1528" height="447" alt="Capture d’écran 2025-07-18 à 10 13 35" src="https://github.com/user-attachments/assets/36d2f76e-7f0e-4124-9b1a-9ae9369a5f18" />

J'en ai profité pour ajuster le message pour les usagers archivés quand il n'y en a pas : 

Avant | Après
:- | -:
<img width="1528" height="447" alt="Capture d’écran 2025-07-18 à 10 14 45" src="https://github.com/user-attachments/assets/bd6e2c9b-29bd-42a5-bfb5-5e33f77b8b1b" />|<img width="1528" height="447" alt="Capture d’écran 2025-07-18 à 10 13 39" src="https://github.com/user-attachments/assets/635bc4fa-3571-4069-9c08-6bbae7b82b20" />
