### PR TITLE
feat(cron): Reduce monitor inbound email threshold

### DIFF
--- a/app/jobs/monitor_inbound_emails_activity_job.rb
+++ b/app/jobs/monitor_inbound_emails_activity_job.rb
@@ -1,9 +1,9 @@
 class MonitorInboundEmailsActivityJob < ApplicationJob
   def perform
-    return if inbound_email_received_less_than_7_days_ago?
+    return if inbound_email_received_less_than_4_days_ago?
 
     MattermostClient.send_to_private_channel(
-      "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
+      "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 4 jours!\n" \
       "Dernier email reçu le #{last_inbound_email_received_at.strftime('%d/%m/%Y %H:%M')}"
     )
   end
@@ -16,7 +16,7 @@ class MonitorInboundEmailsActivityJob < ApplicationJob
     end
   end
 
-  def inbound_email_received_less_than_7_days_ago?
-    last_inbound_email_received_at > 7.days.ago
+  def inbound_email_received_less_than_4_days_ago?
+    last_inbound_email_received_at > 4.days.ago
   end
 end

--- a/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
+++ b/spec/jobs/monitor_inbound_emails_activity_job_spec.rb
@@ -4,10 +4,10 @@ describe MonitorInboundEmailsActivityJob do
   end
 
   describe "#perform" do
-    context "when the last inbound email was received less than 7 days ago" do
+    context "when the last inbound email was received less than 4 days ago" do
       before do
         RedisConnection.with_redis do |redis|
-          redis.set("last_inbound_email_received_at", 6.days.ago.to_i)
+          redis.set("last_inbound_email_received_at", 3.days.ago.to_i)
         end
       end
 
@@ -17,8 +17,8 @@ describe MonitorInboundEmailsActivityJob do
       end
     end
 
-    context "when the last inbound email was received more than 7 days ago" do
-      let(:last_inbound_email_received_at) { 8.days.ago }
+    context "when the last inbound email was received more than 4 days ago" do
+      let(:last_inbound_email_received_at) { 5.days.ago }
 
       before do
         RedisConnection.with_redis do |redis|
@@ -28,7 +28,7 @@ describe MonitorInboundEmailsActivityJob do
 
       it "sends a message to Mattermost" do
         expect(MattermostClient).to receive(:send_to_private_channel).with(
-          "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 7 jours!\n" \
+          "⚠️ Les emails des usagers n'ont pas été transérés depuis plus de 4 jours!\n" \
           "Dernier email reçu le #{last_inbound_email_received_at.strftime('%d/%m/%Y %H:%M')}"
         )
         subject


### PR DESCRIPTION
Je me suis rendu compte en mergeant #3000 que 7 jours était peut-être trop long avant de lever une alerte, je l'ai réduit à 4 jours.