### PR TITLE
fix(view): Remove icon duplicates on external links

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -30,7 +30,7 @@
 @import "./components/agreement_modal";
 @import "./components/rdv_insertion_instance_name";
 @import "./components/token_input";
-@import "./reset_dsfr_overrides.scss";
+@import "./override_dsfr_defaults.scss";
 @import "tippy.js/dist/tippy.css";
 @import "remixicon/fonts/remixicon.css";
 

--- a/app/javascript/stylesheets/override_dsfr_defaults.scss
+++ b/app/javascript/stylesheets/override_dsfr_defaults.scss
@@ -5,7 +5,7 @@
 * the buttons are styled as expected.
 *
 */
-.reset-dsfr-overrides {
+.override-dsfr-defaults {
   p {
     line-height: normal;
   }
@@ -23,6 +23,9 @@
     outline: none !important;
     box-shadow: none !important;
     border: none !important;
+  }
+  [target="_blank"]:not(.fr-link):after {
+    display: none !important;
   }
   .btn-blue-out {
     &:hover {

--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -1,4 +1,4 @@
-<header data-turbo-prefetch="false" class="reset-dsfr-overrides">
+<header data-turbo-prefetch="false" class="override-dsfr-defaults">
   <% if agent_impersonated? %>
       <%= render "common/header_super_admin_bar_impersonated" %>
   <% elsif current_agent&.super_admin? %>

--- a/app/views/layouts/_application_base.html.erb
+++ b/app/views/layouts/_application_base.html.erb
@@ -2,7 +2,7 @@
 <html>
   <%= render 'layouts/head' %>
 
-  <body data-matomo-mask class="<%= "reset-dsfr-overrides" if local_assigns[:reset_dsfr_overrides] %> <%= " bg-white" if local_assigns[:white_background] %>">
+  <body data-matomo-mask class="<%= "override-dsfr-defaults" unless local_assigns[:keep_dsfr_defaults] %> <%= " bg-white" if local_assigns[:white_background] %>">
     <%= render 'common/matomo_script_tag' if @enable_matomo_tracking %>
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= content_for :header %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,6 @@
   <%= render 'common/footer' %>
 <% end %>
 
-<%= render "layouts/application_base", reset_dsfr_overrides: true do %>
+<%= render "layouts/application_base" do %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/user_list_upload.html.erb
+++ b/app/views/layouts/user_list_upload.html.erb
@@ -4,6 +4,6 @@
   <%= render 'common/header' %>
 <% end %>
 
-<%= render "layouts/application_base", white_background: true, reset_dsfr_overrides: true do %>
+<%= render "layouts/application_base", white_background: true do %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/website.html.erb
+++ b/app/views/layouts/website.html.erb
@@ -6,6 +6,6 @@
   <%= render 'common/footer_website' %>
 <% end %>
 
-<%= render "layouts/application_base" do %>
+<%= render "layouts/application_base", keep_dsfr_defaults: true do %>
   <%= yield %>
 <% end %>


### PR DESCRIPTION
Il y avait un bug qui faisait apparaitre deux fois l'icône sur les liens  extérieurs: 

<img width="415" height="96" alt="image" src="https://github.com/user-attachments/assets/753f64ab-3cbd-4e20-b8c4-8dc160268cac" />

Ça vient du fait que le dsfr le rajoute automatiquement sur les liens avec la propriété `target:"_blank"`. 
Je fais en sorte d'overrider cette règle du dsfr.
J'en profite pour renommer la classe css  `reset-dsfr-overrides`, qui était sémantiquement correcte mais un peu confusante IMO.