### PR TITLE
ui(cookies): add cookies consent custom modal link in footer

### DIFF
--- a/app/controllers/concerns/cookies_consent_concern.rb
+++ b/app/controllers/concerns/cookies_consent_concern.rb
@@ -3,11 +3,19 @@ module CookiesConsentConcern
 
   included do
     before_action :set_should_display_cookies_consent, if: -> { request.get? }
+    before_action :set_cookies_consent_for_form, if: -> { request.get? && logged_in? }
   end
 
   private
 
   def set_should_display_cookies_consent
     @should_display_cookies_consent = logged_in? && current_agent.cookies_consent.nil? && !agent_impersonated?
+  end
+
+  def set_cookies_consent_for_form
+    @cookies_consent = current_agent.cookies_consent || current_agent.build_cookies_consent(
+      tracking_accepted: true,
+      support_accepted: true
+    )
   end
 end

--- a/app/controllers/cookies_consents_controller.rb
+++ b/app/controllers/cookies_consents_controller.rb
@@ -1,31 +1,30 @@
 class CookiesConsentsController < ApplicationController
-  before_action :verify_cookies_consent_not_already_given, only: :create
-
   def create
-    cookies_consent = CookiesConsent.new(cookies_consent_params.merge(agent: current_agent))
+    save_cookies_consent
+  end
+
+  def update
+    save_cookies_consent
+  end
+
+  private
+
+  def save_cookies_consent
+    cookies_consent = current_agent.cookies_consent || current_agent.build_cookies_consent
+    cookies_consent.assign_attributes(cookies_consent_params)
+
     if cookies_consent.save
-      redirect_back(notice: "Votre consentement a été enregistré.", fallback_location: authenticated_root_path)
+      redirect_back(notice: "Vos préférences ont été enregistrées.", fallback_location: authenticated_root_path)
     else
       redirect_back(
-        alert: "Une erreur est survenue lors de l'enregistrement de votre consentement: " \
+        alert: "Une erreur est survenue lors de l'enregistrement de vos préférences: " \
                "#{cookies_consent.errors.full_messages.join(', ')}",
         fallback_location: authenticated_root_path
       )
     end
   end
 
-  private
-
   def cookies_consent_params
     params.expect(cookies_consent: [:support_accepted, :tracking_accepted])
-  end
-
-  def verify_cookies_consent_not_already_given
-    return if current_agent.cookies_consent.nil?
-
-    redirect_back(
-      alert: "Vous ne pouvez pas modifier les préférences des cookies.",
-      fallback_location: authenticated_root_path
-    )
   end
 end

--- a/app/models/concerns/agent/cookies_consentable.rb
+++ b/app/models/concerns/agent/cookies_consentable.rb
@@ -6,10 +6,10 @@ module Agent::CookiesConsentable
   end
 
   def support_accepted?
-    cookies_consent&.support_accepted? || false
+    (cookies_consent&.persisted? && cookies_consent.support_accepted?) || false
   end
 
   def tracking_accepted?
-    cookies_consent&.tracking_accepted? || false
+    (cookies_consent&.persisted? && cookies_consent.tracking_accepted?) || false
   end
 end

--- a/app/views/common/_cookies_consent.html.erb
+++ b/app/views/common/_cookies_consent.html.erb
@@ -5,30 +5,23 @@
   </div>
   <ul class="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
     <li>
-      <%= form_for :cookies_consent, url: cookies_consents_path, method: :post do |f| %>
+      <%= form_with model: @cookies_consent, url: cookies_consent_path, local: true do |f| %>
         <%= f.hidden_field :support_accepted, value: true %>
         <%= f.hidden_field :tracking_accepted, value: true %>
-        <%= f.submit "Tout accepter",
-            name: "action",
-            class: "fr-btn",
-            title: "Autoriser tous les cookies" %>
+        <%= f.submit "Tout accepter", class: "fr-btn", title: "Autoriser tous les cookies" %>
       <% end %>
     </li>
     <li>
-      <%= form_for :cookies_consent, url: cookies_consents_path, method: :post do |f| %>
+      <%= form_with model: @cookies_consent, url: cookies_consent_path, local: true do |f| %>
         <%= f.hidden_field :support_accepted, value: false %>
         <%= f.hidden_field :tracking_accepted, value: false %>
-        <%= f.submit "Tout refuser",
-            name: "action",
-            class: "fr-btn",
-            title: "Refuser tous les cookies" %>
+        <%= f.submit "Tout refuser", class: "fr-btn", title: "Refuser tous les cookies" %>
       <% end %>
     </li>
     <li>
-      <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="consent-modal" title="Personnaliser les cookies">
+      <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="cookies-consent-customization-modal" title="Personnaliser les cookies">
         Personnaliser
       </button>
     </li>
   </ul>
 </div>
-<%= render 'common/cookies_consent_customization_modal' %>

--- a/app/views/common/_cookies_consent_customization_modal.html.erb
+++ b/app/views/common/_cookies_consent_customization_modal.html.erb
@@ -1,13 +1,13 @@
-<dialog id="consent-modal" class="fr-modal" aria-labelledby="fr-consent-modal-title">
+<dialog id="cookies-consent-customization-modal" class="fr-modal" aria-labelledby="fr-cookies-consent-customization-modal-title">
   <div class="fr-container fr-container--fluid fr-container-md">
     <div class="fr-grid-row fr-grid-row--center">
       <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
         <div class="fr-modal__body">
           <div class="fr-modal__header">
