### PR TITLE
feat(france_travail): Map excused participations to new ABSENT_EXC status

### DIFF
--- a/app/models/concerns/participation/france_travail_payload.rb
+++ b/app/models/concerns/participation/france_travail_payload.rb
@@ -82,12 +82,14 @@ module Participation::FranceTravailPayload
     collectif? ? "COL" : "IND"
   end
 
-  # Liste des statuts FT : PRIS, EFFECTUE, MODIFIE, ABSENT, ANNULE
+  # Liste des statuts FT : PRIS, EFFECTUE, MODIFIE, ABSENT, ANNULE, ABSENT_EXC
   def france_travail_statut
     case status
     when "seen"
       "EFFECTUE"
-    when "excused", "revoked"
+    when "excused"
+      "ABSENT_EXC"
+    when "revoked"
       "ANNULE"
     when "noshow"
       "ABSENT"

--- a/spec/models/concerns/participation/france_travail_payload_spec.rb
+++ b/spec/models/concerns/participation/france_travail_payload_spec.rb
@@ -132,7 +132,7 @@ describe Participation::FranceTravailPayload, type: :concern do
   describe "france_travail_statut" do
     {
       "seen" => "EFFECTUE",
-      "excused" => "ANNULE",
+      "excused" => "ABSENT_EXC",
       "revoked" => "ANNULE",
       "noshow" => "ABSENT",
       "unknown" => "PRIS"


### PR DESCRIPTION
https://francetravail.io/data/api/rechercher-usager/rdv-partenaire/documentation#/api-reference/schemas/RendezVousPartenaire

En allant par hasard voir la documentation de l'API France Travail rdv_partenaire, j'ai remarqué qu'elle expose désormais le statut `ABSENT_EXC` (absence excusée). Les participations `excused` étaient jusqu'ici remontées comme `ANNULE`, au même titre que les `revoked`.
Elles sont maintenant transmises avec `ABSENT_EXC`, ce qui distingue une absence excusée d'une annulation côté FT.