### PR TITLE
fix(filters): Fix convocations filters and improve date filterings UX

### DIFF
--- a/app/controllers/concerns/users/filterable.rb
+++ b/app/controllers/concerns/users/filterable.rb
@@ -98,7 +98,12 @@ module Users::Filterable
 
     @users = @users.joins(participations: :notifications)
                    .where(participations: { convocable: true, follow_up: @follow_ups })
-                   .where(notifications: { created_at: ...params[:convocation_date_before].to_date.end_of_day })
+                   .where(
+                     notifications: {
+                       event: "participation_created",
+                       created_at: ...params[:convocation_date_before].to_date.end_of_day
+                     }
+                   )
   end
 
   def filter_users_by_convocation_date_after
@@ -106,7 +111,12 @@ module Users::Filterable
 
     @users = @users.joins(participations: :notifications)
                    .where(participations: { convocable: true, follow_up: @follow_ups })
-                   .where("notifications.created_at > ?", params[:convocation_date_after].to_date.beginning_of_day)
+                   .where(
+                     notifications: {
+                       event: "participation_created",
+                       created_at: params[:convocation_date_after].to_date.beginning_of_day..
+                     }
+                   )
   end
 
   def filter_users_by_first_invitations

--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -10,4 +10,33 @@ export default class extends Flatpickr {
       locale: French,
     };
   }
+
+  /* eslint-disable no-underscore-dangle */
+  updateAfterDateMin() {
+    const selectedDate = this.element._flatpickr?.selectedDates[0];
+    if (!selectedDate) return;
+
+    // Find the "after" date field in the same container (if many) or in the document and update its min date
+    const container = this.element.closest("[data-controller*='flatpickr']")?.parentElement;
+
+    const afterDateElement = container?.querySelector("[data-flatpickr-role='after']") || document.querySelector("[data-flatpickr-role='after']");
+
+    if (afterDateElement && afterDateElement._flatpickr && afterDateElement !== this.element) {
+      afterDateElement._flatpickr.set("minDate", selectedDate);
+    }
+  }
+
+  updateBeforeDateMax() {
+    const selectedDate = this.element._flatpickr?.selectedDates[0];
+    if (!selectedDate) return;
+
+    // Find the "before" date field in the same container (if many) or in the document and update its max date
+    const container = this.element.closest("[data-controller*='flatpickr']")?.parentElement;
+    const beforeDateElement = container?.querySelector("[data-flatpickr-role='before']") || document.querySelector("[data-flatpickr-role='before']");
+
+    if (beforeDateElement && beforeDateElement._flatpickr && beforeDateElement !== this.element) {
+      beforeDateElement._flatpickr.set("maxDate", selectedDate);
+    }
+  }
+  /* eslint-enable no-underscore-dangle */
 }

--- a/app/views/dates_filterings/convocation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/convocation_dates_filterings/new.html.erb
@@ -9,6 +9,8 @@
         value: params[:convocation_date_after],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateAfterDateMin",
+          flatpickr_role: "before",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today
@@ -19,6 +21,8 @@
         value: params[:convocation_date_before],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateBeforeDateMax",
+          flatpickr_role: "after",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today

--- a/app/views/dates_filterings/creation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/creation_dates_filterings/new.html.erb
@@ -10,6 +10,8 @@
         value: params[:creation_date_after],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateAfterDateMin",
+          flatpickr_role: "before",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today
@@ -20,6 +22,8 @@
         value: params[:creation_date_before],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateBeforeDateMax",
+          flatpickr_role: "after",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today

--- a/app/views/dates_filterings/invitation_dates_filterings/new.html.erb
+++ b/app/views/dates_filterings/invitation_dates_filterings/new.html.erb
@@ -10,6 +10,8 @@
         value: params[:first_invitation_date_after],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateAfterDateMin",
+          flatpickr_role: "before",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today
@@ -20,6 +22,8 @@
         value: params[:first_invitation_date_before],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateBeforeDateMax",
+          flatpickr_role: "after",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today
@@ -33,6 +37,8 @@
         value: params[:last_invitation_date_after],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateAfterDateMin",
