### PR TITLE
fix(cron): Remove cleanup jobs from cron list

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -43,6 +43,3 @@ store_all_number_of_creneaux_available_job:
 remove_organisation_users_for_expired_archives_job:
   cron: "0 23 * * *" # we remove expired archived users from organisations once a day, at 23:00
   class: "RemoveUsersFromOrgsWithOldArchivesJob"
-rgpd_cleanup_job:
-  cron: "0 0 * * *" # we destroy inactive users and useless resources once a day, at 00:00
-  class: "RgpdCleanupJob"


### PR DESCRIPTION
En attendant d'être vraiment au clair sur certains edge case par rapport aux nouvelles règles liés à la suppression des usagers, je désactive le CRON pour qu'il ne tourne pas ce week-end et qu'on ait pas des suppressions qui ne match pas nos règles.