### PR TITLE
refactor(agent_roles): remove rdv_solidarites_agent_role_id column

### DIFF
--- a/app/dashboards/agent_role_dashboard.rb
+++ b/app/dashboards/agent_role_dashboard.rb
@@ -15,7 +15,6 @@ class AgentRoleDashboard < Administrate::BaseDashboard
     agent: Field::BelongsTo,
     last_webhook_update_received_at: Field::DateTime,
     organisation: Field::BelongsTo,
-    rdv_solidarites_agent_role_id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -38,7 +37,6 @@ class AgentRoleDashboard < Administrate::BaseDashboard
     agent
     last_webhook_update_received_at
     organisation
-    rdv_solidarites_agent_role_id
     created_at
     updated_at
   ].freeze

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -11,69 +11,24 @@ module InboundWebhooks
 
         return if organisation.blank? || organisation.archived? || @data[:access_level] == "intervenant"
 
-        # This is necessary when the agent role has been created through rdv-i without the rdv-s record
-        # when importing an organisation
-        assign_rdv_solidarites_agent_role_id if agent_role
-        event == "destroyed" ? remove_agent_from_org : upsert_agent_role
+        if event == "destroyed"
+          remove_agent_from_organisation
+        elsif agent.blank?
+          # the agent_role webhook can be received before the agent one
+          self.class.perform_in(30.seconds, data, meta)
+        else
+          upsert_agent_role
+        end
       end
 
       private
-
-      def upsert_agent_role
-        return if agent_attributes.blank?
-
-        upsert_agent! if agent.nil?
-
-        UpsertRecordJob.perform_later(
-          "AgentRole",
-          @data,
-          { organisation_id: organisation.id, agent_id: agent.id, last_webhook_update_received_at: @meta[:timestamp] }
-        )
-      end
-
-      def remove_agent_from_org
-        agent_role&.destroy! # we first destroy the agent role record
-        return if agent.blank?
-
-        # we ensure the agent is removed from the org in case agent role record wasn't found
-        agent.organisations.delete(organisation)
-        delete_agent if agent.reload.organisations.empty?
-      end
-
-      def delete_agent
-        agent.destroy!
-      end
-
-      def upsert_agent!
-        raise "Could not upsert agent #{agent_attributes}" unless upsert_agent.success?
-      end
-
-      def upsert_agent
-        @upsert_agent ||= UpsertRecord.call(
-          klass: Agent,
-          rdv_solidarites_attributes: @data[:agent],
-          additional_attributes: { last_webhook_update_received_at: @meta[:timestamp] }
-        )
-      end
-
-      def assign_rdv_solidarites_agent_role_id
-        agent_role.update!(rdv_solidarites_agent_role_id: @data[:id]) if agent_role.rdv_solidarites_agent_role_id.nil?
-      end
 
       def event
         @meta[:event]
       end
 
-      def rdv_solidarites_agent_role_id
-        @data[:id]
-      end
-
       def rdv_solidarites_agent_id
         @data[:agent][:id]
-      end
-
-      def agent_attributes
-        @data[:agent]
       end
 
       def rdv_solidarites_organisation_id
@@ -89,7 +44,21 @@ module InboundWebhooks
       end
 
       def agent_role
-        @agent_role ||= AgentRole.find_by(organisation_id: organisation.id, agent_id: agent&.id)
+        @agent_role ||= AgentRole.find_by(agent:, organisation:)
+      end
+
+      def upsert_agent_role
+        AgentRole.find_or_initialize_by(agent:, organisation:).update!(
+          access_level: @data[:access_level],
+          last_webhook_update_received_at: @meta[:timestamp]
+        )
+      end
+
+      def remove_agent_from_organisation
+        return if agent.blank?
+
+        agent_role&.destroy!
+        agent.destroy! if agent.reload.organisations.empty?
       end
     end
   end

--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -5,7 +5,6 @@ class AgentRole < ApplicationRecord
   belongs_to :agent
   belongs_to :organisation
 