+          flatpickr_role: "before",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today
@@ -43,6 +49,8 @@
         value: params[:last_invitation_date_before],
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateBeforeDateMax",
+          flatpickr_role: "after",
           flatpickr_date_format: "d-m-Y",
           flatpickr_min_date: "2021/04/01",
           flatpickr_max_date: Date.today

--- a/app/views/orientations/_orientation_form.html.erb
+++ b/app/views/orientations/_orientation_form.html.erb
@@ -9,6 +9,8 @@
         placeholder: "du",
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateAfterDateMin",
+          flatpickr_role: "before",
           flatpickr_min_date: "2012/04/01",
           flatpickr_max_date: Date.today
         }
@@ -24,6 +26,8 @@
         placeholder: "au",
         data: {
           controller: "flatpickr",
+          action: "change->flatpickr#updateBeforeDateMax",
+          flatpickr_role: "after",
           flatpickr_min_date: "2012/04/01"
         }
       )

--- a/spec/features/agent_can_filter_user_by_convocation_or_invitation_spec.rb
+++ b/spec/features/agent_can_filter_user_by_convocation_or_invitation_spec.rb
@@ -21,12 +21,16 @@ describe "Agents can filter users by convocation or invitation on index page", :
   end
 
   let(:follow_up) { create(:follow_up, user: user3, motif_category:) }
-  let(:participation) { create(:participation, user: user3, follow_up:, convocable: true) }
-  let!(:notification) { create(:notification, participation:, created_at: 3.days.ago) }
+  let(:participation_user3) { create(:participation, user: user3, follow_up:, convocable: true) }
+  let!(:notification_user3) do
+    create(:notification, event: "participation_created", participation: participation_user3, created_at: 3.days.ago)
+  end
 
   let(:follow_up2) { create(:follow_up, user: user1, motif_category:) }
-  let(:participation2) { create(:participation, user: user1, follow_up: follow_up2, convocable: true) }
-  let!(:notification2) { create(:notification, participation: participation2, created_at: 1.day.ago) }
+  let(:participation_user1) { create(:participation, user: user1, follow_up: follow_up2, convocable: true) }
+  let!(:notification_user1) do
+    create(:notification, event: "participation_created", participation: participation_user1, created_at: 1.day.ago)
+  end
 
   before do
     follow_up.set_status
@@ -63,6 +67,18 @@ describe "Agents can filter users by convocation or invitation on index page", :
       expect(page).to have_content(user1.first_name)
       expect(page).to have_no_content(user2.first_name)
       expect(page).to have_no_content(user3.first_name)
+    end
+
+    context "it does not take other notifications into account" do
+      before do
+        create(:notification, event: "participation_updated", participation: participation_user3, created_at: 1.day.ago)
+      end
+
+      it "filters users the same way" do
+        expect(page).to have_content(user1.first_name)
+        expect(page).to have_no_content(user2.first_name)
+        expect(page).to have_no_content(user3.first_name)
+      end
     end
   end
 


### PR DESCRIPTION
## Filtre sur les dates de convocations

Le filtre sur les dates de convocations sur la page index était en fait un filtre sur toutes les notifications envoyées, que ce soit des notifications de création, de modification, d'annulation ou de rappel de rdv.
Or le filtre est censé être sur les convocations et être en accord avec la date affichée dans la liste, à savoir **la date de l'envoi de la notification de rdv créé** (= convocation).
Je corrige cette erreur ici.

## Améliorations de l'UX

J'en profite pour faire une amélioration simple au niveau de l'UX: je me suis rendu compte qu'à chaque fois qu'on propose deux sélections de dates pour un intervalle, il n'y a rien qui empêche au niveau du front de sélectionner une date "après" qui soit antérieure à la date "avant" et vice versa. 
Je mets en place un mécanisme simple pour que cela ne soit plus possible au niveau de l'UI. Pour ce faire j'ajoute deux nouvelle actions au stimulus `flatpick_controller` qui met à jour automatiquement le max et le min à la sélection de la date d'avant et d'après respectivement en fonction du choix de l'autre date.