### PR TITLE
fix(ft): ignore ID_NON_RECONNU on participation cancellation to avoid retries

### DIFF
--- a/app/jobs/outgoing_webhooks/france_travail/cancel_participation_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/cancel_participation_job.rb
@@ -7,11 +7,16 @@ module OutgoingWebhooks
         # so no reason to cancel it here
         return unless user
 
-        call_service!(FranceTravailApi::CancelParticipation,
-                      participation_id: participation_id,
-                      france_travail_id: france_travail_id,
-                      user: user,
-                      timestamp: timestamp)
+        cancel_result = FranceTravailApi::CancelParticipation.call(
+          participation_id: participation_id,
+          france_travail_id: france_travail_id,
+          user: user,
+          timestamp: timestamp
+        )
+
+        return if cancel_result.error_type == :participation_not_found
+
+        raise ApplicationJob::FailedServiceError, "Errors: #{cancel_result.errors}" if cancel_result.failure?
       end
     end
   end

--- a/app/jobs/outgoing_webhooks/france_travail/cancel_participation_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/cancel_participation_job.rb
@@ -7,16 +7,11 @@ module OutgoingWebhooks
         # so no reason to cancel it here
         return unless user
 
-        cancel_result = FranceTravailApi::CancelParticipation.call(
-          participation_id: participation_id,
-          france_travail_id: france_travail_id,
-          user: user,
-          timestamp: timestamp
-        )
-
-        return if cancel_result.error_type == :participation_not_found
-
-        raise ApplicationJob::FailedServiceError, "Errors: #{cancel_result.errors}" if cancel_result.failure?
+        call_service!(FranceTravailApi::CancelParticipation,
+                      participation_id: participation_id,
+                      france_travail_id: france_travail_id,
+                      user: user,
+                      timestamp: timestamp)
       end
     end
   end

--- a/app/services/france_travail_api/cancel_participation.rb
+++ b/app/services/france_travail_api/cancel_participation.rb
@@ -23,19 +23,31 @@ module FranceTravailApi
     private
 
     def send_request!
-      response = FranceTravailClient.cancel_participation(
+      @response = FranceTravailClient.cancel_participation(
         france_travail_id: @france_travail_id,
         headers: ft_user_headers
       )
 
-      handle_failure!(response) unless response.success?
+      handle_failure! unless @response.success?
     end
 
-    def handle_failure!(response)
-      fail!(
-        "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).\n" \
-        "Status: #{response.status}\n Body: #{response.body.force_encoding('UTF-8')}"
-      )
+    def handle_failure!
+      result.error_type = :participation_not_found if participation_not_found?
+      fail!(error_message)
+    end
+
+    def error_message
+      "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).\n" \
+        "Status: #{@response.status}\n Body: #{@response.body.force_encoding('UTF-8')}"
+    end
+
+    def participation_not_found?
+      # This error is raised when FT returns ID_NON_RECONNU, when the participation ID is not found
+      # It happens when duplicate users were merged on FT side
+      response_body = JSON.parse(@response.body.force_encoding("UTF-8"))
+      response_body["codeErreur"] == "ID_NON_RECONNU"
+    rescue JSON::ParserError
+      false
     end
 
     def ft_user_headers

--- a/app/services/france_travail_api/cancel_participation.rb
+++ b/app/services/france_travail_api/cancel_participation.rb
@@ -28,22 +28,19 @@ module FranceTravailApi
         headers: ft_user_headers
       )
 
-      handle_failure! unless @response.success?
+      handle_failure! unless @response.success? || participation_not_found?
     end
 
     def handle_failure!
-      result.error_type = :participation_not_found if participation_not_found?
-      fail!(error_message)
-    end
-
-    def error_message
-      "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).\n" \
+      fail!(
+        "Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).\n" \
         "Status: #{@response.status}\n Body: #{@response.body.force_encoding('UTF-8')}"
+      )
     end
 
     def participation_not_found?
-      # This error is raised when FT returns ID_NON_RECONNU, when the participation ID is not found
-      # It happens when duplicate users were merged on FT side
+      # FT returns ID_NON_RECONNU when the participation ID is not found, typically after duplicate users
+      # were merged on FT side. The participation no longer exists there, so the cancellation goal is met.
       response_body = JSON.parse(@response.body.force_encoding("UTF-8"))
       response_body["codeErreur"] == "ID_NON_RECONNU"
     rescue JSON::ParserError

--- a/spec/jobs/outgoing_webhooks/france_travail/cancel_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/cancel_participation_job_spec.rb
@@ -33,5 +33,32 @@ describe OutgoingWebhooks::FranceTravail::CancelParticipationJob do
         expect(FranceTravailApi::CancelParticipation).not_to have_received(:call)
       end
     end