-  validates :rdv_solidarites_agent_role_id, uniqueness: true, allow_nil: true
   validates :agent, uniqueness: { scope: :organisation, message: "est déjà relié à l'organisation" }
 
   validate :organisation_is_not_archived, on: :create

--- a/app/services/organisations/create.rb
+++ b/app/services/organisations/create.rb
@@ -33,7 +33,6 @@ module Organisations
 
     def agent_role_for_new_organisation
       # to allow an instant redirection, we create the agent_role directly
-      # the rdv_solidarites_agent_role_id will be added to this agent_role record thanks to the webhook
       # this is safe because the transaction succeeds only if the agent is a territorial admin in the department
       @agent_role_for_new_organisation ||=
         AgentRole.new(agent_id: @agent.id, organisation_id: @organisation.id, access_level: "admin")

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -48,7 +48,6 @@ tables:
       - agent_id
       - authorized_to_export_csv
       - organisation_id
-      - rdv_solidarites_agent_role_id
       - created_at
       - updated_at
       - last_webhook_update_received_at

--- a/db/migrate/20260811170650_remove_rdv_solidarites_agent_role_id_from_agent_roles.rb
+++ b/db/migrate/20260811170650_remove_rdv_solidarites_agent_role_id_from_agent_roles.rb
@@ -1,0 +1,5 @@
+class RemoveRdvSolidaritesAgentRoleIdFromAgentRoles < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :agent_roles, :rdv_solidarites_agent_role_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_131224) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_170650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -67,13 +67,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_131224) do
     t.datetime "created_at", null: false
     t.datetime "last_webhook_update_received_at"
     t.bigint "organisation_id", null: false
-    t.bigint "rdv_solidarites_agent_role_id"
     t.datetime "updated_at", null: false
     t.index ["access_level"], name: "index_agent_roles_on_access_level"
     t.index ["agent_id", "organisation_id"], name: "index_agent_roles_on_agent_id_and_organisation_id", unique: true
     t.index ["agent_id"], name: "index_agent_roles_on_agent_id"
     t.index ["organisation_id"], name: "index_agent_roles_on_organisation_id"
-    t.index ["rdv_solidarites_agent_role_id"], name: "index_agent_roles_on_rdv_solidarites_agent_role_id", unique: true
   end
 
   create_table "agents", force: :cascade do |t|

--- a/spec/factories/agent_role.rb
+++ b/spec/factories/agent_role.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     organisation
     agent
     access_level { "basic" }
-    sequence(:rdv_solidarites_agent_role_id) { |n| n + Process.pid }
     authorized_to_export_csv { false }
   end
 end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -5,61 +5,66 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
 
   let!(:data) do
     {
-      "id" => rdv_solidarites_agent_role_id,
       "access_level" => "basic",
-      "agent" => agent_attributes,
-      "organisation" => { id: rdv_solidarites_organisation_id }
+      "agent" => { "id" => rdv_solidarites_agent_id },
+      "organisation" => { "id" => rdv_solidarites_organisation_id }
     }.deep_symbolize_keys
   end
 
-  let!(:agent_attributes) do
-    { id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko", email: "josiane.balasko@gmail.com" }
-  end
-  let!(:rdv_solidarites_agent_role_id) { 17 }
   let!(:rdv_solidarites_organisation_id) { 222 }
   let!(:rdv_solidarites_agent_id) { 455 }
 
-  let!(:organisation) do
-    create(:organisation, rdv_solidarites_organisation_id:, id: 923, name: "Pôle Parcours")
-  end
-  let!(:agent) do
-    create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko",
-                   email: "josiane.balasko@gmail.com")
-  end
+  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+  let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
 
   let!(:meta) do
     {
       "model" => "AgentRole",
       "timestamp" => "2023-02-09 11:17:22 +0200",
-      "event" => "updated"
+      "event" => "created"
     }.deep_symbolize_keys
   end
 
   describe "#perform" do
