### PR TITLE
bug(ui): app links are black after new website deployment

### DIFF
--- a/app/javascript/stylesheets/components/_button.scss
+++ b/app/javascript/stylesheets/components/_button.scss
@@ -44,10 +44,6 @@ button, input[type="button"] {
   a {
     color: $info;
   }
-
-  a:hover {
-    color: $info;
-  }
 }
 
 .badge-tag.text-brown i {

--- a/app/javascript/stylesheets/reset_dsfr_overrides.scss
+++ b/app/javascript/stylesheets/reset_dsfr_overrides.scss
@@ -6,23 +6,6 @@
 *
 */
 .reset-dsfr-overrides {
-  a {
-    text-decoration: none;
-    color: black;
-  
-    &:hover {
-      color: black;
-    }
-  }
-
-  a {
-    &::after {
-      display: none;
-    }
-    &:active {
-      background-color: transparent !important;
-    }
-  }
   p {
     line-height: normal;
   }
@@ -71,10 +54,10 @@
     width: 50px;
     min-width: 50px !important;
     height: 50px;
-  
+
     &.has-notification {
       @extend .btn-blue;
-  
+
       &::after {
         content: "";
         position: absolute;
@@ -87,19 +70,19 @@
       }
     }
   }
-  
+
   .btn-header {
     height: 50px;
     max-width: 350px;
   }
-  
+
   #rdvi_header_organisation-nav {
     @extend .btn;
     @extend .btn-header;
     @extend .btn-blue-out;
     min-width: 200px;
   }
-  
+
   .btn-blue {
     background-color: $dark-blue;
     border-color: $dark-blue;
@@ -114,7 +97,7 @@
       min-width: 0;
     }
   }
-  
+
   .btn-blue-out {
     border-color: $dark-blue;
     background-color: white;


### PR DESCRIPTION
Suite à https://github.com/gip-inclusion/rdv-insertion/pull/3043
On s'est aperçu que les liens a dans l'app ont quelquefois la mauvaise couleur.
C'est surement lié à un pbl d'override du dsfr.

<img width="1601" height="519" alt="Capture d’écran 2025-09-18 à 11 56 16" src="https://github.com/user-attachments/assets/8d6db006-6ece-4fb2-bfcc-0dce0b7e3993" />
