### PR TITLE
fix(ui): keep chevron always visible in organisation select dropdown

### DIFF
--- a/app/javascript/stylesheets/components/_dropdown.scss
+++ b/app/javascript/stylesheets/components/_dropdown.scss
@@ -47,6 +47,21 @@
   box-shadow: none !important;
 }
 
+.text-truncate-with-chevron {
+  position: relative !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 35px !important;
+
+  &::after {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}
+
 #batch-actions-menu {
   width: 260px;
 }

--- a/app/javascript/stylesheets/components/_dropdown.scss
+++ b/app/javascript/stylesheets/components/_dropdown.scss
@@ -59,6 +59,7 @@
     right: 8px;
     top: 50%;
     transform: translateY(-50%);
+    padding-right: 1.75rem;
   }
 }
 

--- a/app/views/common/_header_organisation_navigation_button.html.erb
+++ b/app/views/common/_header_organisation_navigation_button.html.erb
@@ -1,8 +1,6 @@
 <div id="organisation-navigation" class="dropdown ms-3" data-controller="dropdown-menu">
-  <button id="rdvi_header_organisation-nav" class="dropdown-toggle accessible d-flex align-items-center" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">
-    <span class="text-truncate flex-grow-1">
-      <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
-    </span>
+  <button id="rdvi_header_organisation-nav" class="dropdown-toggle accessible text-truncate-with-chevron" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">
+    <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
   </button>
   <div id="organisation-navigation-dropdown" data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2" data-controller="organisations-list-filter">
     <% if current_agent_department_organisations.length > 10 %>

--- a/app/views/common/_header_organisation_navigation_button.html.erb
+++ b/app/views/common/_header_organisation_navigation_button.html.erb
@@ -1,6 +1,8 @@
 <div id="organisation-navigation" class="dropdown ms-3" data-controller="dropdown-menu">
-  <button id="rdvi_header_organisation-nav" class="dropdown-toggle accessible text-truncate" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">
-    <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
+  <button id="rdvi_header_organisation-nav" class="dropdown-toggle accessible d-flex align-items-center" type="button" data-action="click->dropdown-menu#toggle" data-dropdown-menu-target="button" aria-haspopup="true" aria-expanded="false">
+    <span class="text-truncate flex-grow-1">
+      <i class="<%= department_level? ? "ri-building-line" : "ri-building-4-line" %> me-1"></i> <%= structure_name_with_context(current_structure) %>
+    </span>
   </button>
   <div id="organisation-navigation-dropdown" data-dropdown-menu-target="dropdown" class="dropdown-menu py-0 mt-2" data-controller="organisations-list-filter">
     <% if current_agent_department_organisations.length > 10 %>


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/3033

Avant | Après
:- | -:
<img width="568" height="158" alt="Capture d’écran 2025-09-24 à 15 21 20" src="https://github.com/user-attachments/assets/59915dd0-9b2e-4fb4-af04-3ec6e8575b17" /> | <img width="499" height="158" alt="Capture d’écran 2025-09-24 à 16 10 30" src="https://github.com/user-attachments/assets/98b769f3-f046-43bc-9fd4-1d8f2c9317f0" />
<img width="662" height="158" alt="Capture d’écran 2025-09-24 à 15 21 08" src="https://github.com/user-attachments/assets/793eca6c-6986-4b1c-8522-31c8816cbaf3" /> | <img width="637" height="158" alt="Capture d’écran 2025-09-24 à 16 09 45" src="https://github.com/user-attachments/assets/87fb3f31-676c-44f2-9da7-adf1d629c620" />





