### PR TITLE
fix(wording): Change rights_opening_date traduction

### DIFF
--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -16,7 +16,7 @@ fr:
         department_internal_id: ID interne au département
         nir: Numéro de sécurité sociale
         france_travail_id: ID France Travail
-        rights_opening_date: Date d'entrée flux
+        rights_opening_date: Date d'ouverture des droits
         organisations: Organisation(s)
         uid: Le couple numéro CAF + rôle
         created_at: Date de création

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -147,7 +147,7 @@ describe "Super admin can manage users" do
       expect(page).to have_field("user[department_internal_id]", with: user.department_internal_id)
       expect(page).to have_css("label[for=\"user_france_travail_id\"]", text: "ID France Travail")
       expect(page).to have_field("user[france_travail_id]", with: user.france_travail_id)
-      expect(page).to have_css("label[for=\"user_rights_opening_date\"]", text: "Date d'entrée flux")
+      expect(page).to have_css("label[for=\"user_rights_opening_date\"]", text: "Date d'ouverture des droits")
       expect(page).to have_field("user[rights_opening_date]", with: user.rights_opening_date)
       expect(page).to have_button("Enregistrer")
 

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -81,7 +81,7 @@ describe "Super admin can manage users" do
       expect(page).to have_css("dd", class: "attribute-data", text: user.department_internal_id)
       expect(page).to have_css("dt", id: "france_travail_id", text: "ID FRANCE TRAVAIL")
       expect(page).to have_css("dd", class: "attribute-data", text: user.france_travail_id)
-      expect(page).to have_css("dt", id: "rights_opening_date", text: "DATE D'ENTRÉE FLUX")
+      expect(page).to have_css("dt", id: "rights_opening_date", text: "DATE D'OUVERTURE DES DROITS")
       expect(page).to have_css("dd", class: "attribute-data", text: user.rights_opening_date)
       expect(page).to have_css("dt", id: "organisations", text: "ORGANISATION(S)")
       expect(page).to have_css(

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -100,7 +100,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
         expect(subject.csv).to include("Ville")
         expect(subject.csv).to include("Date de naissance")
         expect(subject.csv).to include("Date de création")
-        expect(subject.csv).to include("Date d'entrée flux")
+        expect(subject.csv).to include("Date d'ouverture des droits")
         expect(subject.csv).to include("Rôle")
         expect(subject.csv).to include("Archivé le")
         expect(subject.csv).to include("Motif d'archivage")

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -144,7 +144,7 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
         expect(csv).to include("Ville")
         expect(csv).to include("Date de naissance")
         expect(csv).to include("Date de création")
-        expect(csv).to include("Date d'entrée flux")
+        expect(csv).to include("Date d'ouverture des droits")
         expect(csv).to include("Rôle")
         expect(csv).to include("Rendez-vous prescrit ? (interne)")
         expect(csv).to include("Prénom du prescripteur (interne)")


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Wording-Date-de-flux-vs-Date-d-ouverture-RSA-3ce5f321b60480178b54cda3ee287a6c