-    it "upserts an agent_role record" do
-      expect(UpsertRecordJob).to receive(:perform_later)
-        .with(
-          "AgentRole", data,
-          { organisation_id: organisation.id, agent_id: agent.id,
-            last_webhook_update_received_at: "2023-02-09 11:17:22 +0200" }
+    context "when the agent does not belong to the org" do
+      it "attaches the agent to the org" do
+        subject
+        agent_role = agent.reload.agent_roles.find_by(organisation: organisation)
+        expect(agent_role).to have_attributes(
+          access_level: "basic",
+          last_webhook_update_received_at: "2023-02-09 11:17:22 +0200".to_datetime
         )
-      subject
+      end
     end
 
-    context "when the agent role is created" do
+    context "when the agent already belongs to the org" do
       let!(:agent_role) do
-        create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
+        create(:agent_role, organisation: organisation, agent: agent, access_level: "basic")
       end
 
-      it "assigns the rdv solidarites agent role id" do
+      it "updates the agent role" do
+        data[:access_level] = "admin"
         subject
-        expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
+        expect(agent_role.reload.access_level).to eq("admin")
+      end
+
+      it "does not create another agent role" do
+        expect { subject }.not_to change(AgentRole, :count)
+      end
+    end
+
+    context "when the agent cannot be found" do
+      let!(:agent) { create(:agent, rdv_solidarites_agent_id: "some-other-id") }
+
+      it "reenqueues the job 30 seconds later" do
+        expect(described_class).to receive(:perform_in).with(30.seconds, data, meta)
+        subject
       end
     end
 
     context "for destroyed event" do
       let!(:agent_role) do
-        create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
+        create(:agent_role, organisation: organisation, agent: agent)
       end
 
       let!(:meta) do
@@ -69,21 +74,8 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
         }.deep_symbolize_keys
       end
 
-      it "removes the agent from organisation" do
+      it "removes the agent from the organisation" do
         expect { subject }.to change(AgentRole, :count).by(-1)
-      end
-
-      it "does not attach the agent to the organisation" do
-        expect(UpsertRecordJob).not_to receive(:perform_later)
-        subject
-      end
-
-      context "when the agent role record cannot be found through id" do
-        before { data[:id] = "some-other-id" }
-
-        it "still removes the agent from the organisation" do
-          expect { subject }.to change(AgentRole, :count).by(-1)
-        end
       end
 
       context "when the agent belongs to this org only" do
@@ -103,88 +95,48 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
           expect { subject }.to change(AgentRole, :count).by(-1)
         end
       end
+
+      context "when the agent cannot be found" do
+        let!(:agent) { create(:agent, rdv_solidarites_agent_id: "some-other-id") }
+
+        it "does not reenqueue the job" do
+          expect(described_class).not_to receive(:perform_in)
+          subject
+        end
+
+        it "does not remove any agent role" do
+          expect { subject }.not_to change(AgentRole, :count)
+        end
+      end
     end
 
     context "when organisation cannot be found" do
       let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: 2131) }
 
-      it "does not remove the agent from the org" do
-        expect { subject }.not_to change(AgentRole, :count)
-      end
-
       it "does not attach the agent to the organisation" do
-        expect(UpsertRecordJob).not_to receive(:perform_later)
-        subject
-      end
-    end
-
-    context "when the agent cannot be found" do
-      let!(:meta) do
-        {
-          "model" => "AgentRole",
-          "event" => "created",
-          "timestamp" => "2022-05-30 14:44:22 +0200"
-        }.deep_symbolize_keys
-      end
-
-      before do
-        allow(Agent).to receive(:find_by).and_return(nil, nil, agent)
-        allow(UpsertRecord).to receive(:call).and_return(OpenStruct.new(success?: true))
-      end
-
-      it "upserts the agent and the role" do
-        expect(UpsertRecord).to receive(:call)
-          .with(
-            klass: Agent,
-            rdv_solidarites_attributes: agent_attributes,
-            additional_attributes: { last_webhook_update_received_at: meta[:timestamp] }
-          )
-        expect(UpsertRecordJob).to receive(:perform_later)
-          .with(
-            "AgentRole",
-            data,
-            { organisation_id: organisation.id, agent_id: agent.id, last_webhook_update_received_at: meta[:timestamp] }
-          )
-        subject
-        expect(agent).to have_attributes(
-          agent_attributes.except(:id).merge(rdv_solidarites_agent_id: rdv_solidarites_agent_id)
-        )
-      end
-
-      context "when the agent upsert fails" do
-        before do
-          allow(Agent).to receive(:find_by).and_return(nil)
-          allow(UpsertRecord).to receive(:call).and_return(OpenStruct.new(success?: false))
-        end
-
-        it "raises an error" do
-          expect { subject }.to raise_error(StandardError, "Could not upsert agent #{agent_attributes}")
-        end
+        expect { subject }.not_to change(AgentRole, :count)
       end
     end
 
     context "for an intervenant" do
       let!(:data) do
         {
-          "id" => rdv_solidarites_agent_role_id,
           "access_level" => "intervenant",
-          "agent" => { id: rdv_solidarites_agent_id },
-          "organisation" => { id: rdv_solidarites_organisation_id }
+          "agent" => { "id" => rdv_solidarites_agent_id },
+          "organisation" => { "id" => rdv_solidarites_organisation_id }
         }.deep_symbolize_keys
       end
 
