### PR TITLE
fix(letters): harmonize direction names spacing with user address

### DIFF
--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -52,15 +52,11 @@ u {
   }
 }
 
-.user-address {
-  position: absolute;
-  right: 0;
-}
-
 .direction-names {
   margin-top: 100px;
+  line-height: 1.2;
   p {
-    margin-top: 5px;
+    margin: 0;
   }
 }
 
@@ -71,6 +67,7 @@ u {
 
 .user-address {
   position: absolute;
+  right: 0;
   top: 57mm;
   left: 117mm;
   width: 85mm;

--- a/app/views/letters/_header.html.erb
+++ b/app/views/letters/_header.html.erb
@@ -24,6 +24,6 @@
 </div>
 <div class="direction-names">
   <% direction_names.each do |direction_name| %>
-    <p><%= direction_name.upcase %></p>
+    <p><%= direction_name.upcase_first %></p>
   <% end %>
 </div>

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -35,7 +35,7 @@ describe Invitations::GenerateLetter, type: :service do
       subject
       content = strip_tags(letter_content(invitation))
       expect(content).to include("20 AVENUE DE SEGUR")
-      expect(content).to include("DIRECTION DÉPARTEMENTAL")
+      expect(content).to include("Direction départemental")
       expect(content).to include(
         " Pour vous aider dans vos démarches, " \
         "le Conseil départemental a mis en place une plateforme de prise de rendez-vous en ligne."

--- a/spec/services/notifications/generate_letter_spec.rb
+++ b/spec/services/notifications/generate_letter_spec.rb
@@ -46,7 +46,7 @@ describe Notifications::GenerateLetter, type: :service do
       subject
       content = strip_tags(letter_content(notification)).gsub("&nbsp;", " ")
       expect(content).to include("20 AVENUE DE SEGUR")
-      expect(content).to include("DIRECTION DÉPARTEMENTAL")
+      expect(content).to include("Direction départemental")
       expect(content).to include("Convocation à un rendez-vous d'orientation dans le cadre de votre RSA")
       expect(content).to include(
         "Vous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à " \
@@ -92,7 +92,7 @@ describe Notifications::GenerateLetter, type: :service do
         subject
         content = strip_tags(letter_content(notification)).gsub("&nbsp;", " ")
         expect(content).to include("20 AVENUE DE SEGUR")
-        expect(content).to include("DIRECTION DÉPARTEMENTAL")
+        expect(content).to include("Direction départemental")
         expect(content).to include("Convocation à un rendez-vous d'orientation téléphonique dans le cadre de votre RSA")
         expect(content).to include(
           "Un conseiller d'insertion vous appellera le dimanche 25 décembre 2022 " \
@@ -132,7 +132,7 @@ describe Notifications::GenerateLetter, type: :service do
           subject
           content = strip_tags(letter_content(notification)).gsub("&nbsp;", " ")
           expect(content).to include("20 AVENUE DE SEGUR")
-          expect(content).to include("DIRECTION DÉPARTEMENTAL")
+          expect(content).to include("Direction départemental")
           expect(content).to include(
             "Convocation à un nouveau type de rendez-vous téléphonique dans le cadre de votre RSA"
           )
@@ -157,7 +157,7 @@ describe Notifications::GenerateLetter, type: :service do
         subject
         content = strip_tags(letter_content(notification)).gsub("&nbsp;", " ")
         expect(content).to include("20 AVENUE DE SEGUR")
-        expect(content).to include("DIRECTION DÉPARTEMENTAL")
+        expect(content).to include("Direction départemental")
         expect(content).to include(
           "Convocation à un rendez-vous d'orientation par visioconférence dans le cadre de votre RSA"
         )
@@ -194,7 +194,7 @@ describe Notifications::GenerateLetter, type: :service do
         subject
         content = strip_tags(letter_content(notification)).gsub("&nbsp;", " ")
         expect(content).to include("20 AVENUE DE SEGUR")
-        expect(content).to include("DIRECTION DÉPARTEMENTAL")
+        expect(content).to include("Direction départemental")
         expect(content).to include(
           "Votre rendez-vous d'orientation, prévu le dimanche 25 décembre 2022 " \
           "à 09h30 dans le cadre de votre RSA a été annulé"


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Formatage-Courriers-En-t-te-1-3c25f321b604808e960ad799130781b3

On garde le même espacement pour l'en tête (direction names) que pour l'adresse de l'usager.
On garde la casse enregistrée (on upcase juste la première lettre)

Avant
<img width="806" height="1146" alt="Capture d’écran 2026-08-25 à 11 59 40" src="https://github.com/user-attachments/assets/ec142bc0-d7e7-4df2-b64c-84582b96283f" />
Aprés
<img width="806" height="1146" alt="Capture d’écran 2026-08-25 à 11 59 50" src="https://github.com/user-attachments/assets/f499810b-a7ef-4bf2-b4ba-7de46c525b28" />


