### PR TITLE
fix(webhooks): Order ProcessUserJob

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
@@ -2,7 +2,7 @@ module InboundWebhooks
   module RdvSolidarites
     class ProcessUserJob < LockedAndOrderedJobBase
       def self.lock_key(data, _meta)
-        "#{base_lock_key}:#{data.dig(:id)}"
+        "#{base_lock_key}:#{data[:id]}"
       end
 
       def perform(data, meta)

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_job.rb
@@ -1,6 +1,10 @@
 module InboundWebhooks
   module RdvSolidarites
-    class ProcessUserJob < ApplicationJob
+    class ProcessUserJob < LockedAndOrderedJobBase
+      def self.lock_key(data, _meta)
+        "#{base_lock_key}:#{data.dig(:id)}"
+      end
+
       def perform(data, meta)
         @data = data.deep_symbolize_keys
         @meta = meta.deep_symbolize_keys


### PR DESCRIPTION
On a eu des erreurs où on essayait de recréer un usager qui venait d'être supprimé: https://sentry.incubateur.net/organizations/betagouv/issues/185014/?environment=production&project=16&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=3

Voici ce qu'il se passait: 

* L'usager était enlevé de son organisation sur rdv-i et rdv-sp via le CRON qui enlève les usagers archivés depuis + de 2 ans: https://github.com/gip-inclusion/rdv-insertion/blob/d633d8892556efced90666f7c82e6837541f3039/app/jobs/remove_organisation_user_for_expired_archive_job.rb#L20
* L'usager était dans cette organisation seulement, du coup il est soft deleted sur rdv-sp
* L'usager est donc supprimé sur rdv-i (via webhook de suppression de rdv-sp)
* Dans le même moment, on reçoit des webhooks d'updates de l'usager (probablement un update qui se fait au niveau rdv-sp avant le soft delete)
* Si on traite le webhook d'update après le webhook de delete, on obtient l'erreur annoncé où on essaie de mettre à jour un usager supprimé

## Solution

Je fais en sorte d'exécuter dans l'ordre les jobs traitants les webhooks entrant des usagers (en faisant hériter `InboundWebhooks::RdvSolidarites::ProcessUserJob` de `InboundWebhooks::RdvSolidarites::LockedAndOrderedJobBase`).

⚠️ ceci devrait nous donner plus de sécurité mais ne garantit pas le fait que cette erreur n'arrive plus. En effet, les updates ne se font pas directement dans ce job mais dans les `UpsertRecordJob`. Si ce dernier est traité après le job de suppression de l'usager, on aura toujours l'erreur. Si c'est le cas on peut envisager de faire l'upsert de manière synchrone dans ce job pour résoudre l'erreur.