### PR TITLE
fix(deps): Patch `with_advisory_lock` gem methods to use Skylight correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,9 +133,9 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     bindex (0.8.1)
     blueprinter (1.1.2)
     bootsnap (1.18.4)
@@ -157,7 +157,7 @@ GEM
     choice (0.2.0)
     chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -180,7 +180,7 @@ GEM
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
       railties (>= 6.1)
-    drb (2.2.1)
+    drb (2.2.3)
     dsfr-assets (1.13.0.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -280,7 +280,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.5)
+    logger (1.7.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -296,7 +296,7 @@ GEM
       rake
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.25.5)
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -609,12 +609,12 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_advisory_lock (5.1.0)
-      activerecord (>= 6.1)
-      zeitwerk (>= 2.6)
+    with_advisory_lock (7.0.1)
+      activerecord (>= 7.2)
+      zeitwerk (>= 2.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.1)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   aarch64-linux

--- a/config/initializers/with_advisory_lock_patch.rb
+++ b/config/initializers/with_advisory_lock_patch.rb
@@ -1,0 +1,42 @@
+Rails.application.config.after_initialize do
+  # Monkey patch for the `with_advisory_lock` gem.
+  #
+  # By default, the gem adds a random `AS` alias to advisory lock SQL queries to prevent Rails caching.
+  # (see https://github.com/ClosureTree/with_advisory_lock/blob/40f9af3a19cbe3fc15b1a891a5e764d41e0089ad/lib/with_advisory_lock/postgresql_advisory.rb#L108).
+
+  # This makes the queries harder to identify and group in Skylight because the alias is random.
+  #
+  # However, this mechanism is old and we can use the `uncached` method to prevent Rails caching instead.
+  # (see https://github.com/ClosureTree/with_advisory_lock/issues/48)
+  # So this patch removes the alias and wraps the SQL call in `uncached`
+  # so Skylight can capture clean, consistent SQL traces like:
+  #   SELECT pg_try_advisory_lock(123,456) /* lock_name */
+
+  # ⚠️ WARNING: This patch relies on private methods of the gem.
+  # It may break things if the gem changes even if it's tested, so watch for version updates!
+
+  expected_gem_version = Gem::Version.new("7.0.1")
+  actual_gem_version = Gem.loaded_specs["with_advisory_lock"]&.version
+
+  if actual_gem_version != expected_gem_version
+    error_message = "\n[with_advisory_lock_patch] ⚠️ Expected with_advisory_lock version #{expected_gem_version}, " \
+                    "but got #{actual_gem_version}.\n" \
+                    "Please review the patch and update the expected version if it works as expected.\n"
+    Rails.env.local? ? raise(error_message) : Rails.logger.error(error_message)
+  end
+
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  module WithAdvisoryLock::PostgreSQLAdvisory
+    private
+
+    def execute_advisory(function, lock_keys, lock_name)
+      uncached { select_value(prepare_sql(function, lock_keys, lock_name)) }.in?(LOCK_RESULT_VALUES)
+    end
+
+    def prepare_sql(function, lock_keys, lock_name)
+      comment = lock_name.to_s.gsub(%r{(/\*)|(\*/)}, "--")
+      "SELECT #{function}(#{lock_keys.join(',')}) /* #{comment} */"
+    end
+  end
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+end

--- a/spec/initializers/with_advisory_lock_patch_spec.rb
+++ b/spec/initializers/with_advisory_lock_patch_spec.rb
@@ -1,6 +1,5 @@
 # This is a regression test to ensure that the with_advisory_lock_patch is applied correctly
 # and does not break the lock mechanism
-
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "with_advisory_lock" do
   after do
@@ -92,7 +91,5 @@ RSpec.describe "with_advisory_lock" do
     expect(uncached_lock_queries).to eq(2)
     expect(cached_lock_queries).to eq(0)
   end
