### PR TITLE
fix(rgpd): Add rules to rgpd cleanup

### DIFF
--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -3,7 +3,8 @@ class MattermostClient
     main: ENV["MATTERMOST_MAIN_CHANNEL_URL"],
     notification: ENV["MATTERMOST_NOTIFICATIONS_CHANNEL_URL"],
     private: ENV["MATTERMOST_PRIVATE_CHANNEL_URL"],
-    sentry: ENV["MATTERMOST_SENTRY_CHANNEL_URL"]
+    sentry: ENV["MATTERMOST_SENTRY_CHANNEL_URL"],
+    rgpd_cleanup: ENV["MATTERMOST_RGDP_CLEANUP_CHANNEL_URL"],
   }.freeze
 
   class << self
@@ -21,6 +22,10 @@ class MattermostClient
 
     def send_to_sentry_channel(text)
       send_message(:sentry, text)
+    end
+
+    def send_to_rgpd_cleanup_channel(text)
+      send_message(:rgpd_cleanup, text)
     end
 
     def send_unique_message(channel_type:, text:, expiration: 24.hours)

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -4,7 +4,7 @@ class MattermostClient
     notification: ENV["MATTERMOST_NOTIFICATIONS_CHANNEL_URL"],
     private: ENV["MATTERMOST_PRIVATE_CHANNEL_URL"],
     sentry: ENV["MATTERMOST_SENTRY_CHANNEL_URL"],
-    rgpd_cleanup: ENV["MATTERMOST_RGDP_CLEANUP_CHANNEL_URL"],
+    rgpd_cleanup: ENV["MATTERMOST_RGDP_CLEANUP_CHANNEL_URL"]
   }.freeze
 
   class << self

--- a/app/jobs/rgpd_cleanup_organisation_job.rb
+++ b/app/jobs/rgpd_cleanup_organisation_job.rb
@@ -1,6 +1,8 @@
 class RgpdCleanupOrganisationJob < ApplicationJob
   def perform(organisation_id)
     organisation = Organisation.find(organisation_id)
-    call_service!(Organisations::RgpdCleanup, organisation: organisation, dry_run: ENV["RGDP_CLEANUP_DRY_RUN"] == "true")
+    call_service!(
+      Organisations::RgpdCleanup, organisation: organisation, dry_run: ENV["RGDP_CLEANUP_DRY_RUN"] == "true"
+    )
   end
 end

--- a/app/jobs/rgpd_cleanup_organisation_job.rb
+++ b/app/jobs/rgpd_cleanup_organisation_job.rb
@@ -1,6 +1,6 @@
 class RgpdCleanupOrganisationJob < ApplicationJob
   def perform(organisation_id)
     organisation = Organisation.find(organisation_id)
-    call_service!(Organisations::RgpdCleanup, organisation: organisation)
+    call_service!(Organisations::RgpdCleanup, organisation: organisation, dry_run: ENV["RGDP_CLEANUP_DRY_RUN"] == "true")
   end
 end

--- a/app/models/organisation/users_retriever.rb
+++ b/app/models/organisation/users_retriever.rb
@@ -5,11 +5,14 @@ class Organisation::UsersRetriever
   end
 
   def inactive_users
-    @organisation.users.where(users: { created_at: ...@date_limit })
-                 .where.not(id: users_with_recent_invitations)
-                 .where.not(id: users_with_recent_participations)
-                 .where.not(id: users_with_recent_tag_assignments)
-                 .where.not(id: users_with_recent_referent_assignations)
+    User.joins(:users_organisations)
+        .where(users_organisations: { organisation: @organisation, created_at: ...@date_limit })
+        .where.not(id: users_with_recent_invitations)
+        .where.not(id: users_with_recent_participations)
+        .where.not(id: users_with_recent_tag_assignments)
+        .where.not(id: users_with_recent_referent_assignations)
+        .where.not(id: users_updated_recently)
+        .distinct
   end
 
   private
