### PR TITLE
feat(user): better handling of deleted users related erros

### DIFF
--- a/app/controllers/concerns/users/ensure_presence_in_structure.rb
+++ b/app/controllers/concerns/users/ensure_presence_in_structure.rb
@@ -1,0 +1,12 @@
+module Users::EnsurePresenceInStructure
+  extend ActiveSupport::Concern
+
+  private
+
+  def ensure_user_presence_in_structure
+    return if @user.present?
+
+    flash[:error] = "Aucun utilisateur trouvé avec cet identifiant dans votre structure. L'utilisateur a peut-être été archivé ou supprimé de votre structure."
+    redirect_to structure_users_path
+  end
+end

--- a/app/controllers/users/follow_ups_controller.rb
+++ b/app/controllers/users/follow_ups_controller.rb
@@ -1,6 +1,8 @@
 module Users
   class FollowUpsController < ApplicationController
-    before_action :set_user, :set_department, :set_organisation, :set_user_department_organisations,
+    include Users::EnsurePresenceInStructure
+
+    before_action :set_user, :ensure_user_presence_in_structure, :set_department, :set_organisation, :set_user_department_organisations,
                   :set_all_configurations, :set_user_tags,
                   :set_back_to_users_list_url, only: [:index]
 
@@ -23,10 +25,10 @@ module Users
     private
 
     def set_user
-      @user = policy_scope(User).preload(
+      @user = policy_scope(User).where(current_organisations_filter).preload(
         organisations: [:department, :motif_categories], follow_ups: :participations,
         tags: :tag_organisations, invitations: :follow_up
-      ).find(params[:user_id])
+      ).find_by(id: params[:user_id])
     end
 
     def set_department

--- a/app/controllers/users/parcours_controller.rb
+++ b/app/controllers/users/parcours_controller.rb
@@ -1,6 +1,8 @@
 module Users
   class ParcoursController < ApplicationController
-    before_action :set_user, :set_user_tags, :set_back_to_users_list_url,
+    include Users::EnsurePresenceInStructure
+
+    before_action :set_user, :ensure_user_presence_in_structure, :set_user_tags, :set_back_to_users_list_url,
                   :ensure_has_access_to_parcours, only: [:show]
 
     include BackToListConcern
@@ -26,7 +28,7 @@ module Users
     end
 
     def set_user
-      @user = policy_scope(User).preload(:archives).find(params[:user_id])
+      @user = policy_scope(User).where(current_organisations_filter).preload(:archives).find_by(id: params[:user_id])
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,20 +13,21 @@ class UsersController < ApplicationController
   include Users::Sortable
   include Users::Taggable
   include Users::ArchivedList
+  include Users::EnsurePresenceInStructure
 
   before_action :set_organisation, :set_department, :set_all_configurations,
                 :set_users_scope, :set_current_category_configuration, :set_current_motif_category,
                 :set_users, :set_follow_ups, :set_orientation_types, :set_filterable_tags,
                 :set_referents_list, :filter_users, :order_users,
                 for: :index
-  before_action :set_user, :set_organisation, :set_department, :set_all_configurations,
+  before_action :set_user, :ensure_user_presence_in_structure, :set_organisation, :set_department, :set_all_configurations,
                 :set_user_tags, :set_user_referents, :set_back_to_users_list_url,
                 for: :show
   before_action :set_organisation, :set_department,
                 for: :new
   before_action :set_organisation, :set_department,
                 for: :create
-  before_action :set_user, :set_organisation, :set_department,
+  before_action :set_user, :ensure_user_presence_in_structure, :set_organisation, :set_department,
                 for: [:edit, :update]
   before_action :reset_tag_users, only: :update
   after_action :store_back_to_users_list_url, only: [:index]
@@ -159,7 +160,7 @@ class UsersController < ApplicationController
       .preload(:tag_users)
       .where(current_organisations_filter)
       .preload(:archives)
-      .find(params[:id])
+      .find_by(id: params[:id])
   end
 
   def set_organisation

