### PR TITLE
fix(ft): France Travail webhooks fix

### DIFF
--- a/app/jobs/outgoing_webhooks/france_travail/base_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/base_job.rb
@@ -3,7 +3,7 @@ module OutgoingWebhooks
     class BaseJob < ApplicationJob
       include LockedAndOrderedJobs
 
-      discard_on FranceTravailApi::RetrieveUserToken::NoMatchingUser
+      discard_on FranceTravailApi::RetrieveUserToken::NoMatchingUser, FranceTravailApi::RetrieveUserToken::AccessForbidden
 
       def self.lock_key(participation_id:, **)
         "#{base_lock_key}:#{participation_id}"

--- a/app/jobs/outgoing_webhooks/france_travail/base_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/base_job.rb
@@ -3,7 +3,8 @@ module OutgoingWebhooks
     class BaseJob < ApplicationJob
       include LockedAndOrderedJobs
 
-      discard_on FranceTravailApi::RetrieveUserToken::NoMatchingUser, FranceTravailApi::RetrieveUserToken::AccessForbidden
+      discard_on FranceTravailApi::RetrieveUserToken::NoMatchingUser,
+                 FranceTravailApi::RetrieveUserToken::AccessForbidden
 
       def self.lock_key(participation_id:, **)
         "#{base_lock_key}:#{participation_id}"

--- a/app/jobs/outgoing_webhooks/france_travail/upsert_participation_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/upsert_participation_job.rb
@@ -4,7 +4,7 @@ module OutgoingWebhooks
       def perform(participation_id:, timestamp:)
         participation = Participation.find_by(id: participation_id)
 
-        return unless participation
+        return unless participation&.eligible_for_france_travail_webhook?
 
         if participation.france_travail_id?
           call_service!(FranceTravailApi::UpdateParticipation, participation:, timestamp:)

--- a/app/services/france_travail_api/retrieve_user_token.rb
+++ b/app/services/france_travail_api/retrieve_user_token.rb
@@ -25,11 +25,9 @@ module FranceTravailApi
     end
 
     def handle_success
-      if no_matching_user?
-        raise NoMatchingUser, "Aucun usager trouvé avec l'id #{@user.id}"
-      else
-        @france_travail_user_token = @response_body["jetonUsager"]
-      end
+      raise NoMatchingUser, "Aucun usager trouvé avec l'id #{@user.id}" if no_matching_user?
+
+      @france_travail_user_token = @response_body["jetonUsager"]
     end
 
     def no_matching_user?
@@ -41,7 +39,7 @@ module FranceTravailApi
 
     def handle_error
       error_message = "Erreur lors de l'appel à l'api recherche-usager FT.\n" \
-        "Status: #{@response.status}\n Body: #{@response.body.force_encoding('UTF-8')}"
+                      "Status: #{@response.status}\n Body: #{@response.body.force_encoding('UTF-8')}"
 
       Rails.logger.error(error_message)
 

--- a/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
@@ -63,6 +63,22 @@ describe OutgoingWebhooks::FranceTravail::UpsertParticipationJob do
           end.not_to raise_error
         end
       end
+
+      context "when update service fails with AccessForbidden error" do
+        before do
+          allow(FranceTravailApi::UpdateParticipation).to receive(:call)
+            .and_raise(FranceTravailApi::RetrieveUserToken::AccessForbidden, "Aucun usager trouvé")
+        end
+
+        it "discards the job without raising an error" do
+          expect do
+            described_class.perform_now(
+              participation_id: participation.id,
+              timestamp: timestamp
+            )
+          end.not_to raise_error
+        end
+      end
     end
 
     context "when participation is not found" do

--- a/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
@@ -1,10 +1,10 @@
 describe OutgoingWebhooks::FranceTravail::UpsertParticipationJob do
   subject { described_class.perform_now(participation_id: participation.id, timestamp: timestamp) }
+
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, organisation_type: "delegataire_rsa", department: department) }
   let!(:timestamp) { Time.zone.parse("21/01/2023 23:42:11") }
   let!(:participation) { create(:participation, france_travail_id: nil) }
-
 
   before do
     travel_to timestamp

--- a/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/upsert_participation_job_spec.rb
@@ -1,149 +1,56 @@
 describe OutgoingWebhooks::FranceTravail::UpsertParticipationJob do
+  subject { described_class.perform_now(participation_id: participation.id, timestamp: timestamp) }
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, organisation_type: "delegataire_rsa", department: department) }
-  let!(:now) { Time.zone.parse("21/01/2023 23:42:11") }
+  let!(:timestamp) { Time.zone.parse("21/01/2023 23:42:11") }
+  let!(:participation) { create(:participation, france_travail_id: nil) }
+
 
   before do