-            <button aria-controls="consent-modal" data-fr-opened="false" title="Fermer" type="button" class="fr-btn--close fr-btn">Fermer</button>
+            <button aria-controls="cookies-consent-customization-modal" data-fr-opened="false" title="Fermer" type="button" class="fr-btn--close fr-btn">Fermer</button>
           </div>
           <div class="fr-modal__content">
-            <h1 id="fr-consent-modal-title" class="fr-modal__title">
+            <h1 id="fr-cookies-consent-customization-modal-title" class="fr-modal__title">
               Panneau de gestion des cookies
             </h1>
             <div class="fr-consent-manager">
@@ -17,14 +17,14 @@
                   <legend id="finality-legend" class="fr-consent-service__title">Préférences pour tous les services.<br><%= link_to "Données personnelles et cookies", politique_de_confidentialite_path, class: "fr-link" %>
                   </legend>
                   <div class="fr-consent-service__radios">
-                    <%= form_for :cookies_consent, url: cookies_consents_path, method: :post do |f| %>
+                    <%= form_with model: @cookies_consent, url: cookies_consent_path, local: true do |f| %>
                       <%= f.hidden_field :support_accepted, value: false %>
                       <%= f.hidden_field :tracking_accepted, value: false %>
                       <button type="submit" class="fr-btn me-2">
                         Tout refuser
                       </button>
                     <% end %>
-                    <%= form_for :cookies_consent, url: cookies_consents_path, method: :post do |f| %>
+                    <%= form_with model: @cookies_consent, url: cookies_consent_path, local: true do |f| %>
                       <%= f.hidden_field :support_accepted, value: true %>
                       <%= f.hidden_field :tracking_accepted, value: true %>
                       <button type="submit" class="fr-btn">
@@ -54,13 +54,13 @@
                   <p id="finality-0-desc" class="fr-consent-service__desc">Ce site utilise des cookies nécessaires à son bon fonctionnement qui ne peuvent pas être désactivés.</p>
                 </fieldset>
               </div>
-              <%= form_for :cookies_consent, url: cookies_consents_path, method: :post do |f| %>
+              <%= form_with model: @cookies_consent, url: cookies_consent_path, local: true do |f| %>
                 <div class="fr-consent-service">
                   <fieldset aria-labelledby="tracking-legend tracking-desc" role="group" class="fr-fieldset">
                   <legend id="tracking-legend" class="fr-consent-service__title">Mesure d'audience</legend>
                   <div class="fr-consent-service__radios">
                     <div class="fr-radio-group">
-                      <%= f.radio_button :tracking_accepted, true, id: "tracking-accept", checked: true %>
+                      <%= f.radio_button :tracking_accepted, true, id: "tracking-accept" %>
                       <%= f.label :tracking_accepted, "Accepter", for: "tracking-accept", class: "fr-label" %>
                     </div>
                     <div class="fr-radio-group">
@@ -76,7 +76,7 @@
                   <legend id="support-legend" class="fr-consent-service__title">Support et assistance utilisateur</legend>
                   <div class="fr-consent-service__radios">
                     <div class="fr-radio-group">
-                      <%= f.radio_button :support_accepted, true, id: "support-accept", checked: true %>
+                      <%= f.radio_button :support_accepted, true, id: "support-accept" %>
                       <%= f.label :support_accepted, "Accepter", for: "support-accept", class: "fr-label" %>
                     </div>
                     <div class="fr-radio-group">

--- a/app/views/common/_footer.html.erb
+++ b/app/views/common/_footer.html.erb
@@ -51,6 +51,11 @@
         <li class="footer-bottom-list-item">
           <%= link_to "Accessibilité: non conforme", accessibilite_path, id: "rdvi_footer_accessibility-link" %>
         </li>
+        <li class="footer-bottom-list-item">
+          <button data-fr-opened="false" aria-controls="cookies-consent-customization-modal" title="Gérer les préférences de cookies" id="rdvi_footer_cookies-link">
+            Gestion des cookies
+          </button>
+        </li>
       </ul>
       <div>
         <p>Sauf mention contraire, tous les textes de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank">licence etalab-2.0</a></p>

--- a/app/views/layouts/_application_base.html.erb
+++ b/app/views/layouts/_application_base.html.erb
@@ -14,6 +14,7 @@
       <%= render 'common/accept_dpa_modal' if @should_display_accept_dpa %>
       <%= render 'common/crisp' %>
       <%= render 'common/cookies_consent' if @should_display_cookies_consent %>
+      <%= render 'common/cookies_consent_customization_modal' if logged_in? %>
     </div>
     <%= content_for :footer %>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
   get "/organisations", to: "organisations#index", as: :authenticated_root
 
   resources :notification_center, only: [:index]
-  resources :cookies_consents, only: [:create]
+  resource :cookies_consent, only: [:create, :update]
 
   resources :organisations, only: [:index, :new, :show, :edit, :create, :update] do
     get :geolocated, on: :collection


### PR DESCRIPTION
Pour permettre l'update des préférences des cookies j'ai du faire quelques ajustements : 
 
  Architecture RESTful.
  - Routes : `resource :cookies_consent` (singleton) au lieu de resources
  - Controller : actions `create` et `update` séparées

  Changement dans les vues pour permettre l'update des paramètres
  - Remplacement de `form_for` par `form_with` model
  - `@cookies_consent` initialisé via `before_action` dans le concern
  - Valeurs par défaut gérées côté controller
  - render de la modale `common/cookies_consent_customization_modal` dans `application_base`, elle peut être appelée de n'importe ou dans l'app.

  Corrections.
  - Ajout vérification `persisted?` dans `tracking_accepted?` / `support_accepted?` pour éviter faux positifs
  - Lien dans le footer "Gestion des cookies" pour modification des préférences après consentement initial