### PR TITLE
fix(file_configurations): Order file configurations

### DIFF
--- a/app/controllers/category_configurations_controller.rb
+++ b/app/controllers/category_configurations_controller.rb
@@ -85,7 +85,7 @@ class CategoryConfigurationsController < ApplicationController
       FileConfiguration
       .preload(:organisations, category_configurations: [:motif_category, :organisation])
       .where(id: department_scope_file_configuration_ids + agent_scope_file_configuration_ids)
-      .distinct
+      .distinct.order(:created_at)
   end
 
   def department_scope_file_configuration_ids

--- a/app/controllers/concerns/cookies_consent_concern.rb
+++ b/app/controllers/concerns/cookies_consent_concern.rb
@@ -8,6 +8,6 @@ module CookiesConsentConcern
   private
 
   def set_should_display_cookies_consent
-    @should_display_cookies_consent = logged_in? && current_agent.cookies_consent.nil?
+    @should_display_cookies_consent = logged_in? && current_agent.cookies_consent.nil? && !agent_impersonated?
   end
 end


### PR DESCRIPTION
Cette PR apporte deux mini fixs:

* Je trie les `file_configurations` par rapport à leur date de création suite à #3014 pour une meilleure UX
* Je cache la bannière des cookies lorsqu'on se "log en tant que"