### PR TITLE
fix(webhooks): do not send webhook when destruction fails

### DIFF
--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -41,7 +41,9 @@ module WebhookDeliverable
       generate_webhook_payload(:destroyed, endpoint.organisation_type)
     end
     # Execute la suppression, après avoir construit les données à envoyer
-    yield if block_given?
+    result = yield if block_given?
+    return if result == false
+
     payloads.each do |endpoint, payload|
       OutgoingWebhooks::SendWebhookJob.perform_later(endpoint.id, payload)
     end


### PR DESCRIPTION
Je me suis rendu compte que l'on avait un problème dans le callback `around_destroy` sur le concern `WebhookDeliverable`: si on appelle la méthode `destroy` sur un record et que cette méthode renvoie `false` (la transaction échoue), on envoie quand même le webhook de destruction. 
Je pense que c'est jamais arrivé parce qu'on supprime jamais la donnée silencieusement (= sans utiliser `destroy!`), mais il est important de rectifier ce comportement.

P.S: sur rdv-sp on a pas ce "bug" parce qu'on enqueue les jobs en créant des entrées dans la table d'exécutions de `good_job`, et du coup cet insert est rollback en même temps que le rollback du record en question. Vu qu'on utilise redis pour pusher nos jobs on n'a pas le même comportement.