### PR TITLE
fix(css): disable sass charset to keep BOM out of compiled bundles (bug after postcss update)

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -36,7 +36,15 @@ module.exports = {
       },
       {
         test: /\.(?:sa|sc|c)ss$/i,
-        use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+        use: [
+          MiniCssExtractPlugin.loader,
+          "css-loader",
+          {
+            loader: "sass-loader",
+            // See https://github.com/WordPress/gutenberg/issues/81382
+            options: { sassOptions: { charset: false } },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
Depuis le bump de postcss 8.5.12 → 8.5.25 (#3360) nous avons certaines variables css `bg-*`, `text-*` cassées
en prod et staging.

Plus d'infos sur l'origine du bug et le fix de cette PR ici https://github.com/WordPress/gutenberg/issues/81382.