### PR TITLE
fix(invitations): Set explicit error when no category configuration

### DIFF
--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -73,7 +73,9 @@ class InviteUser < BaseService
 
         all_configurations.first
       else
-        all_configurations.find { |c| c.motif_category_id == motif_category.id }
+        all_configurations.find { |c| c.motif_category_id == motif_category.id }.tap do |configuration|
+          fail!("L'organisation de l'usager n'est pas configurée pour cette catégorie de motif") if configuration.nil?
+        end
       end
   end
 

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -54,6 +54,20 @@ describe InviteUser, type: :service do
       subject
     end
 
+    context "when the user has no linked category configurations for this motif category" do
+      before do
+        category_configuration.update!(motif_category: create(:motif_category))
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+
+      it "stores the error" do
+        expect(subject.errors).to eq(["L'organisation de l'usager n'est pas configurée pour cette catégorie de motif"])
+      end
+    end
+
     context "when there is no motif category attributes" do
       let!(:motif_category_attributes) { {} }
 


### PR DESCRIPTION
Il peut arriver, lorsqu'on fait un upload au niveau du territoire, que l'usager soit placé dans une organisation qui ne gère pas la catégorie dans laquelle on fait l'upload.
Si tel est le cas, aucune `category_configuration` n'est trouvé dans le service `InviteUser` et on se retrouve avec ce type d'erreur: https://sentry.incubateur.net/organizations/betagouv/issues/189455/events/206a4e83e8e9456ea02febbb9698fa1d/

En attendant de voir si on ne prévient pas en amont que l'usager est placé dans ce type de catégorie, je mets un message d'erreur plus explicite au niveau du service.