### PR TITLE
fix(error): RDVS motifs link is incorrect

### DIFF
--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -96,7 +96,7 @@ module Invitations
       add_templated_error(message: "Aucun motif de suivi n'a été défini pour la catégorie #{motif_category_name}",
                           template_name: "no_follow_up_category",
                           locals: {
-                            organisation_id: organisations.first.id,
+                            rdv_solidarites_organisation_id: organisations.first.rdv_solidarites_organisation_id,
                             motif_category_name: motif_category_name
                           })
     end

--- a/spec/services/invitations/validate_spec.rb
+++ b/spec/services/invitations/validate_spec.rb
@@ -209,7 +209,7 @@ describe Invitations::Validate, type: :service do
               message: "Aucun motif de suivi n'a été défini pour la catégorie #{category_orientation.name}",
               template_name: "no_follow_up_category",
               locals: { motif_category_name: "RSA orientation",
-                        organisation_id: organisation.id }
+                        rdv_solidarites_organisation_id: organisation.rdv_solidarites_organisation_id }
             )
           )
         end


### PR DESCRIPTION
Le lien envoyé dans la page d'erreur permettant de rediriger sur RDVS n'est pas bon il pointe vers rdvs avec un ID d'orga rdvi