-    travel_to now
-    allow(described_class).to receive(:perform_later)
-  end
-
-  describe "callbacks" do
-    context "when the organisation is eligible for France Travail webhooks" do
-      let!(:rdv) { build(:rdv) }
-
-      context "when user has a valid nir" do
-        let!(:user) { create(:user, :with_valid_nir) }
-        let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-        it "notifies via upsert job on creation" do
-          expect(described_class).to receive(:perform_later)
-          participation.save
-        end
-
-        context "on update" do
-          let!(:participation) { create(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-          it "notifies via upsert job on update" do
-            expect(described_class).to receive(:perform_later)
-            participation.save
-          end
-        end
-      end
-
-      context "when user has a valid France Travail ID" do
-        let!(:user) { create(:user, france_travail_id: "12345678901") }
-        let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-        it "notifies via upsert job" do
-          expect(described_class).to receive(:perform_later)
-          participation.save
-        end
-      end
-
-      context "when user is not eligible" do
-        let!(:user) { create(:user, france_travail_id: "12345671") } # ID invalide
-        let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-        it "does not send webhook" do
-          expect(described_class).not_to receive(:perform_later)
-          participation.save
-        end
-      end
-    end
-
-    context "when organisation is not eligible (france_travail type)" do
-      let!(:organisation) { create(:organisation, organisation_type: "france_travail", department: department) }
-      let!(:user) { create(:user, :with_valid_nir) }
-      let!(:rdv) { build(:rdv) }
-      let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-      it "does not send webhook" do
-        expect(described_class).not_to receive(:perform_later)
-        participation.save
-      end
-    end
-
-    context "when department has webhooks disabled" do
-      let!(:department) { create(:department, disable_ft_webhooks: true) }
-      let!(:organisation) { create(:organisation, organisation_type: "delegataire_rsa", department: department) }
-      let!(:user) { create(:user, :with_valid_nir) }
-      let!(:rdv) { build(:rdv) }
-      let!(:participation) { build(:participation, rdv: rdv, user: user, organisation: organisation) }
-
-      it "does not send webhook" do
-        expect(described_class).not_to receive(:perform_later)
-        participation.save
-      end
-    end
+    travel_to timestamp
+    allow(FranceTravailApi::CreateParticipation).to receive(:call)
+      .and_return(OpenStruct.new(success?: true, errors: []))
+    allow(FranceTravailApi::UpdateParticipation).to receive(:call)
+      .and_return(OpenStruct.new(success?: true, errors: []))
+    allow_any_instance_of(Participation).to receive(:eligible_for_france_travail_webhook?).and_return(true)
   end
 
   describe "#perform" do
-    let(:create_service) { instance_double(FranceTravailApi::CreateParticipation, result: service_result) }
-    let(:update_service) { instance_double(FranceTravailApi::UpdateParticipation, result: service_result) }
-    let(:service_result) { OpenStruct.new(errors: []) }
-    let(:timestamp) { Time.current }
-
     context "when participation has no france_travail_id" do
-      let(:participation) { create(:participation, france_travail_id: nil) }
-
-      before do
-        allow(FranceTravailApi::CreateParticipation).to receive(:new).and_return(create_service)
-        allow(create_service).to receive(:call)
-        allow(FranceTravailApi::UpdateParticipation).to receive(:new).and_return(update_service)
-        allow(update_service).to receive(:call)
-      end
-
       it "calls CreateParticipation service only" do
-        described_class.perform_now(
-          participation_id: participation.id,
-          timestamp: timestamp
-        )
+        subject
 
-        expect(create_service).to have_received(:call)
-        expect(update_service).not_to have_received(:call)
+        expect(FranceTravailApi::CreateParticipation).to have_received(:call)
+        expect(FranceTravailApi::UpdateParticipation).not_to have_received(:call)
       end
     end
 
     context "when participation has a france_travail_id" do
       let(:participation) { create(:participation, france_travail_id: "ft-123") }
 
-      before do
-        allow(FranceTravailApi::UpdateParticipation).to receive(:new).and_return(update_service)
-        allow(update_service).to receive(:call).and_return(service_result)
-        allow(FranceTravailApi::CreateParticipation).to receive(:new).and_return(create_service)
-        allow(create_service).to receive(:call)
-      end
-
       it "calls UpdateParticipation service only" do
-        described_class.perform_now(
-          participation_id: participation.id,
-          timestamp: timestamp
-        )
+        subject
 
-        expect(update_service).to have_received(:call)
-        expect(create_service).not_to have_received(:call)
+        expect(FranceTravailApi::UpdateParticipation).to have_received(:call)
+        expect(FranceTravailApi::CreateParticipation).not_to have_received(:call)
       end
 
       context "when update service fails with regular error" do
         before do
-          allow(update_service).to receive(:call)
+          allow(FranceTravailApi::UpdateParticipation).to receive(:call)
             .and_raise(ApplicationJob::FailedServiceError, "Some error")
         end
 
         it "raises a FailedServiceError" do
           expect do
-            described_class.perform_now(
-              participation_id: participation.id,
-              timestamp: timestamp
-            )
+            subject
           end.to raise_error(ApplicationJob::FailedServiceError)
         end
       end
 
       context "when update service fails with NoMatchingUser error" do
         before do
-          allow(update_service).to receive(:call)
+          allow(FranceTravailApi::UpdateParticipation).to receive(:call)
             .and_raise(FranceTravailApi::RetrieveUserToken::NoMatchingUser, "Aucun usager trouvé")
         end
 
@@ -159,22 +66,27 @@ describe OutgoingWebhooks::FranceTravail::UpsertParticipationJob do
     end
 
     context "when participation is not found" do
+      it "discards the job without raising an error" do
+        described_class.perform_now(
+          participation_id: 999_999,
+          timestamp: timestamp
+        )
+
+        expect(FranceTravailApi::UpdateParticipation).not_to have_received(:call)
+        expect(FranceTravailApi::CreateParticipation).not_to have_received(:call)
+      end
+    end
+
+    context "when participation is not eligible to ft webhooks" do
       before do
-        allow(FranceTravailApi::CreateParticipation).to receive(:new).and_call_original
-        allow(FranceTravailApi::UpdateParticipation).to receive(:new).and_call_original
+        allow_any_instance_of(Participation).to receive(:eligible_for_france_travail_webhook?).and_return(false)
       end
 
       it "discards the job without raising an error" do
-        expect do
-          perform_enqueued_jobs do
-            described_class.perform_now(
-              participation_id: 999_999,
-              timestamp: timestamp
-            )
-          end
-        end.not_to raise_error
+        subject
 
-        assert_no_enqueued_jobs
+        expect(FranceTravailApi::UpdateParticipation).not_to have_received(:call)
+        expect(FranceTravailApi::CreateParticipation).not_to have_received(:call)
       end
     end
   end

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -297,6 +297,15 @@ describe Participation do
         expect(subject).to eq(false)
       end
     end
+
+    context "when the department has disabled France Travail webhooks" do
+      let!(:department) { create(:department, disable_ft_webhooks: true) }
+      let!(:organisation) { create(:organisation, organisation_type: "conseil_departemental", department:) }
+
+      it "is not eligible" do
+        expect(subject).to eq(false)
+      end
+    end
   end
 
   describe "france travail webhook callbacks on update" do

--- a/spec/services/france_travail_api/retrieve_user_token_spec.rb
+++ b/spec/services/france_travail_api/retrieve_user_token_spec.rb
@@ -55,7 +55,7 @@ describe FranceTravailApi::RetrieveUserToken do
       end
 
       context "when the API call fails" do
-        let(:response_body) { { "jetonUsager" => nil, "codeRetour" => "R001" }.to_json }
+        let(:response_body) { { "jetonUsager" => nil, "codeRetour" => "123" }.to_json }
 
         before do
           allow(france_travail_client).to receive(:retrieve_user_token_by_nir)
@@ -69,6 +69,20 @@ describe FranceTravailApi::RetrieveUserToken do
           expect(subject.errors).to eq(
             ["Erreur lors de l'appel à l'api recherche-usager FT.\nStatus: 400\n Body: #{response_body}"]
           )
+        end
+
+        context "when the API call returns a 403 with codeRetour R001" do
+          let(:response_body) { { "jetonUsager" => nil, "codeRetour" => "R001" }.to_json }
+
+          before do
+            allow(france_travail_client).to receive(:retrieve_user_token_by_nir)
+              .with(payload: expected_payload, headers: headers)
+              .and_return(OpenStruct.new(success?: false, status: 403, body: response_body))
+          end
+
+          it "returns an error" do
+            expect { subject }.to raise_error(FranceTravailApi::RetrieveUserToken::AccessForbidden)
+          end
         end
       end
 


### PR DESCRIPTION
closes #2963 

On fait en sorte ici d'ignorer l'erreur "accès non autorisé" lors de l'appel à l'API FT. Comme expliqué dans l'issue cette erreur arrive de rare fois quand l'usager n'est pas dans notre scope d'usagers FT, auquel cas il ne sert à rien de retenter l'appel.

## Changements annexes

* Je fais également en sorte de ne pas appeler l'API si la participation n'est plus éligible à être envoyée chez FT entre le moment où on a enqueue le job et le moment où on lance le job. On a notamment un cas d'erreur où on essaie de retenter un appel pour un usager supprimé
* J'ai un peu reformatté l'écriture du test du job parce qu'il comprenait de la logique de callback plutôt liée au model `Participation`.

## Reste à faire

Il y a encore l'erreur "ID_NON_RECONNU" au moment d'un update d'une participation qui n'est pas pris en compte. On attend le retour de @Michaelvilleneuve pour avoir un retour du support de FT et voir si c'est ok de discard ces erreurs aussi.