### PR TITLE
fix(webhooks): Unset motif_category when unset in RDV-SP

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_motif_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_motif_job.rb
@@ -46,9 +46,9 @@ module InboundWebhooks
           rdv_solidarites_motif.to_rdv_insertion_attributes,
           {
             organisation_id: organisation.id,
-            last_webhook_update_received_at: @meta[:timestamp]
+            last_webhook_update_received_at: @meta[:timestamp],
+            motif_category_id: motif_category&.id
           }
-            .merge(motif_category ? { motif_category_id: motif_category.id } : {})
         )
       end
 

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_motif_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_motif_job_spec.rb
@@ -37,7 +37,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessMotifJob do
       expect(UpsertRecordJob).to receive(:perform_later)
         .with(
           "Motif", motif_attributes,
-          { organisation_id: organisation.id, last_webhook_update_received_at: "2022-05-30 14:44:22 +0200" }
+          { organisation_id: organisation.id, motif_category_id: nil, last_webhook_update_received_at: "2022-05-30 14:44:22 +0200" }
         )
       subject
     end


### PR DESCRIPTION
Lorsqu'on enlève une catégorie de motif d'un motif sur RDV-SP, ce changement n'était pas reflété (voir cette [conversation](https://mattermost.incubateur.net/betagouv/pl/4jcapepeqtdquytumjq6o9a3by)). 
Je fix ça ici.