### PR TITLE
feat(oauth): Force rdv solidarites oauth token use

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -7,8 +7,8 @@ module Api
       include RateLimitingConcern
       include MaliciousAgentBlockingConcern
 
-      before_action :validate_api_credentials!, :retrieve_agent!, :mark_agent_as_logged_in!,
-                    :set_current_agent
+      before_action :validate_api_credentials!, :retrieve_agent!, :require_rdv_solidarites_oauth_token!,
+                    :mark_agent_as_logged_in!, :set_current_agent
       after_action :log_api_call
 
       include AuthorizationConcern
@@ -42,6 +42,17 @@ module Api
 
         render json: { success: false, errors: ["L'agent ne fait pas partie d'une organisation sur RDV-Insertion"] },
                status: :forbidden
+      end
+
+      def require_rdv_solidarites_oauth_token!
+        return if authenticated_agent.rdv_solidarites_oauth_token
+
+        render(
+          json: { success: false,
+                  errors: ["Vous devez vous connecter à RDV-Insertion et autoriser l'application sur " \
+                           "RDV-Solidarités avant d'utiliser l'API."] },
+          status: :unauthorized
+        )
       end
 
       def mark_agent_as_logged_in!

--- a/app/javascript/stylesheets/components/_navbar.scss
+++ b/app/javascript/stylesheets/components/_navbar.scss
@@ -99,11 +99,19 @@ header:not(.fr-header) {
     }
   }
 
+  &.orange-style {
+    background-color: $orange;
+
+    p {
+      color: white;
+    }
+  }
+
 }
 
 .nav {
   &.draggable {
-    
+
     i {
       cursor: ew-resize;
       margin-left: 10px;

--- a/app/views/common/_header_super_admin_bar_impersonated.html.erb
+++ b/app/views/common/_header_super_admin_bar_impersonated.html.erb
@@ -21,3 +21,14 @@
     <i class="ri-shield-user-line"></i>
   </button>
 </div>
+
+<% unless current_agent.rdv_solidarites_oauth_token %>
+  <div class="top-bar d-flex orange-style">
+    <div class="container d-flex justify-content-center px-3">
+      <p class="mb-0">
+        <i class="ri-error-warning-line me-1"></i>
+        Cet agent ne s'est jamais connecté à rdv-insertion et n'a donc pas de tokens pour appeler RDV-Solidarités: les actions vers RDV-Solidarités échoueront.
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/administrate/super_admin_can_log_in_as_another_agent_spec.rb
+++ b/spec/features/administrate/super_admin_can_log_in_as_another_agent_spec.rb
@@ -28,6 +28,10 @@ describe "Super admin can log in as another agent", :js do
       expect(page).to have_content(
         "Vous êtes connecté.e en tant que #{agent.first_name} #{agent.last_name.upcase}", wait: 10
       )
+      # the impersonated agent has no oauth token, so we warn that rdv-solidarités actions will fail
+      expect(page).to have_content(
+        "Cet agent ne s'est jamais connecté à rdv-insertion et n'a donc pas de tokens pour appeler RDV-Solidarités"
+      )
       expect(page).to have_current_path(organisations_path)
       # We check the organisations displayed to check that it is really the agent's account
       expect(page).to have_content(agent_department.name)
@@ -50,6 +54,20 @@ describe "Super admin can log in as another agent", :js do
       expect(page).to have_no_content(agent_department.name)
       expect(page).to have_no_content(agent_organisation1.name)
       expect(page).to have_no_content(agent_organisation2.name)
+    end
+
+    context "when the impersonated agent has an oauth token" do
+      before { create(:rdv_solidarites_oauth_token, agent: agent) }
+
+      it "does not warn about a missing token" do
+        visit super_admins_agent_path(agent.id)
+        click_button("Se logger en tant que")
+
+        expect(page).to have_content("Vous êtes connecté.e en tant que", wait: 10)
+        expect(page).to have_no_content(
+          "Cet agent ne s'est jamais connecté à rdv-insertion et n'a donc pas de tokens pour appeler RDV-Solidarités"
+        )
+      end
     end
 
     it "cannot impersonate himself" do

--- a/spec/requests/api/v1/oauth_token_requirement_spec.rb
+++ b/spec/requests/api/v1/oauth_token_requirement_spec.rb
@@ -1,0 +1,18 @@
+describe "Api::V1 rdv-solidarités oauth token requirement", type: :request do
+  let!(:agent) { create(:agent) }
+  let(:headers) { { "uid" => agent.email, "client" => "someclient", "access-token" => "sometoken" } }
+
+  before do
+    stub_request(:get, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/auth/validate_token")
+      .to_return(body: { "data" => { "uid" => agent.email } }.to_json)
+  end
+
+  context "when the authenticated agent has no oauth token" do
+    it "returns unauthorized and asks the agent to sign in" do
+      get "/api/v1/departments/1", headers: headers
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body["errors"].join).to match(/vous connecter à RDV-Insertion/)
+    end
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -55,6 +55,7 @@ module ApiSpecHelper
     let(:api_credentials) { instance_double(ApiCredentials) }
 
     before do
+      create(:rdv_solidarites_oauth_token, agent: agent)
       stub_request(:get, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/auth/validate_token")
         .with(headers: auth_headers.merge({ "Content-Type" => "application/json" }))
         .to_return(body: { "data" => { "uid" => agent.email } }.to_json)


### PR DESCRIPTION
⚠️ Ce changement ne doit être MEP qu'après s'être assuré que des tokens oauth sont présents pour tous les utilisateurs de notre API

## Contexte

Suite à #3352 (RDV-Insertion communique avec RDV-Solidarités via des tokens OAuth), le secret partagé va être débranché de `/api/v1` côté RDV-Solidarités. Dès lors, un agent sans token OAuth ne peut plus déclencher d'appels sortants vers `/api/v1` (création/màj d'usagers, invitations…). Cette PR verrouille les points d'entrée où un agent token-less pourrait initier ces appels, pour échouer clairement plutôt que via une erreur opaque.

## Implémentation

- **API** : un before_action dans Api::V1::ApplicationController renvoie un 401 si l'agent authentifié n'a pas de token OAuth, avec un message lui demandant de se connecter à RDV-Insertion et d'autoriser l'application sur RDV-Solidarités.
- **Impersonation** : un bandeau d'avertissement (sous le bandeau super admin) s'affiche quand l'agent impersonné n'a pas de token, prévenant que les actions vers RDV-Solidarités échoueront. 


_Suivi opérationnel (hors PR) : forcer la reconnexion des agents web sans token (rotate_session_key!) pour qu'ils en obtiennent un, à faire avant le débranchement du secret partagé sur /api/v1._