-
-
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/initializers/with_advisory_lock_patch_spec.rb
+++ b/spec/initializers/with_advisory_lock_patch_spec.rb
@@ -1,0 +1,86 @@
+# This is a regression test to ensure that the with_advisory_lock_patch is applied correctly
+# and does not break the lock mechanism
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "with_advisory_lock" do
+  after do
+    # Ensure all DB connections are returned and locks are cleared after each test
+    ActiveRecord::Base.connection_pool.clear_reloadable_connections!
+  end
+
+  # This ensures the with_advisory_lock patch does not break the lock mechanism
+  it "only executes the block in one thread" do
+    lock_key = "test-lock-key"
+    executed = []
+
+    t1 = Thread.new do
+      # Each thread must use its own DB connection to ensure advisory locks work correctly.
+      # `with_connection` also ensures connections are checked back into the pool,
+      # so that locks don't persist after the test and no leaks occur.
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActiveRecord::Base.with_advisory_lock(lock_key, timeout_seconds: 0.1) do
+          executed << :t1
+          sleep 0.2
+        end
+      end
+    end
+
+    t2 = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActiveRecord::Base.with_advisory_lock(lock_key, timeout_seconds: 0.1) do
+          executed << :t2
+          sleep 0.2
+        end
+      end
+    end
+
+    [t1, t2].each(&:join)
+
+    expect(executed.size).to eq(1)
+    expect(executed).to contain_exactly(:t1).or contain_exactly(:t2)
+  end
+
+  # This ensures the with_advisory_lock patch does not generate an alias in advisory lock SQL
+  it "does not generate an alias in advisory lock SQL" do
+    sql = nil
+
+    # Capture the SQL run by ActiveRecord
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+      sql = payload[:sql] if payload[:sql].include?("pg_try_advisory_lock") && payload[:sql].include?("/*")
+    end
+
+    ActiveRecord::Base.with_advisory_lock("test-lock-key") { "test" }
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    expect(sql).to be_present
+    expect(sql).to include("/* test-lock-key */")
+    expect(sql).not_to include(" AS ")
+  end
+
+  # we ensure the patch that changed caching is still working as expected
+  it "does not cache advisory lock SQL, but caches inner queries" do
+    sqls = []
+
+    ActiveSupport::Notifications.subscribed(
+      ->(_name, _start, _finish, _id, payload) { sqls << payload[:sql] }, "sql.active_record"
+    ) do
+      # First advisory lock call
+      ActiveRecord::Base.with_advisory_lock("my_lock") do
+        2.times { User.where(email: "foo@example.org").load }
+      end
+
+      # Second advisory lock call
+      ActiveRecord::Base.with_advisory_lock("my_lock") do
+        2.times { User.where(email: "foo@example.org").load }
+      end
+    end
+
+    lock_queries = sqls.select { |sql| sql.include?("pg_try_advisory_lock") }
+    user_queries = sqls.select { |sql| sql.include?("FROM \"users\"") }
+
+    expect(lock_queries.size).to eq(2) # advisory lock should run twice (not cached)
+    expect(user_queries.size).to eq(2) # user query should be cached after first time
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Contexte

Suite à une longue discussion avec le support de Skylight (voir conversation [ici](https://www.notion.so/gip-inclusion/Dev-2475f321b6048054a61fdac00e9e45d1?source=copy_link#2475f321b60480f58bb1d70c87121e56)), il est apparu que Skylight n'arrivait pas bien à aggréger les requêtes sur notre app et que donc les évènements qui sont présentés par l'appli sont incohérents.
Cela vient du fait que la gem `with_advisory_lock` utilise un alias random `AS ...` pour chaque requête de lock appelé via la méthode `ActiveRecord::Base#with_advisory_lock`. 
Cet alias sert probablement à s'assurer que les requêtes de lock ne sont pas cachées par Rails, même si cette façon de faire est désuette depuis que `ActiveRecord::Base.uncached` existe.

Il semblerait que ce comportement ne soit pas amené à changer pour l'instant: https://github.com/ClosureTree/with_advisory_lock/issues/48

## Implémentation

Suite aux suggestions du support de Skylight, je fais donc un patch pour changer les méthodes qui génèrent la requête SQL et enlever l'alias, et à la place utilser la méthode `uncached` pour être sûr que ces requêtes ne sont pas cachées. 

Ce patch est un peu risqué puisqu'on réécrit des méthodes privées, j'ai donc pris quelques actions pour mitiger le risque:

* J'ajoute plusieurs tests pour vérifier:

  * que le comportement originel de la gem ne soit pas affecté
  * que le patch fonctionne bien
  * que la version ne puisse pas être changée silencieusement pour qu'on vérifie que le patch marche bien sur de nouvelles versions