@@ -39,6 +42,16 @@ class Organisation::UsersRetriever
     User.joins(referent_assignations: { agent: :organisations })
         .where(referent_assignations: { created_at: @date_limit.. })
         .where(organisations: { id: @organisation.id })
+        .select(:id)
+  end
+
+  def users_updated_recently
+    # versions are created only when important changes are made to the user
+    # (e.g. name, email, phone number, etc.), so it's more reliable than checking
+    # the user's updated_at field that can be set by any migration or non-human action
+    # (e.g. when nullifying the rdv_solidarites_user_id for rgpd reasons)
+    User.joins("INNER JOIN versions ON versions.item_type = 'User' AND versions.item_id::bigint = users.id")
+        .where(versions: { event: "update", created_at: @date_limit.. })
         .select(:id)
   end
 end

--- a/app/services/organisations/rgpd_cleanup.rb
+++ b/app/services/organisations/rgpd_cleanup.rb
@@ -1,12 +1,16 @@
 class Organisations::RgpdCleanup < BaseService
-  def initialize(organisation:)
+  def initialize(organisation:, dry_run:)
     @organisation = organisation
     @date_limit = organisation.data_retention_duration_in_months.months.ago
+    @dry_run = dry_run
   end
 
   def call
-    process_inactive_users # process users for rgpd reasons (destroy or remove from org)
-    destroy_useless_rdvs # destroying users will destroy participations ; rdvs with no participations are useless for us
+    ActiveRecord::Base.transaction do
+      process_inactive_users # process users for rgpd reasons (destroy or remove from org)
+      destroy_useless_rdvs # destroying users will destroy participations ; rdvs with no participations are useless for us
+      raise ActiveRecord::Rollback if @dry_run
+    end
   end
 
   private
@@ -17,7 +21,7 @@ class Organisations::RgpdCleanup < BaseService
 
     remove_users_from_org(inactive_users)
 
-    users_to_delete, users_to_remove_from_org = inactive_users.partition { |user| user.organisations.reload.empty? }
+    users_to_delete, users_to_remove_from_org = inactive_users.partition { |user| user.reload.organisations.empty? }
 
     process_users_to_delete(users_to_delete)
     notify_user_removals(users_to_remove_from_org.pluck(:id))
@@ -49,22 +53,22 @@ class Organisations::RgpdCleanup < BaseService
   end
 
   def notify_user_deletions(user_ids)
