### PR TITLE
fix(reminder): reminders are not sent for re-entry users

### DIFF
--- a/app/jobs/send_invitation_reminder_job.rb
+++ b/app/jobs/send_invitation_reminder_job.rb
@@ -21,16 +21,16 @@ class SendInvitationReminderJob < ApplicationJob
     @invitation ||= Invitation.new(
       trigger: "reminder",
       user: @user,
-      department: first_invitation.department,
-      organisations: first_invitation.organisations,
-      follow_up: first_invitation.follow_up,
+      department: reference_invitation.department,
+      organisations: reference_invitation.organisations,
+      follow_up: reference_invitation.follow_up,
       format: @invitation_format,
-      help_phone_number: first_invitation.help_phone_number,
-      rdv_solidarites_lieu_id: first_invitation.rdv_solidarites_lieu_id,
-      link: first_invitation.link,
-      rdv_solidarites_token: first_invitation.rdv_solidarites_token,
-      expires_at: first_invitation.expires_at,
-      rdv_with_referents: first_invitation.rdv_with_referents
+      help_phone_number: reference_invitation.help_phone_number,
+      rdv_solidarites_lieu_id: reference_invitation.rdv_solidarites_lieu_id,
+      link: reference_invitation.link,
+      rdv_solidarites_token: reference_invitation.rdv_solidarites_token,
+      expires_at: reference_invitation.expires_at,
+      rdv_with_referents: reference_invitation.rdv_with_referents
     )
   end
 
@@ -57,11 +57,11 @@ class SendInvitationReminderJob < ApplicationJob
 
   def eligible_for_reminder?
     @follow_up.status == "invitation_pending" &&
-      first_invitation.created_at.to_date == Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.to_date &&
-      first_invitation.expireable? && first_invitation.expires_at >= 2.days.from_now
+      reference_invitation.created_at.to_date == Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.to_date &&
+      reference_invitation.expireable? && reference_invitation.expires_at >= 2.days.from_now
   end
 
-  def first_invitation
-    @first_invitation ||= @follow_up.first_invitation_relative_to_last_participation
+  def reference_invitation
+    @reference_invitation ||= @follow_up.reference_invitation_for_current_period
   end
 end

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -3,8 +3,8 @@ class SendInvitationRemindersJob < ApplicationJob
     @sent_reminders_user_ids = []
 
     follow_ups_with_reminder_needed.find_each do |follow_up|
-      invitation = follow_up.first_invitation_relative_to_last_participation
-      # we check here that the **first** invitation has been sent Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER
+      invitation = follow_up.reference_invitation_for_current_period
+      # we check here that the reference invitation has been sent Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER
       # number of days ago with that value being set to 3
       next unless invitation_sent_3_days_ago?(invitation)
 

--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -37,21 +37,11 @@ module Invitable
   end
 
   def reference_invitation_for_current_period
-    if participations.any?
-      first_invitation_after_last_participation
-    else
-      # last_manual_invitation may return nil only if the first invitation sent was a periodic one
-      last_manual_invitation || first_invitation
-    end
+    participations.any? ? first_invitation_after_last_participation : last_manual_invitation
   end
 
   def reference_invitation_for_current_period_by(format)
-    if participations.any?
-      first_invitation_after_last_participation_by(format)
-    else
-      # last_manual_invitation may return nil only if the first invitation sent was a periodic one
-      last_manual_invitation_by(format) || first_invitation_by(format)
-    end
+    participations.any? ? first_invitation_after_last_participation_by(format) : last_manual_invitation_by(format)
   end
 
   def all_invitations_expired?

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -40,7 +40,7 @@
             <% if follow_up.rdv_pending? || follow_up.closed? %>
               <!-- show nothing -->
             <% elsif user.can_be_invited_through?(invitation_format) %>
-              <%= render "invitations/checkbox_form", user: user, invitation_format: invitation_format, motif_category: @current_motif_category, follow_up: follow_up, checked: checked = follow_up.first_invitation_relative_to_last_participation_by(invitation_format).present?, disabled: checked || user.deleted? %>
+              <%= render "invitations/checkbox_form", user: user, invitation_format: invitation_format, motif_category: @current_motif_category, follow_up: follow_up, checked: checked = follow_up.reference_invitation_for_current_period_by(invitation_format).present?, disabled: checked || user.deleted? %>
             <% else %>
               -
             <% end %>

--- a/spec/jobs/send_invitation_reminders_job_spec.rb
+++ b/spec/jobs/send_invitation_reminders_job_spec.rb
@@ -12,6 +12,7 @@ describe SendInvitationRemindersJob do
       create(:user, email: "camille5@gouv.fr", phone_number: "0649031935")
     end
     let!(:user6) { create(:user, email: "camille6@gouv.fr", phone_number: "0649031935") }
+    let!(:user7) { create(:user, email: "camille7@gouv.fr", phone_number: "0649031937") }
 
     let!(:follow_up1) do
       create(:follow_up, status: "invitation_pending", user: user1)
@@ -35,6 +36,9 @@ describe SendInvitationRemindersJob do
     end
     let!(:follow_up7) do
       create(:follow_up, status: "invitation_pending", user: user1)
+    end
+    let!(:follow_up8) do
+      create(:follow_up, status: "invitation_pending", user: user7)
     end
 
     # OK
@@ -92,16 +96,35 @@ describe SendInvitationRemindersJob do
       )
     end
 
+    let!(:invitation8_old) do
+      create(
+        :invitation,
+        user: user7, follow_up: follow_up8,
+        created_at: 60.days.ago, expires_at: 50.days.ago
+      )
+    end
+    let!(:invitation8_new) do
+      create(
+        :invitation,
+        user: user7, follow_up: follow_up8,
+        created_at: 3.days.ago, expires_at: 4.days.from_now
+      )
+    end
+
     before do
       allow(SendInvitationReminderJob).to receive(:perform_later)
       allow(MattermostClient).to receive(:send_to_notif_channel)
     end
 
-    it "enqueues reminder jobs for the eligible contexts only" do
+    it "enqueues reminder jobs for the eligible contexts only" do # rubocop:disable RSpec/ExampleLength
       expect(SendInvitationReminderJob).to receive(:perform_later)
         .with(follow_up1.id, "sms")
       expect(SendInvitationReminderJob).to receive(:perform_later)
         .with(follow_up1.id, "email")
+      expect(SendInvitationReminderJob).to receive(:perform_later)
+        .with(follow_up8.id, "sms")
+      expect(SendInvitationReminderJob).to receive(:perform_later)
+        .with(follow_up8.id, "email")
       expect(SendInvitationReminderJob).not_to receive(:perform_later)
         .with(follow_up2.id, "sms")
       expect(SendInvitationReminderJob).not_to receive(:perform_later)
@@ -132,8 +155,8 @@ describe SendInvitationRemindersJob do
     it "sends a notification to mattermost" do
       expect(MattermostClient).to receive(:send_to_notif_channel)
         .with(
-          "📬 1 relances en cours!\n" \
-          "Les usagers sont: [#{user1.id}]"
+          "📬 2 relances en cours!\n" \
+          "Les usagers sont: [#{user1.id}, #{user7.id}]"
         )
       subject
     end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/3074
J'en ai profité pour renommer les méthodes concernées qui n'étaient plus représentatives du comportement réèl.
J'ai vérifié on a aucun `FollowUp` avec une seule invitation périodique donc `last_manual_invitation` renverra toujours quelque chose (vu que la feature des invitations périodiques a été enlevée).