-      it "does not process the upsert" do
-        expect(UpsertRecordJob).not_to receive(:perform_later)
-        subject
+      it "does not attach the agent to the organisation" do
+        expect { subject }.not_to change(AgentRole, :count)
       end
     end
 
     context "when the organisation is archived" do
       let!(:organisation) { create(:organisation, archived_at: Time.current) }
 
-      it "does not process the upsert" do
-        expect(UpsertRecordJob).not_to receive(:perform_later)
-        subject
+      it "does not attach the agent to the organisation" do
+        expect { subject }.not_to change(AgentRole, :count)
       end
     end
   end

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -1,32 +1,4 @@
 describe AgentRole do
-  describe "rdv_solidarites_agent_role_id uniqueness validation" do
-    context "no collision" do
-      let(:agent_role) { build(:agent_role, rdv_solidarites_agent_role_id: 1) }
-
-      it { expect(agent_role).to be_valid }
-    end
-
-    context "blank rdv_solidarites_agent_role_id" do
-      let!(:agent_role_existing) { create(:agent_role, rdv_solidarites_agent_role_id: 1) }
-
-      let(:agent_role) { build(:agent_role, rdv_solidarites_agent_role_id: "") }
-
-      it { expect(agent_role).to be_valid }
-    end
-
-    context "colliding rdv_solidarites_agent_role_id" do
-      let!(:agent_role_existing) { create(:agent_role, rdv_solidarites_agent_role_id: 1) }
-      let(:agent_role) { build(:agent_role, rdv_solidarites_agent_role_id: 1) }
-
-      it "adds errors" do
-        expect(agent_role).not_to be_valid
-        expect(agent_role.errors.details).to eq({ rdv_solidarites_agent_role_id: [{ error: :taken, value: 1 }] })
-        expect(agent_role.errors.full_messages.to_sentence)
-          .to include("Rdv solidarites agent role est déjà utilisé")
-      end
-    end
-  end
-
   describe "access_level inclusion validation" do
     context "correct access_level value" do
       let(:agent_role) { build(:agent_role, access_level: "basic") }


### PR DESCRIPTION
En lien avec : https://app.notion.com/p/gip-inclusion/Nettoyage-Enlever-la-colonne-rdv_solidarites_agent_role_id-28d5f321b604805d9839c88b2595ecb3

## Contexte

La colonne `rdv_solidarites_agent_role_id` ne servait plus qu'à retrouver l'`agent_role` dans `UpsertRecord` ce qui était inutile puisque le couple `(agent, organisation)` identifie déjà le record de manière unique.

## Changements

- Suppression de la colonne `rdv_solidarites_agent_role_id`
- Réécriture de `ProcessAgentRoleJob` sur le modèle de `ProcessUserProfileJob`  et `ProcessReferentAssignationJob` : upsert direct par `(agent, organisation)`, et re-enqueue du job 30 s plus tard si l'agent n'est pas encore en base (webhook `agent_role` reçu avant le webhook `agent`)