-    MattermostClient.send_to_notif_channel(
-      "🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation " \
+    MattermostClient.send_to_rgpd_cleanup_channel(
+      "#{dry_run_log_prefix}🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation " \
       "#{@organisation.name} : #{user_ids.join(', ')}"
     )
-    Rails.logger.info("🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation " \
+    Rails.logger.info("#{dry_run_log_prefix}🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation " \
                       "#{@organisation.name} : #{user_ids.join(', ')}")
   end
 
   def notify_user_removals(user_ids)
     return if user_ids.empty?
 
-    MattermostClient.send_to_notif_channel(
-      "↩️ Les usagers suivants ont été retirés de l'organisation " \
+    MattermostClient.send_to_rgpd_cleanup_channel(
+      "#{dry_run_log_prefix}↩️ Les usagers suivants ont été retirés de l'organisation " \
       "#{@organisation.name} pour inactivité (mais restent actifs ailleurs) : #{user_ids.join(', ')}"
     )
-    Rails.logger.info("↩️ Les usagers suivants ont été retirés de l'organisation " \
+    Rails.logger.info("#{dry_run_log_prefix}↩️ Les usagers suivants ont été retirés de l'organisation " \
                       "#{@organisation.name} pour inactivité (mais restent actifs ailleurs) : #{user_ids.join(', ')}")
   end
 
@@ -91,11 +95,15 @@ class Organisations::RgpdCleanup < BaseService
   end
 
   def notify_rdv_deletions(rdv_ids)
-    MattermostClient.send_to_notif_channel(
-      "🚮 Les rdvs suivants ont été supprimés automatiquement pour l'organisation " \
+    MattermostClient.send_to_rgpd_cleanup_channel(
+      "#{dry_run_log_prefix}🚮 Les rdvs suivants ont été supprimés automatiquement pour l'organisation " \
       "#{@organisation.name} : #{rdv_ids.join(', ')}"
     )
-    Rails.logger.info("🚮 Les rdvs suivants ont été supprimés automatiquement pour l'organisation " \
+    Rails.logger.info("#{dry_run_log_prefix}🚮 Les rdvs suivants ont été supprimés automatiquement pour l'organisation " \
                       "#{@organisation.name} : #{rdv_ids.join(', ')}")
+  end
+
+  def dry_run_log_prefix
+    @dry_run ? "[🔍 DRY RUN] " : ""
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -40,6 +40,9 @@ refresh_out_of_date_follow_up_statuses_job:
 store_all_number_of_creneaux_available_job:
   cron: "0 5 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "Creneaux::StoreAllNumberOfCreneauxAvailableJob"
-remove_organisation_users_for_expired_archives_job:
+remove_users_from_orgs_with_old_archives_job:
   cron: "0 23 * * *" # we remove expired archived users from organisations once a day, at 23:00
   class: "RemoveUsersFromOrgsWithOldArchivesJob"
+rgpd_cleanup_job:
+  cron: "0 0 * * *" # we destroy inactive users and useless resources once a day, at 00:00
+  class: "RgpdCleanupJob"

--- a/spec/jobs/rgpd_cleanup_organisation_job_spec.rb
+++ b/spec/jobs/rgpd_cleanup_organisation_job_spec.rb
@@ -6,13 +6,14 @@ describe RgpdCleanupOrganisationJob do
   let(:organisation) { create(:organisation) }
 
   before do
-    allow(Organisations::RgpdCleanup).to receive(:call).with(organisation:).and_return(OpenStruct.new(success?: true))
+    allow(Organisations::RgpdCleanup).to receive(:call).with(organisation:, dry_run: false)
+                                     .and_return(OpenStruct.new(success?: true))
   end
 
   describe "#perform" do
     it "calls the RgpdCleanUp with the organisation" do
       subject
-      expect(Organisations::RgpdCleanup).to have_received(:call).with(organisation:)
+      expect(Organisations::RgpdCleanup).to have_received(:call).with(organisation:, dry_run: false)
     end
   end
 end

--- a/spec/models/organisation/users_retriever_spec.rb
+++ b/spec/models/organisation/users_retriever_spec.rb
@@ -3,8 +3,8 @@ describe Organisation::UsersRetriever, type: :model do
   let(:retriever) { described_class.new(organisation: organisation) }
   let(:old_date) { 25.months.ago }
   let(:recent_date) { 1.month.ago }
-  let!(:inactive_user) { create(:user, created_at: old_date) }
-  let!(:active_user) { create(:user, created_at: recent_date) }
+  let!(:inactive_user) { create(:user) }
+  let!(:active_user) { create(:user) }
   let!(:inactive_user_organisation) do
     create(:users_organisation, user: inactive_user, organisation: organisation, created_at: old_date)
   end
@@ -25,7 +25,7 @@ describe Organisation::UsersRetriever, type: :model do
       end
 
       it "excludes the user from inactive users" do
-        expect(retriever.inactive_users).not_to include(inactive_user)
+        expect(retriever.inactive_users).to eq([])
       end
     end
 
@@ -36,7 +36,7 @@ describe Organisation::UsersRetriever, type: :model do
       end
 
       it "excludes the user from inactive users" do
-        expect(retriever.inactive_users).not_to include(inactive_user)
+        expect(retriever.inactive_users).to eq([])
       end
     end
 
@@ -45,7 +45,7 @@ describe Organisation::UsersRetriever, type: :model do
       let!(:recent_tag_user) { create(:tag_user, user: inactive_user, tag: tag, created_at: recent_date) }
 
       it "excludes the user from inactive users" do
-        expect(retriever.inactive_users).not_to include(inactive_user)
+        expect(retriever.inactive_users).to eq([])
       end
     end
 
@@ -56,7 +56,7 @@ describe Organisation::UsersRetriever, type: :model do
       end
 
       it "excludes the user from inactive users" do
-        expect(retriever.inactive_users).not_to include(inactive_user)
+        expect(retriever.inactive_users).to eq([])
       end
     end
 
@@ -69,7 +69,7 @@ describe Organisation::UsersRetriever, type: :model do
         end
 
         it "still includes the user in inactive users" do
-          expect(retriever.inactive_users).to include(inactive_user)
+          expect(retriever.inactive_users).to contain_exactly(inactive_user)
         end
       end
 
@@ -80,7 +80,7 @@ describe Organisation::UsersRetriever, type: :model do
         end
 
         it "still includes the user in inactive users" do
-          expect(retriever.inactive_users).to include(inactive_user)
+          expect(retriever.inactive_users).to contain_exactly(inactive_user)
         end
       end
 
@@ -91,7 +91,7 @@ describe Organisation::UsersRetriever, type: :model do
         end
 
         it "still includes the user in inactive users" do
-          expect(retriever.inactive_users).to include(inactive_user)
+          expect(retriever.inactive_users).to contain_exactly(inactive_user)
         end
       end
 
@@ -102,8 +102,18 @@ describe Organisation::UsersRetriever, type: :model do
         end
 
         it "still includes the user in inactive users" do
-          expect(retriever.inactive_users).to include(inactive_user)
+          expect(retriever.inactive_users).to contain_exactly(inactive_user)
         end
+      end
+    end
+
+    context "when the user has been updated recently" do
+      before do
+        inactive_user.update!(first_name: "John", last_name: "Doe")
+      end
+
+      it "excludes the user from inactive users" do
+        expect(retriever.inactive_users).to eq([])
       end
     end
   end

--- a/spec/services/organisations/rgpd_cleanup_spec.rb
+++ b/spec/services/organisations/rgpd_cleanup_spec.rb
@@ -104,12 +104,20 @@ describe Organisations::RgpdCleanup, type: :service do
         allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
       end
 
-      it "does not destroy anything" do
+      it "does not destroy users" do
         expect { subject }.not_to change(User, :count)
-        expect { subject }.not_to change(Rdv, :count)
-        expect { subject }.not_to change(UsersOrganisation, :count)
         expect(User.exists?(inactive_user.id)).to be true
         expect(User.exists?(active_user.id)).to be true
+      end
+
+      it "does not destroy rdvs" do
+        expect { subject }.not_to change(Rdv, :count)
+      end
+
+      it "does not remove users from org" do
+        expect { subject }.not_to change(UsersOrganisation, :count)
+        expect(inactive_user.reload.users_organisations.where(organisation: organisation)).to be_present
+        expect(active_user.reload.users_organisations.where(organisation: organisation)).to be_present
       end
 
       it "still sends notification when users are to be deleted" do

--- a/spec/services/organisations/rgpd_cleanup_spec.rb
+++ b/spec/services/organisations/rgpd_cleanup_spec.rb
@@ -124,7 +124,9 @@ describe Organisations::RgpdCleanup, type: :service do
         subject
 
         expect(MattermostClient).to have_received(:send_to_rgpd_cleanup_channel).with(
-          match(/\[🔍 DRY RUN\] 🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation #{organisation.name}/)
+          match(
+            /\[🔍 DRY RUN\] 🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation/
+          )
         )
       end
     end

--- a/spec/services/organisations/rgpd_cleanup_spec.rb
+++ b/spec/services/organisations/rgpd_cleanup_spec.rb
@@ -1,25 +1,15 @@
 describe Organisations::RgpdCleanup, type: :service do
+  subject { described_class.call(organisation: organisation, dry_run: dry_run) }
+
+  let(:dry_run) { false }
   let(:organisation) { create(:organisation, data_retention_duration_in_months: 24) }
-  let(:service) { described_class.new(organisation: organisation) }
 
   describe "#call" do
-    it "calls all cleanup methods" do
-      allow(service).to receive(:process_inactive_users)
-      allow(service).to receive(:destroy_useless_rdvs)
-
-      service.call
-
-      expect(service).to have_received(:process_inactive_users)
-      expect(service).to have_received(:destroy_useless_rdvs)
-    end
-  end
-
-  describe "#process_inactive_users" do
     let(:old_date) { 25.months.ago }
     let(:recent_date) { 1.month.ago }
 
-    let!(:inactive_user) { create(:user, created_at: old_date) }
-    let!(:active_user) { create(:user, created_at: recent_date) }
+    let!(:inactive_user) { create(:user) }
+    let!(:active_user) { create(:user) }
     let!(:inactive_user_organisation) do
       create(:users_organisation, user: inactive_user, organisation: organisation, created_at: old_date)
     end
@@ -29,19 +19,19 @@ describe Organisations::RgpdCleanup, type: :service do
 
     context "when user is only in current organisation" do
       it "destroys the user completely" do
-        allow(MattermostClient).to receive(:send_to_notif_channel)
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
 
-        expect { service.call }.to change(User, :count).by(-1)
+        expect { subject }.to change(User, :count).by(-1)
         expect(User.exists?(inactive_user.id)).to be false
         expect(User.exists?(active_user.id)).to be true
       end
 
       it "sends deletion notification" do
-        allow(MattermostClient).to receive(:send_to_notif_channel)
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
 
-        service.call
+        subject
 
-        expect(MattermostClient).to have_received(:send_to_notif_channel).with(
+        expect(MattermostClient).to have_received(:send_to_rgpd_cleanup_channel).with(
           match(/Les usagers suivants ont été supprimés pour inactivité dans l'organisation #{organisation.name}/)
         )
       end
@@ -54,57 +44,81 @@ describe Organisations::RgpdCleanup, type: :service do
       end
 
       it "removes user from current organisation only" do
-        allow(MattermostClient).to receive(:send_to_notif_channel)
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
 
-        expect { service.call }.not_to change(User, :count)
+        expect { subject }.not_to change(User, :count)
         expect(User.exists?(inactive_user.id)).to be true
         expect(inactive_user.reload.users_organisations.where(organisation: organisation)).to be_empty
         expect(inactive_user.users_organisations.where(organisation: other_organisation)).to be_present
       end
 
       it "sends removal notification" do
-        allow(MattermostClient).to receive(:send_to_notif_channel)
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
 
-        service.call
+        subject
 
-        expect(MattermostClient).to have_received(:send_to_notif_channel).with(
+        expect(MattermostClient).to have_received(:send_to_rgpd_cleanup_channel).with(
           match(/Les usagers suivants ont été retirés de l'organisation #{organisation.name} pour inactivité/)
         )
       end
     end
-  end
 
-  describe "#destroy_useless_rdvs" do
-    let(:old_date) { 25.months.ago }
-    let(:recent_date) { 1.month.ago }
-    let!(:webhook_endpoint) { create(:webhook_endpoint, organisation:, subscriptions: %w[rdv]) }
+    context "when rdvs are useless" do
+      let(:old_date) { 25.months.ago }
+      let(:recent_date) { 1.month.ago }
+      let!(:webhook_endpoint) { create(:webhook_endpoint, organisation:, subscriptions: %w[rdv]) }
 
-    let!(:useless_rdv) do
-      rdv = create(:rdv, organisation: organisation, created_at: old_date)
-      rdv.participations.destroy_all
-      rdv
+      let!(:useless_rdv) do
+        rdv = create(:rdv, organisation: organisation, created_at: old_date)
+        rdv.participations.destroy_all
+        rdv
+      end
+
+      let!(:recent_rdv) do
+        rdv = create(:rdv, organisation: organisation, created_at: recent_date)
+        rdv.participations.destroy_all
+        rdv
+      end
+
+      it "destroys old rdvs without participations and does not send webhooks" do
+        expect(OutgoingWebhooks::SendWebhookJob).not_to receive(:perform_later)
+        expect { subject }.to change(Rdv, :count).by(-1)
+        expect(Rdv.exists?(useless_rdv.id)).to be false
+        expect(Rdv.exists?(recent_rdv.id)).to be true
+      end
+
+      it "sends notification when rdvs are deleted" do
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
+        subject
+
+        expect(MattermostClient).to have_received(:send_to_rgpd_cleanup_channel).with(
+          match(/Les rdvs suivants ont été supprimés automatiquement pour l'organisation #{organisation.name}/)
+        )
+      end
     end
 
-    let!(:recent_rdv) do
-      rdv = create(:rdv, organisation: organisation, created_at: recent_date)
-      rdv.participations.destroy_all
-      rdv
-    end
+    context "when dry run is enabled" do
+      let!(:dry_run) { true }
 
-    it "destroys old rdvs without participations and does not send webhooks" do
-      expect(OutgoingWebhooks::SendWebhookJob).not_to receive(:perform_later)
-      expect { service.call }.to change(Rdv, :count).by(-1)
-      expect(Rdv.exists?(useless_rdv.id)).to be false
-      expect(Rdv.exists?(recent_rdv.id)).to be true
-    end
+      before do
+        allow(MattermostClient).to receive(:send_to_rgpd_cleanup_channel)
+      end
 
-    it "sends notification when rdvs are deleted" do
-      allow(MattermostClient).to receive(:send_to_notif_channel)
-      service.call
+      it "does not destroy anything" do
+        expect { subject }.not_to change(User, :count)
+        expect { subject }.not_to change(Rdv, :count)
+        expect { subject }.not_to change(UsersOrganisation, :count)
+        expect(User.exists?(inactive_user.id)).to be true
+        expect(User.exists?(active_user.id)).to be true
+      end
 
-      expect(MattermostClient).to have_received(:send_to_notif_channel).with(
-        match(/Les rdvs suivants ont été supprimés automatiquement pour l'organisation #{organisation.name}/)
-      )
+      it "still sends notification when users are to be deleted" do
+        subject
+
+        expect(MattermostClient).to have_received(:send_to_rgpd_cleanup_channel).with(
+          match(/\[🔍 DRY RUN\] 🚮 Les usagers suivants ont été supprimés pour inactivité dans l'organisation #{organisation.name}/)
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Nouvelles règles 

Suite à [la discussion](https://mattermost.incubateur.net/betagouv/pl/frotff9bx7dxidinkw1iymtmhh) qu'on a eu après le lancement du premier job de cleanup avec les nouvelles règles RGPD, je fais quelques ajustements sur nos règles:

* Je prends en compte la date d'ajout à l'organisation (et non plus la date de création de l'usager) comme critère pour enlever l'usager de l'orga
* J'essaie de prendre en compte les mises à jour de l'usager comme "activité" sur l'usager. Pour cela on ne peut pas se fier au champ `updated_at` parce qu'il est changé alors que l'usager n'a pas été vraiment mis à jour. Du coup je prends en compte les changements dans la table `versions`: au moins on est sûr qu'il s'agit d'une mise à jour "significative" sur l'usager. Le problème est que cette table a été créé il y a 3 mois, du coup il est possible que l'on supprime des usagers qui ont été mis à jour entre il y a 3 mois et il y a 2 ans, mais j'imagine que c'est ok s'il n'y a pas d'autre activité à côté

## Mode dry_run

Je mets en place la possibilité de lancer le service de clean up en mode dry run pour pouvoir voir l'effet de lancer ces jobs sans que les suppressions ne soit vraiment faites en DB. Ça nous permettra d'être confiant avant de réactiver réellement le CRON. Pour activer le mode dry run, il faut set la variable d'environnement `RGDP_CLEANUP_DRY_RUN` à `true`

## Channel de notifications à part

Au vu du nombre de notifications envoyées, et même si les notifications à mattermost sont probablement temporaires, j'ai préféré les mettre dans un channel à part pour ne pas mettre encore plus de bruit sur le channel `notifications`. 