### PR TITLE
chore(deps): Update rubyzip depedency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.2.2)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
     selenium-webdriver (4.40.0)
       base64 (~> 0.2)


### PR DESCRIPTION
La version antérieure de rubyzip contenait une vulnérabilité qui faisait échouer la CI