--- a/spec/controllers/users/follow_ups_controller_spec.rb
+++ b/spec/controllers/users/follow_ups_controller_spec.rb
@@ -101,6 +101,17 @@ describe Users::FollowUpsController do
         expect(response.body).not_to match(/Convoqué par/)
       end
 
+      context "when user no longer exists" do
+        let(:user_from_another_organisation) { create(:user, organisations: [create(:organisation)]) }
+
+        it "redirects with authorization error" do
+          get :index, params: { user_id: user_from_another_organisation.id, organisation_id: organisation.id }
+
+          expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
+          expect(flash[:error]).to include("Aucun utilisateur trouvé avec cet identifiant")
+        end
+      end
+
       context "when a follow_up is not open" do
         let!(:follow_up2) { nil }
         let!(:invitation_accompagnement) { nil }

--- a/spec/controllers/users/parcours_controller_spec.rb
+++ b/spec/controllers/users/parcours_controller_spec.rb
@@ -28,6 +28,17 @@ describe Users::ParcoursController do
       end
     end
 
+    context "when user no longer exists" do
+      let(:user_from_another_organisation) { create(:user, organisations: [create(:organisation)]) }
+
+      it "redirects with authorization error" do
+        get :index, params: { user_id: user_from_another_organisation.id, organisation_id: organisation.id }
+
+        expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
+        expect(flash[:error]).to include("Aucun utilisateur trouvé avec cet identifiant")
+      end
+    end
+
     context "when organization type doesn't have parcours access" do
       let!(:non_parcours_organisation) { create(:organisation, department: department, organisation_type: "autre") }
       let!(:non_parcours_agent) { create(:agent, basic_role_in_organisations: [non_parcours_organisation]) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -218,6 +218,18 @@ describe UsersController do
       end
     end
 
+    context "when user no longer exists" do
+      let(:user_from_another_organisation) { create(:user, organisations: [create(:organisation)]) }
+      let!(:show_params) { { id: user_from_another_organisation.id, organisation_id: organisation.id } }
+
+      it "redirects with authorization error" do
+        get :show, params: show_params
+
+        expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
+        expect(flash[:error]).to include("Aucun utilisateur trouvé avec cet identifiant")
+      end
+    end
+
     context "when department_level" do
       let!(:show_params) { { id: user.id, department_id: department.id } }
 
@@ -1034,9 +1046,8 @@ describe UsersController do
         end
 
         it "does not call the service" do
-          expect do
-            post :update, params: update_params
-          end.to raise_error(ActiveRecord::RecordNotFound)
+          post :update, params: update_params
+          expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
         end
       end
 
@@ -1203,10 +1214,27 @@ describe UsersController do
           sign_in(another_agent)
         end
 
-        it "does not call the service" do
-          expect do
-            patch :update, params: update_params
-          end.to raise_error(ActiveRecord::RecordNotFound)
+        it "redirects with authorization error" do
+          patch :update, params: update_params
+          expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
+        end
+      end
+
+      context "when user no longer exists" do
+        let(:user_from_another_organisation) { create(:user, organisations: [create(:organisation)]) }
+        let!(:update_params) do
+          { 
+            id: user_from_another_organisation.id, 
+            organisation_id: organisation.id, 
+            user: { first_name: "Alain", last_name: "Deloin", phone_number: "0123456789" } 
+          }
+        end
+  
+        it "redirects with authorization error" do
+          patch :update, params: update_params
+  
+          expect(response).to redirect_to(organisation_users_path(organisation_id: organisation.id))
+          expect(flash[:error]).to include("Aucun utilisateur trouvé avec cet identifiant")
         end
       end
 


### PR DESCRIPTION
Cette PR permet de mieux gérer des cas d'erreurs lié au fait de conserver des onglets ouverts sur des usagers supprimés, ou liés au fait de naviguer les pages d'un usager qu'un autre agent a supprimé / retiré de la structure entre temps.

Concrètement cette PR rajoute via un concern un check qui lorsque l'usager n'est pas set fait une redirection vers la page de la structure. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2960