+
+    context "when the service fails with regular error" do
+      before do
+        allow(FranceTravailApi::CancelParticipation).to receive(:call)
+          .and_return(OpenStruct.new(success?: false, failure?: true, errors: ["Some error"], error_type: nil))
+      end
+
+      it "raises a FailedServiceError" do
+        expect { subject }.to raise_error(ApplicationJob::FailedServiceError)
+      end
+    end
+
+    context "when the service fails with participation_not_found error_type" do
+      before do
+        allow(FranceTravailApi::CancelParticipation).to receive(:call)
+          .and_return(OpenStruct.new(
+                        success?: false,
+                        failure?: true,
+                        errors: ["L'ID France Travail de la participation n'existe plus"],
+                        error_type: :participation_not_found
+                      ))
+      end
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/jobs/outgoing_webhooks/france_travail/cancel_participation_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/cancel_participation_job_spec.rb
@@ -34,30 +34,14 @@ describe OutgoingWebhooks::FranceTravail::CancelParticipationJob do
       end
     end
 
-    context "when the service fails with regular error" do
+    context "when the service fails" do
       before do
         allow(FranceTravailApi::CancelParticipation).to receive(:call)
-          .and_return(OpenStruct.new(success?: false, failure?: true, errors: ["Some error"], error_type: nil))
+          .and_return(OpenStruct.new(success?: false, failure?: true, errors: ["Some error"]))
       end
 
       it "raises a FailedServiceError" do
         expect { subject }.to raise_error(ApplicationJob::FailedServiceError)
-      end
-    end
-
-    context "when the service fails with participation_not_found error_type" do
-      before do
-        allow(FranceTravailApi::CancelParticipation).to receive(:call)
-          .and_return(OpenStruct.new(
-                        success?: false,
-                        failure?: true,
-                        errors: ["L'ID France Travail de la participation n'existe plus"],
-                        error_type: :participation_not_found
-                      ))
-      end
-
-      it "does not raise an error" do
-        expect { subject }.not_to raise_error
       end
     end
   end

--- a/spec/services/france_travail_api/cancel_participation_spec.rb
+++ b/spec/services/france_travail_api/cancel_participation_spec.rb
@@ -54,4 +54,25 @@ describe FranceTravailApi::CancelParticipation, type: :service do
       )
     end
   end
+
+  context "when API call fails with ID_NON_RECONNU error" do
+    let(:error_body) do
+      {
+        codeHttp: 400,
+        codeErreur: "ID_NON_RECONNU",
+        message: "Il n'existe pas de rdv pour l'id et l'utilisateur indiqué"
+      }.to_json
+    end
+
+    before do
+      allow(FranceTravailClient).to receive(:cancel_participation)
+        .and_return(OpenStruct.new(success?: false, status: 400, body: error_body))
+    end
+
+    it("is a failure") { is_a_failure }
+
+    it "sets error_type to :participation_not_found" do
+      expect(subject.error_type).to eq(:participation_not_found)
+    end
+  end
 end

--- a/spec/services/france_travail_api/cancel_participation_spec.rb
+++ b/spec/services/france_travail_api/cancel_participation_spec.rb
@@ -69,10 +69,10 @@ describe FranceTravailApi::CancelParticipation, type: :service do
         .and_return(OpenStruct.new(success?: false, status: 400, body: error_body))
     end
 
-    it("is a failure") { is_a_failure }
+    it("is a success") { is_a_success }
 
-    it "sets error_type to :participation_not_found" do
-      expect(subject.error_type).to eq(:participation_not_found)
+    it "creates the webhook receipt" do
+      expect { subject }.to change(WebhookReceipt, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
Cette erreur remonte régulièrement dans nos jobs Sidekiq :

`Calling service FranceTravailApi::CancelParticipation failed in OutgoingWebhooks::FranceTravail::CancelParticipationJob:
Errors: ["Impossible d'appeler l'endpoint de l'api rendez-vous-partenaire FT (Suppression de Participation).
Status: 400
Body: {"codeErreur":"ID_NON_RECONNU","message":"Il n'existe pas de rdv pour l'id et l'utilisateur indiqué", ...}"]`

FT renvoie `ID_NON_RECONNU` quand la participation n'existe plus dans son SI (typiquement après une fusion de doublons d'usagers côté FT). Le job échoue alors et Sidekiq le retente en boucle.

### Solution

On applique le même principe que ce qui a été fait pour l'update : le service détecte l'erreur `ID_NON_RECONNU` et la signale via `:participation_not_found`, le job ignore ce cas au lieu de lever une erreur.

Seule différence avec l'update : on ne tente pas de recréer la participation côté FT. Il s'agit ici d'une suppression, si la participation n'existe déjà plus dans le SI FT il n'y a rien d'autre à faire.
