### PR TITLE
feat(app): Monitor inbound emails activity

### DIFF
--- a/app/jobs/monitor_inbound_emails_activity_job.rb
+++ b/app/jobs/monitor_inbound_emails_activity_job.rb
@@ -4,7 +4,7 @@ class MonitorInboundEmailsActivityJob < ApplicationJob
 
     MattermostClient.send_to_private_channel(
       "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
-      "Dernier email reçu le #{last_inbound_email_received_at.strftime("%d/%m/%Y %H:%M")}"
+      "Dernier email reçu le #{last_inbound_email_received_at.strftime('%d/%m/%Y %H:%M')}"
     )
   end
 
@@ -12,7 +12,7 @@ class MonitorInboundEmailsActivityJob < ApplicationJob
 
   def last_inbound_email_received_at
     RedisConnection.with_redis do |redis|
-      Time.at(redis.get("last_inbound_email_received_at").to_i)
+      Time.zone.at(redis.get("last_inbound_email_received_at").to_i)
     end
   end
 

--- a/app/jobs/monitor_inbound_emails_activity_job.rb
+++ b/app/jobs/monitor_inbound_emails_activity_job.rb
@@ -1,0 +1,22 @@
+class MonitorInboundEmailsActivityJob < ApplicationJob
+  def perform
+    return if inbound_email_received_less_than_7_days_ago?
+
+    MattermostClient.send_to_private_channel(
+      "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
+      "Dernier email reçu le #{last_inbound_email_received_at.strftime("%d/%m/%Y %H:%M")}"
+    )
+  end
+
+  private
+
+  def last_inbound_email_received_at
+    RedisConnection.with_redis do |redis|
+      Time.at(redis.get("last_inbound_email_received_at").to_i)
+    end
+  end
+
+  def inbound_email_received_less_than_7_days_ago?
+    last_inbound_email_received_at > 7.days.ago
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -2,6 +2,9 @@
 monitor_webhook_activity_job:
   cron: "0 0-1,6-23 * * 1-5" # Monitor webhooks activity every hour from Monday to Friday except between 1:00 and 6:00
   class: "MonitorWebhookActivityJob"
+monitor_inbound_emails_activity_job:
+  cron: "0 15 * * *" # Monitor inbound emails activity every day at 15:00
+  class: "MonitorInboundEmailsActivityJob"
 notify_jobs_to_retry_on_mattermost_job:
   cron: "30 10 * * *" # we send jobs in the retry_set once a day, at 10:30
   class: "NotifyJobsToRetryOnMattermostJob"

--- a/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
+++ b/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
@@ -29,7 +29,7 @@ describe MonitorInboundEmailsActivityJob do
       it "sends a message to Mattermost" do
         expect(MattermostClient).to receive(:send_to_private_channel).with(
           "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
-          "Dernier email reçu le #{last_inbound_email_received_at.strftime("%d/%m/%Y %H:%M")}"
+          "Dernier email reçu le #{last_inbound_email_received_at.strftime('%d/%m/%Y %H:%M')}"
         )
         subject
       end

--- a/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
+++ b/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
@@ -1,0 +1,38 @@
+describe MonitorInboundEmailsActivityJob do
+  subject do
+    described_class.new.perform
+  end
+
+  describe "#perform" do
+    context "when the last inbound email was received less than 7 days ago" do
+      before do
+        RedisConnection.with_redis do |redis|
+          redis.set("last_inbound_email_received_at", 6.days.ago.to_i)
+        end
+      end
+
+      it "does not send a message to Mattermost" do
+        expect(MattermostClient).not_to receive(:send_to_private_channel)
+        subject
+      end
+    end
+
+    context "when the last inbound email was received more than 7 days ago" do
+      let(:last_inbound_email_received_at) { 8.days.ago }
+
+      before do
+        RedisConnection.with_redis do |redis|
+          redis.set("last_inbound_email_received_at", last_inbound_email_received_at.to_i)
+        end
+      end
+
+      it "sends a message to Mattermost" do
+        expect(MattermostClient).to receive(:send_to_private_channel).with(
+          "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
+          "Dernier email reçu le #{last_inbound_email_received_at.strftime("%d/%m/%Y %H:%M")}"
+        )
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2946 

Pour qu'on soit alerté si jamais les emails des usagers ne sont plus transférés (ce qui est arrivé récemment), je mets en place un CRON qui se lance chaque jour et vérifie que l'on a reçu un email d'usager il y a moins de cette jour.
Pour se faire, on va chercher dans redis le timestamp du dernier inbound email reçu. Je fais donc en sorte qu'on mette à ce jour ce timestamp à chaque fois qu'on reçoit un inbound email.