### PR TITLE
fix(stats): incorrect margins

### DIFF
--- a/app/javascript/stylesheets/components/_stat.scss
+++ b/app/javascript/stylesheets/components/_stat.scss
@@ -1,7 +1,9 @@
 .highlight-stat {
+  margin-top: 30px;
+
   &.big {
     font-size: 3rem;
-    margin-bottom: 0rem;
+    margin-bottom: 1rem;
   }
   &.margin-left {
     margin-left: 20px;


### PR DESCRIPTION
Cette PR corrige un problème de marge causé par l'ajout du DSFR sur le template du website

<img width="1163" height="739" alt="Screenshot 2025-09-18 at 15 23 25" src="https://github.com/user-attachments/assets/4c5e1000-afcc-42e5-bdd8-17d4a0f62d67" />
