### PR TITLE
fix(dsfr): Remove DSFR undesired animations

### DIFF
--- a/app/javascript/stylesheets/reset_dsfr_overrides.scss
+++ b/app/javascript/stylesheets/reset_dsfr_overrides.scss
@@ -24,6 +24,14 @@
   a[href]:not(.fr-link):hover {
     --underline-hover-width: unset;
   }
+  input[type="radio"]:checked,
+  input[type="checkbox"]:checked,
+  input[type="radio"]:focus,
+  input[type="checkbox"]:focus {
+    outline: none !important;
+    box-shadow: none !important;
+    border: none !important;
+  }
   .btn-blue-out {
     &:hover {
       background-color: $light-grey-2 !important;

--- a/app/javascript/stylesheets/reset_dsfr_overrides.scss
+++ b/app/javascript/stylesheets/reset_dsfr_overrides.scss
@@ -114,15 +114,30 @@
       background-color: $dark-blue;
     }
   }
-  
+
   .btn-grey {
     border-color: $light-grey;
     background-color: white;
     color: black;
   }
-  
+
   .btn-sm {
     min-width: 105px !important;
     padding: 0.25rem;
+  }
+
+  // this avoids the grey hover on links in the header like the logo link
+  .fr-header__brand,
+  .fr-enlarge-link {
+    --background-raised-grey-hover: transparent;
+    --background-raised-grey-active: transparent;
+  }
+
+  // this class can be added to elements that should not have a hover effect
+  .no-hover-bg:hover {
+    background-color: initial !important;
+    // You might also need to override DSFR's CSS custom properties for this button
+    --background-action-high-blue-france: initial;
+    --background-action-high-blue-france-hover: initial;
   }
 }

--- a/app/javascript/stylesheets/reset_dsfr_overrides.scss
+++ b/app/javascript/stylesheets/reset_dsfr_overrides.scss
@@ -8,7 +8,10 @@
 .reset-dsfr-overrides {
   a {
     &::after {
-        display: none;
+      display: none;
+    }
+    &:active {
+      background-color: transparent !important;
     }
   }
   p {

--- a/app/views/common/_flash_content.html.erb
+++ b/app/views/common/_flash_content.html.erb
@@ -9,7 +9,7 @@
           <span><a href="<%= flash_message.link_url %>"><%= flash_message.link_text %></a></span>
         <% end %>
       </div>
-      <button type="button" class="btn-close me-3" data-action="flash#remove" aria-label="Close"></button>
+      <button type="button" class="btn-close no-hover-bg me-3" data-action="flash#remove" aria-label="Close"></button>
     </div>
   </div>
 </div>

--- a/app/views/common/_header_help_menu.html.erb
+++ b/app/views/common/_header_help_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="dropdown" data-controller="dropdown-menu">
-  <button class="btn btn-link btn-header dropdown-toggle accessible" type="button" id="rdvi_header_help-center" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">Besoin d'aide ?</button>
+  <button class="btn btn-link btn-header no-hover-bg dropdown-toggle accessible" type="button" id="rdvi_header_help-center" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">Besoin d'aide ?</button>
   <div data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2">
     <a class="dropdown-item py-3 d-flex justify-content-between" target="_blank" href="https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/configurer-loutil-et-envoyer-des-invitations/envoyer-des-invitations-ou-convocations/importer-des-personnes">
       Importer des usagers

--- a/app/views/common/_header_website.html.erb
+++ b/app/views/common/_header_website.html.erb
@@ -38,7 +38,7 @@
               <% else %>
                 <li>
                   <%= form_tag("/auth/rdvservicepublic", method: "post", data: { turbo: false }) do %>
-                    <button class="fr-btn fr-icon-lock-line" type='submit'>Connexion agent</button>
+                    <button class="fr-btn fr-icon-lock-line no-hover-bg" type='submit'>Connexion agent</button>
                   <% end %>
                 </li>
               <% end %>

--- a/app/views/layouts/_application_base.html.erb
+++ b/app/views/layouts/_application_base.html.erb
@@ -2,12 +2,12 @@
 <html>
   <%= render 'layouts/head' %>
 
-  <body data-matomo-mask class="<%= "bg-white" if local_assigns[:white_background] %>">
+  <body data-matomo-mask class="reset-dsfr-overrides<%= " bg-white" if local_assigns[:white_background] %>">
     <%= render 'common/matomo_script_tag' if @enable_matomo_tracking %>
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= content_for :header %>
     <%= render 'common/flashes' %>
-    <div class="wrapper reset-dsfr-overrides">
+    <div class="wrapper">
       <%= turbo_frame_tag "remote_modal", target: "_top" %>
       <%= yield %>
       <%= render 'common/accept_cgu_modal' if @should_display_accept_cgu %>


### PR DESCRIPTION
Je me suis rendu compte qu'il y avait plusieurs petits effets de bord avec l'introduction du DSFR qui étaient passés inaperçus et que je tente de corriger ici.

## Animation au clic sur un lien

Lorsqu'on clique sur un lien, il y a un changement de la couleur du background de tout l'élément `a` , ce qui peut faire des effets très moches lorsque l'élément cliquable est plus petit que le lien par exemple lorsqu'un bouton est wrapped dans un lien:

<img width="1327" height="85" alt="image" src="https://github.com/user-attachments/assets/9b4a2fcf-02b3-4a09-b14b-110f9eebd55e" />

C'est fix en ajoutant cet override à la classe `.reset-dsfr-overrides`: https://github.com/gip-inclusion/rdv-insertion/commit/9427fb1ffcca17af318df0f3c8d5c917ded95e78

## Animation à la sélection d'une option

Lorsqu'on sélectionne un input, l'input sélectionné a une bordure par défaut qui donne un effet désagréable, par exemple ici: 

<img width="767" height="114" alt="image" src="https://github.com/user-attachments/assets/b350d5c0-243e-4a7b-8dcf-26177e325a08" />

<img width="357" height="90" alt="image" src="https://github.com/user-attachments/assets/7307494b-beb2-4803-a757-8efc8b644755" />


Je corrige ça en enlevant les propriétés focus sur les input dans la classe d'override: https://github.com/gip-inclusion/rdv-insertion/commit/2433a6a815487b58ecc8e569df8d13341aad5a1a

## Permettre de ne pas changer le background au hover de certains liens

Il y a certains liens dont je pense qu'on ne veut pas avoir une animation au hover, comme par exemple les liens du header non connecté (lien vers la page d'accueil sur le logo et lien de connexion du bouton): 

<img width="380" height="147" alt="image" src="https://github.com/user-attachments/assets/c8fa137e-562e-4ae6-a2c5-0b29b3d289bb" />

<img width="269" height="87" alt="image" src="https://github.com/user-attachments/assets/3da5373e-e5da-4feb-9351-cfdaea2fb6a1" />


J'ajoute une classe qui permet de les désactiver [ici](https://github.com/gip-inclusion/rdv-insertion/commit/894a9d5b309af4d5110b271ffadd295258c0bbfa) et je désactive pour les liens du header et du footer **en ajoutant la classe `reset-dsfr-overrides`** sur le `body` pour qu'il soit appliqués au headers aussi. 

Je désactive aussi sur le bouton de fermeture des bannières flash:

<img width="240" height="137" alt="image" src="https://github.com/user-attachments/assets/16d0172f-658d-4b96-a993-93c9ed120715" />
