### PR TITLE
fix(upload): Set more precise user_row#saved_user method

### DIFF
--- a/app/models/user_list_upload/user_row.rb
+++ b/app/models/user_list_upload/user_row.rb
@@ -56,7 +56,7 @@ class UserListUpload::UserRow < ApplicationRecord
   end
 
   def saved_user
-    user_save_attempts.last&.user
+    user_save_attempts.find(&:success?)&.user
   end
 
   def matching_user_attribute_changed?(attribute)


### PR DESCRIPTION
On a eu quelques reports d'erreurs où le `user` passé au service `InviteUser` depuis l'upload était `nil`: https://sentry.incubateur.net/organizations/betagouv/issues/188138/?environment=production&project=16&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1

Le service est appelé depuis la méthode `create_from_row` du model `UserListUpload::InvitationAttempt` ici: https://github.com/gip-inclusion/rdv-insertion/blob/ee01214972e1d266de260c057d7d6f43cb8b0cc8/app/models/user_list_upload/invitation_attempt.rb#L9

Cela veut dire que dans ces cas-là, `user_row.saved_user` renvoie `nil`, alors qu'on a bien à faire à des `user_row` qui ont été sauvegardées avec succès. 

J'essaie ici de changer la méthode `saved_user` qui prenait le `user` dernier `user_save_attempt` lié à ligne en question, pour explicitement dire de prendre le `user` lié à une sauvegarde ayant été un succès.
On va voir si cela résout l'erreur.