### PR TITLE
fix(db): Redo unlaunched migration

### DIFF
--- a/db/migrate/20250722122431_remove_created_by_and_rdv_solidarites_prescripteur_id_from_participations.rb
+++ b/db/migrate/20250722122431_remove_created_by_and_rdv_solidarites_prescripteur_id_from_participations.rb
@@ -1,4 +1,4 @@
-class RemoveParticipationsUselessColumns < ActiveRecord::Migration[8.0]
+class RemoveCreatedByAndRdvSolidaritesPrescripteurIdFromParticipations < ActiveRecord::Migration[8.0]
   def change
     remove_column :participations, :rdv_solidarites_agent_prescripteur_id, :bigint
     remove_column :participations, :created_by, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_17_214918) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_22_122431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -418,8 +418,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_214918) do
     t.boolean "created_by_agent_prescripteur", default: false
     t.string "created_by_type"
     t.bigint "rdv_solidarites_created_by_id"
-    t.string "created_by"
-    t.bigint "rdv_solidarites_agent_prescripteur_id"
     t.index ["follow_up_id"], name: "index_participations_on_follow_up_id"
     t.index ["status"], name: "index_participations_on_status"
     t.index ["user_id", "rdv_id"], name: "index_participations_on_user_id_and_rdv_id", unique: true


### PR DESCRIPTION
J'ai remarqué que la migration écrite dans #2981 n'a jamais été lancée et que le schéma n'avait pas été modifié.
Je la relance ici avec le schéma modifié, et je la place après la migration qui consistait à changer la non-null constraint sur  la colonne `created_by` (que l'on enlève ici) et qui était placée après ce fichier de migration.