### PR TITLE
fix(archive): Add validation on user belonging to org

### DIFF
--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -30,6 +30,6 @@ class Archive < ApplicationRecord
   def user_must_belong_to_organisation
     return if user.reload.organisation_ids.include?(organisation_id)
 
-    errors.add(:user, "doit appartenir à l'organisation")
+    errors.add(:user_id, "doit appartenir à l'organisation")
   end
 end

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -5,6 +5,7 @@ class Archive < ApplicationRecord
   belongs_to :organisation
 
   validates :user_id, uniqueness: { scope: :organisation_id }
+  validate :user_must_belong_to_organisation
 
   after_create_commit :invalidate_related_invitations
 
@@ -24,5 +25,11 @@ class Archive < ApplicationRecord
 
       ExpireInvitationJob.perform_later(invitation.id)
     end
+  end
+
+  def user_must_belong_to_organisation
+    return if user.reload.organisation_ids.include?(organisation_id)
+
+    errors.add(:user, "doit appartenir à l'organisation")
   end
 end

--- a/config/locales/models/archive.fr.yml
+++ b/config/locales/models/archive.fr.yml
@@ -6,3 +6,5 @@ fr:
       archive:
         archiving_reason: Motif d'archivage
         created_at: Archivé le
+        user_id: Usager
+        organisation_id: Organisation

--- a/spec/factories/archive.rb
+++ b/spec/factories/archive.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :archive do
     organisation
-    user
+    user { create(:user, organisations: [organisation]) }
   end
 end

--- a/spec/jobs/remove_users_from_orgs_with_old_archives_job_spec.rb
+++ b/spec/jobs/remove_users_from_orgs_with_old_archives_job_spec.rb
@@ -25,8 +25,8 @@ describe RemoveUsersFromOrgsWithOldArchivesJob do
     end
 
     context "with expired archives but users with recent RDVs" do
-      let!(:user_with_recent_rdv) { create(:user) }
-      let!(:user_without_recent_rdv) { create(:user) }
+      let!(:user_with_recent_rdv) { create(:user, organisations: [org1]) }
+      let!(:user_without_recent_rdv) { create(:user, organisations: [org1]) }
       let!(:expired_archive_with_recent_rdv) do
         create(:archive, organisation: org1, user: user_with_recent_rdv, created_at: 25.months.ago)
       end

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -3,38 +3,44 @@ describe Archive do
 
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department:) }
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user, organisations: [organisation]) }
+
+  describe "user must belong to organisation" do
+    let!(:user) { create(:user, organisations: [create(:organisation)]) }
+
+    it "is not valid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.full_messages).to include("User doit appartenir à l'organisation")
+    end
+  end
 
   describe "xss attempt" do
-    let(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
-    let!(:archive) { create(:archive, archiving_reason:, organisation:, user:) }
+    let!(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
+    let!(:archive) { build(:archive, archiving_reason:, organisation:, user:) }
 
     it "strips all html" do
-      expect(archive.reload.archiving_reason).to eq("\">")
+      archive.save!
+      expect(archive.archiving_reason).to eq("\">")
     end
 
     describe "attempt logging on sentry" do
-      subject { create(:archive, archiving_reason:, organisation:, user: other_user) }
-
-      let(:other_user) { create(:user) }
-
       context "message is legit" do
-        let(:archiving_reason) do
+        let!(:archiving_reason) do
           "Suivi accompagnement\n\r\t Envoyer des offres &  d'emploi et d'entreprises pour son alternance "
         end
 
         it "does not log" do
           expect(Sentry).not_to receive(:capture_message)
-          subject
+          archive.save!
         end
       end
 
       context "message is not legit" do
-        let(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
+        let!(:archiving_reason) { "\"><img src=1 onerror=alert(1)>" }
 
         it "logs on sentry" do
           expect(Sentry).to receive(:capture_message).once
-          subject
+          archive.save!
         end
       end
     end
@@ -42,14 +48,14 @@ describe Archive do
 
   describe "no collision" do
     context "when the user is not archived" do
-      let(:archive) { build(:archive, organisation: organisation, user: user) }
+      let!(:archive) { build(:archive, organisation: organisation, user: user) }
 
       it { expect(subject).to be_valid }
     end
 
     context "when the user is archived in another organisation" do
       let!(:existing_archive) do
-        create(:archive, user: user, organisation: create(:organisation))
+        create(:archive, user: user, organisation: create(:organisation, users: [user]))
       end
 
       it { expect(subject).to be_valid }

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -10,7 +10,7 @@ describe Archive do
 
     it "is not valid" do
       expect(subject).not_to be_valid
-      expect(subject.errors.full_messages).to include("User doit appartenir à l'organisation")
+      expect(subject.errors.full_messages).to include("Usager doit appartenir à l'organisation")
     end
   end
 

--- a/spec/services/user_list_upload/save_user_spec.rb
+++ b/spec/services/user_list_upload/save_user_spec.rb
@@ -89,12 +89,8 @@ describe UserListUpload::SaveUser, type: :service do
     end
 
     context "when user is archived" do
+      let!(:organisation) { create(:organisation, users: [user]) }
       let!(:archive) { create(:archive, user: user, organisation: organisation) }
-
-      before do
-        allow(UserListUpload::RetrieveOrganisationToAssign).to receive(:call)
-          .and_return(OpenStruct.new(success?: true, organisation: organisation))
-      end
 
       it "unarchives the user" do
         expect { subject }.to change { user.archives.count }.from(1).to(0)


### PR DESCRIPTION
En travaillant sur #3083 je me suis rendu compte qu'il était possible d'archiver un usager qui n'appartenait plus à une orga si on ne rafraichissait pas la page de l'usager.
J'ajoute donc une validation au niveau du model `Archive` pour rendre impossible un archivage si l'usager n'appartient pas à l'organisation en question.