### PR TITLE
feat(stats): Do not recalculate all stats from beginning

### DIFF
--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -1,22 +1,22 @@
 module Stats
   module MonthlyStats
     class UpsertStatJob < Stats::BaseJob
-      def perform(structure_type, structure_id, until_date_string)
+      def perform(structure_type, structure_id, from_date_string = 1.year.ago.to_s, until_date_string = Time.zone.now.to_s)
         @stat = Stat.find_or_initialize_by(statable_type: structure_type, statable_id: structure_id)
-        @date = @stat.statable&.created_at || DateTime.parse("01/01/2022")
+        date = from_date_string.to_date
 
-        while @date < until_date_string.to_date
-          compute_monthly_stats
+        while date < until_date_string.to_date
+          compute_monthly_stats(date)
 
-          @date += 1.month
+          date += 1.month
         end
       end
 
       private
 
-      def compute_monthly_stats
+      def compute_monthly_stats(date)
         Stat::MONTHLY_STAT_ATTRIBUTES.each do |method_name|
-          Stats::MonthlyStats::ComputeAndSaveSingleStatJob.perform_later(@stat.id, method_name, @date)
+          Stats::MonthlyStats::ComputeAndSaveSingleStatJob.perform_later(@stat.id, method_name, date)
         end
       end
     end

--- a/app/jobs/stats/monthly_stats/upsert_stats_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stats_job.rb
@@ -2,14 +2,14 @@ module Stats
   module MonthlyStats
     class UpsertStatsJob < Stats::BaseJob
       def perform
-        Stats::MonthlyStats::UpsertStatJob.perform_later("Department", nil, Time.zone.now)
+        Stats::MonthlyStats::UpsertStatJob.perform_later("Department", nil)
 
         Department.find_each do |department|
-          Stats::MonthlyStats::UpsertStatJob.perform_later("Department", department.id, Time.zone.now)
+          Stats::MonthlyStats::UpsertStatJob.perform_later("Department", department.id)
         end
 
         Organisation.find_each do |organisation|
-          Stats::MonthlyStats::UpsertStatJob.perform_later("Organisation", organisation.id, Time.zone.now)
+          Stats::MonthlyStats::UpsertStatJob.perform_later("Organisation", organisation.id)
         end
       end
     end

--- a/spec/jobs/stats/monthly_stats/upsert_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/upsert_stat_job_spec.rb
@@ -1,9 +1,10 @@
 describe Stats::MonthlyStats::UpsertStatJob, type: :service do
   subject do
-    described_class.new.perform(structure_type, structure_id, until_date_string)
+    described_class.new.perform(structure_type, structure_id, from_date_string, until_date_string)
   end
 
-  let!(:department) { create(:department, created_at: Time.zone.parse("2022-01-17 12:00:00 +0100")) }
+  let!(:department) { create(:department) }
+  let!(:from_date_string) { "2022-01-17 12:00:00 +0100" }
   let!(:until_date_string) { "2022-05-01 12:00:00 +0100" }
   let!(:date) { until_date_string.to_date }
   let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
@@ -40,7 +41,7 @@ describe Stats::MonthlyStats::UpsertStatJob, type: :service do
       Stat::MONTHLY_STAT_ATTRIBUTES.each do |method_name|
         4.times do |i|
           expect(Stats::MonthlyStats::ComputeAndSaveSingleStatJob).to receive(:perform_later)
-            .with(stat.id, method_name, department.created_at + i.month)
+            .with(stat.id, method_name, from_date_string.to_date + i.month)
             .once
         end
       end


### PR DESCRIPTION
## Contexte

Lorsque nous avons mis en place notre système de calcul de statistiques, on a fait en sorte de recalculer à chaque fois toutes les stats de tous les mois depuis les débuts de l'appli. Cela était notamment utile pour affiner le calcul de nos stats et ajouter des stats au fur et à mesure, et que tout l'historique soit mis à jour automatiquement. 
Maintenant que nous sommes assez confiant sur nos stats, je propose que l'on ne recalcule pas à chaque fois toutes les stats depuis le début, pour plusieurs raisons:

* Avec les suppressions d'usagers et de rdvs pour cause de RGPD, les stats qui datent d'il y a plus de deux ans et qui sont recalculés sont faussés puisqu'on soustrait tout ce qui a été supprimé 
* On pourra récupérer le nombre total de rdvs et d'usagers en faisant la somme de tous les mois. Vu que les anciens comptages ne seront pas écrasés, on pourra alors avoir le nombre total de rdvs/usagers sans soustraire les rdvs et usagers qui ont été supprimés pour RGPD
* Même si ce calcul se fait le week-end de manière asynchrone, on peut économiser des ressources sur des calculs qui ne sont pas nécessaires

## Solution

Je fais donc en sorte que le calcul des stats par mois se fasse que sur l'année qui vient de passer. Ainsi on ne recalcule pas les données qui datent d'il y a plus d'un an, et ça nous permet d'éviter le faussement de la donnée à cause des suppression RGPD.
Ce choix d'un an est arbitraire, mais il nous permet à la fois:
* D'être confiant que tous les statuts de rdvs sont bien à jour
* Les données ne soient pas supprimés. En théorie une orga peut choisir une durée de rétention inférieur à un an, si jamais c'est le cas on pourra revoir ce mécanisme et setter cette valeur dynamiquement