### PR TITLE
fix(invitations): Allow agent to be deleted even if attached to invitation

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -18,6 +18,8 @@ class Agent < ApplicationRecord
   has_many :csv_exports, dependent: :destroy
   has_many :parcours_documents, dependent: :nullify
   has_many :dpa_agreements, dependent: :nullify
+  has_many :invitations, foreign_key: :created_by_agent_id, inverse_of: :created_by_agent,
+                         dependent: :nullify
   has_many :user_list_uploads, dependent: :destroy
   has_many :organisations, through: :agent_roles
   has_many :departments, -> { distinct }, through: :organisations


### PR DESCRIPTION
Certains jobs de suppression d'agent ne peuvent pas être processé parce que des invitations sont rattachées à l'agent.
J'ajoute une option `dependent: :nullify` pour permettre la suppression de ces agents.